### PR TITLE
Fix GPG key import in release workflow

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -233,10 +233,13 @@ jobs:
 
       - name: Import GPG key
         shell: bash
-        run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode | gpg --batch --import
         env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_TTY: /dev/null
+        run: |
+          # --ignore-garbage tolerates trailing whitespace/CR from the secret;
+          # printf avoids the trailing newline echo would add.
+          printf '%s' "$GPG_PRIVATE_KEY" | base64 --decode --ignore-garbage | gpg --batch --import
 
       - name: Set Maven project version
         shell: bash


### PR DESCRIPTION
## Summary
- The v1.0.0 release run failed at the **Import GPG key** step. The key actually imported successfully (gpg reported `secret keys imported: 1`), but `base64: invalid input` returned exit 1 from trailing whitespace, and `set -o pipefail` propagated it.
- Switch to `printf '%s'` (no implicit newline) + `base64 --decode --ignore-garbage` (tolerates trailing whitespace/CR/LF), and pass the secret via `env:` so shell quoting is robust.

## Failing run
https://github.com/webliteca/swingwebview/actions/runs/25963898543/job/76323948325

## Test plan
- [ ] Merge, delete tag v1.0.0, re-tag at the new merge commit, push tag
- [ ] Confirm the new `Release to Maven Central` workflow completes and publishes `ca.weblite:webview:1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)