### PR TITLE
Fix copy/paste in embedded WebView (macOS, Linux, Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ The `WebViewComponent.create()` factory picks the right mode for the
 current platform (heavyweight on macOS / Windows, lightweight on
 Linux), so most callers don't need to think about it.
 
+### Clipboard & editing shortcuts
+
+The standard platform shortcut (`Cmd` on macOS, `Ctrl` on Linux /
+Windows) + `C` / `V` / `X` / `A` performs Copy / Paste / Cut /
+Select-All inside the embedded WebView on all platforms.  A
+`KeyEventDispatcher` installed on the component routes the shortcut to
+the native editing primitive — `[WKWebView copy:/paste:/cut:/selectAll:]`
+on macOS, `webkit_web_view_execute_editing_command` on Linux,
+`document.execCommand` on Windows.  Sibling Swing widgets (a
+`JTextField` in a toolbar above the WebView, etc.) keep their default
+shortcut handling — the dispatcher only fires when the user is actually
+interacting with the WebView.
+
 ## Quick start
 
 ```java
@@ -158,6 +171,30 @@ snapshots `cairo_image_surface_t` pixels at ~30Hz into a
   just `webview.dll`, no separate `WebView2Loader.dll`.  The system
   WebView2 Runtime (part of Edge / Windows 11) provides the actual
   Chromium binaries.
+
+### Focus cooperation (macOS + Windows heavyweight)
+
+The AWT focus chain and the native focus chain (AppKit responder /
+Win32 keyboard focus) are independent on these platforms, and the
+heavyweight WebView's native peer holds native focus in a way AWT
+doesn't observe.  Two consequences are handled automatically:
+
+* When the user clicks into the WebView, the previously-focused Swing
+  `JTextComponent`'s caret is hidden (visual cue that typing now lands
+  in the WebView).  macOS hooks `becomeFirstResponder` on the
+  `WKWebView` via a runtime class swizzle; Windows hooks
+  `ICoreWebView2Controller::add_GotFocus`.
+* When the user clicks back to a Swing component in the same window,
+  the suppressed caret is restored and its blink timer is restarted
+  via a synthetic `FocusEvent.FOCUS_GAINED`.  On Windows we
+  additionally force Win32 keyboard focus back to the JFrame HWND
+  (cross-thread `SetFocus` via `AttachThreadInput`) so subsequent
+  keystrokes actually reach the Swing component — WebView2 otherwise
+  keeps Win32 focus on its child HWND and steals keystrokes.
+
+For debugging, set `-Dca.weblite.webview.debugShortcut=true` (Java
+side) and `WEBVIEW_DEBUG_SHORTCUT=1` (native side) to log the
+dispatcher decisions and Win32 `SetFocus` calls.
 
 ## Demo
 

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -790,18 +790,40 @@ Files:
      triggering an editing command in this WebView.
    - Resolve the AWT focus owner via
      `KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner()`.
-     If it is a `javax.swing.text.JTextComponent`, query the
-     native first-responder state via
-     `embedded.isNativeFirstResponder()`. If the WebView IS
-     the native first responder, override the Swing deferral
-     and continue with the WebView dispatch — the user has
-     clicked into the WebView and is interacting with it
-     even though AWT's focus owner stayed on the Swing
-     text widget. Only if the WebView is NOT the native
-     first responder do we return `false` to defer to
-     Swing's own Cut/Copy/Paste bindings on the focused
-     text widget (preserving sibling `JTextField` behaviour
-     when the user has genuinely clicked back on it).
+     Compute two boolean signals:
+     - `focusInWebView`: true iff the AWT focus owner is
+       non-null and is either this component or descended
+       from it (`focusOwner == this ||
+       SwingUtilities.isDescendingFrom(focusOwner, this)`).
+       This is the standard signal on Linux lightweight,
+       where the component calls
+       `requestFocusInWindow()` on mouse-pressed; it may
+       also be true on Windows when AWT focus is on the
+       embedded heavyweight `Canvas`.
+     - `nativeFocusOnWebView`:
+       `embedded.isNativeFirstResponder()`. macOS-specific
+       in practice (Linux / Windows native bodies stub to
+       return 0); on macOS this is the ONLY reliable signal
+       that the user is interacting with the WebView,
+       because AWT's focus owner stays on whichever Swing
+       component last had focus while the WKWebView holds
+       native first-responder status.
+   - **Default to deferring to Swing.** If both signals are
+     false, return `false` so AWT delivers the event to its
+     focus owner via the normal dispatch path. This is the
+     conservative gate that keeps a sibling `JTextField` (or
+     any other Swing component) working when the user is
+     interacting with it rather than the WebView. The
+     earlier "defer iff focus owner is a `JTextComponent`,
+     otherwise dispatch" gate was too permissive: any
+     non-text focus owner (a `JFrame`'s content pane, a
+     `null` focus owner during a focus transition, the AWT
+     focus owner being weirdly out-of-sync with native
+     focus on Windows) caused Ctrl+V to hijack to the
+     WebView even when the user was nowhere near it.
+   - Only when at least one of the two signals is true
+     do we call `embedded.executeEditingCommand(cmd)` and
+     return `true` to consume the event.
    - **Do NOT also require focus owner to be `this` or a
      descendant.** On macOS the heavyweight peer holds the
      real keyboard focus natively, and AWT's focus owner

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -82,7 +82,7 @@ generated_at: 2026-05-16T07:19:13-07:00
   AWT focus chain and the AppKit responder chain is the
   defining wrinkle of the AWT-embedded WKWebView setup; the
   dispatcher's gating logic exists to bridge it.
-- Visual focus cooperation (macOS only): when the user shifts
+- Visual focus cooperation (macOS + Windows): when the user shifts
   interaction to the WebView (WKWebView becomes the native
   first responder), the previously-focused Swing
   `JTextComponent` (if any) MUST have its caret hidden so
@@ -942,7 +942,26 @@ Files:
    - `native static void webview_embed_set_focus_callback(long w, WebViewFocusCallback cb)`.
      Stores a JNI global ref to `cb` on the engine. Passing
      `null` clears + deletes any prior global ref.
-5. Native swizzle (`src_c/webview_embed.cpp`, Cocoa branch):
+5. Per-platform focus-event source:
+   - **macOS**: WKWebView class swizzle. See step 5a below.
+   - **Windows**: hook
+     `ICoreWebView2Controller::add_GotFocus` and
+     `add_LostFocus` during engine creation; the registered
+     `FocusHandler` instances call `fire_focus_callback`
+     with `became=true` and `became=false` respectively.
+     `set_focus_callback` stores the Java callback's JNI
+     global ref on the Engine; the FocusHandler reads it.
+     `destroy_engine` releases the global ref BEFORE the
+     WebView2 worker tears down so LostFocus during
+     teardown does not invoke a freed callback.
+   - **Linux**: no current implementation; the offscreen
+     WebKitGTK widget does not have an AppKit-style focus
+     event that maps to "user shifted interaction to the
+     web view." Acceptable for now: the lightweight engine
+     on Linux is in-process and already gets AWT focus
+     correctly via `requestFocusInWindow()`.
+
+5a. Native swizzle (`src_c/webview_embed.cpp`, Cocoa branch):
    - Maintain a process-global `std::map<id, Engine *>
      g_webview_to_engine` guarded by `g_webview_map_mutex`.
      Populated in `cocoa_create_engine` after WKWebView

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -62,6 +62,75 @@ generated_at: 2026-05-16T07:19:13-07:00
   macOS 13.3+. On macOS 12.x and earlier the selector does
   not exist and is skipped — right-click → Inspect Element
   still works via the existing `developerExtrasEnabled` flag.
+- Clipboard & editing-command shortcuts: pressing the standard
+  platform shortcut modifier + `C` / `V` / `X` / `A` MUST
+  perform Copy / Paste / Cut / Select-All against whatever has
+  the in-page focus inside the native WebView whenever the
+  user is "interacting with" the WebView. "Interacting with"
+  the WebView means: the user's current input target is the
+  WebView, which we detect via the native first-responder
+  state on macOS — if AppKit's first responder is the
+  `WKWebView` (or any inner view of it), the WebView is the
+  active target regardless of which Swing component holds the
+  AWT focus owner. Concretely: if a sibling `JTextField` in
+  the same window happened to be the last Swing component to
+  receive focus, but the user has since clicked into the
+  WebView (so AppKit promoted `WKWebView` to first responder
+  while AWT's focus owner stayed on the `JTextField`),
+  Cmd+C MUST copy from the WebView's selection — NOT from
+  the `JTextField`. This bidirectional asymmetry between the
+  AWT focus chain and the AppKit responder chain is the
+  defining wrinkle of the AWT-embedded WKWebView setup; the
+  dispatcher's gating logic exists to bridge it.
+- Visual focus cooperation (macOS only): when the user shifts
+  interaction to the WebView (WKWebView becomes the native
+  first responder), the previously-focused Swing
+  `JTextComponent` (if any) MUST have its caret hidden so
+  the user gets a visual cue that typing now lands in the
+  WebView. When the user shifts back to the Swing component
+  (WKWebView resigns first responder — which happens
+  automatically when AWT moves focus to a Swing component,
+  because AWT calls AppKit `makeFirstResponder:` on its
+  NSView), the previously-suppressed caret MUST be restored.
+  The cooperation is one-directional in implementation but
+  bidirectional in observable behaviour: the
+  WebView-became-FR direction needs an explicit Cocoa hook
+  because AWT doesn't observe AppKit responder changes; the
+  WebView-resigned-FR direction is driven by AWT's own
+  focus → AppKit sync as a side-effect of the user clicking
+  the Swing component, after which our resign hook restores
+  caret state. Crucially: the WebView-became-FR handler MUST
+  NOT call `requestFocusInWindow()` on the WebView component
+  — AWT would then call AppKit `makeFirstResponder:` on its
+  NSView and kick WKWebView right back out of first
+  responder, cutting off keyboard input to the page.
+   The modifier is `Cmd` on macOS and `Ctrl`
+  on Linux / Windows; the component detects it via
+  `Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()`
+  rather than hardcoding either mask. Implementation lives
+  in the heavyweight component (`KeyEventDispatcher` installed
+  in `addNotify` / removed in `removeNotify`) plus a new
+  cross-platform JNI entry point
+  `webview_embed_execute_editing_command(long peer, int cmdId)`:
+  - **macOS** (WKWebView): on the AppKit main thread, call
+    `[NSApp sendAction:@selector(cut:|copy:|paste:|selectAll:)
+    to:nil from:webview]`. Targeting `nil` resolves against
+    the first responder, which under a focused contentEditable
+    or `<input>` is the in-page element — directly addressing
+    the `WKWebView` would short-circuit that resolution.
+  - **Linux** (WebKitGTK): on the GTK main thread, call
+    `webkit_web_view_execute_editing_command(WEBKIT_WEB_VIEW(e->web),
+    WEBKIT_EDITING_COMMAND_CUT | _COPY | _PASTE | _SELECT_ALL)`.
+  - **Windows** (WebView2): on the WebView2 worker thread, call
+    `webview->ExecuteScript("document.execCommand('cut'|'copy'|'paste'|'selectAll')")`.
+    WebView2 has no first-class editing-command IPC, and
+    `document.execCommand` reliably routes through the focused
+    element's clipboard handlers. If a follow-up confirms that
+    WebView2's own `AcceleratorKeyPressed` default already
+    covers Ctrl+C/V/X/A end-to-end on every supported Windows
+    build, the Windows native body MAY be a no-op stub that
+    returns immediately — but the JNI entry point must still
+    exist so the Java caller is platform-uniform.
 - Definition of Done: documented by `README.md ("Heavyweight platform notes" section)` ("Heavyweight
   platform notes") and exercised by the `WebViewHeavyweightDemo`
   (`demos/WebViewHeavyweightDemo/...`). No automated tests cover
@@ -92,6 +161,19 @@ generated_at: 2026-05-16T07:19:13-07:00
   - Overrides `addJavascriptCallback(name, cb)` to reject any
     name starting with `__webview_` (matches the canvas-5
     reserved-prefix norm).
+  - `editingShortcutDispatcher: KeyEventDispatcher` —
+    `null` whenever the component is not currently displayable.
+    Non-null exactly between `addNotify()` and the matching
+    `removeNotify()`. When non-null it is also registered on
+    `KeyboardFocusManager.getCurrentKeyboardFocusManager()`,
+    and `removeNotify()` MUST unregister it. The dispatcher
+    intercepts platform-shortcut + C/V/X/A `KEY_PRESSED`
+    events whose AWT focus owner is the component or a
+    descendant, forwards them to
+    `EmbeddedWebView.executeEditingCommand`, and returns
+    `true` to consume the event. Short-circuits to `false`
+    when `embedded == null` so a late event during teardown
+    cannot call JNI on a disposed peer.
 - **EmbeddedCanvas** (inner class, extends `Canvas`,
   `WebViewHeavyweightComponent.java:186`) — the heavyweight peer
   that JAWT can lock to obtain a native window handle. Invariants:
@@ -119,6 +201,24 @@ generated_at: 2026-05-16T07:19:13-07:00
     The native call is responsible for marshaling to the
     correct UI thread on platforms that require it
     (Windows: WebView2 worker; macOS: AppKit main).
+  - New method `executeEditingCommand(EditingCommand cmd): EmbeddedWebView`
+    — `checkAlive`, then call
+    `WebViewNative.webview_embed_execute_editing_command(peer, cmd.nativeId)`.
+    Pure side-effect; does not touch `heap` or `bindings`.
+    Native side is responsible for marshaling to the correct
+    UI thread (AppKit main / GTK main / WebView2 worker).
+- **EditingCommand** (new public enum,
+  `src/ca/weblite/webview/EditingCommand.java`). Stable
+  contract between Java and the JNI bridge — the integer IDs
+  MUST match what the native side dispatches on.
+  - Values: `CUT(1)`, `COPY(2)`, `PASTE(3)`, `SELECT_ALL(4)`.
+  - Each value carries a `private final int nativeId`
+    exposed via `int getNativeId()`. The integer IDs are
+    part of the JNI ABI: renumbering them is a breaking
+    change across native + Java boundaries and MUST be
+    avoided. New commands (e.g. `UNDO`, `REDO`) MUST be
+    appended with new IDs rather than reusing or shifting
+    existing ones.
 
 ## A · Approach
 - **Heavyweight peer hosts the native view.** AWT/JAWT exposes a
@@ -187,6 +287,74 @@ generated_at: 2026-05-16T07:19:13-07:00
   `AddScriptToExecuteOnDocumentCreated` machinery re-fires at
   document-start for every new document. No re-install on
   page change is required.
+- **Editing-command shortcuts driven from Java, not from
+  AppKit / X11.** The standard platform Cut/Copy/Paste/Select-All
+  shortcuts (`Cmd+C/V/X/A` on macOS, `Ctrl+C/V/X/A` elsewhere)
+  do not work out-of-the-box on any platform when the WebView
+  is embedded as a heavyweight AWT peer:
+  - On macOS, AWT's NSEvent dispatch consumes
+    `Cmd`-modified key events for its own key-equivalent
+    handling before WKWebView's `performKeyEquivalent:` is
+    given a chance.
+  - On Linux, the focused X11 window is the embedded
+    WebKitGTK widget (after `XSetInputFocus`), but AWT does
+    not route a corresponding `KeyEvent` back through the
+    Swing focus owner, and the GTK side never installs a
+    key-binding for the AWT shortcut.
+  - On Windows, WebView2 *usually* handles Ctrl+C/V/X/A
+    natively, but the AWT focus owner may still intercept
+    them in some configurations.
+  Two alternatives were rejected:
+  1. Install a synthetic AppKit `Edit` menu into
+     `NSApp.mainMenu`. Functional but mutates the host
+     application's menu bar — a destructive side-effect for
+     library code. It is also macOS-only, so the cross-platform
+     problem still needs a different mechanism for Linux and
+     Windows.
+  2. Install a Swing `KeyListener` on the embedded `Canvas`.
+     Unreliable: with the heavyweight peer holding native
+     focus, AWT's focus owner is the canvas, but the
+     `KeyListener` runs after AWT's own shortcut consumption.
+  Chosen mechanism: a single `KeyEventDispatcher` registered
+  on `KeyboardFocusManager.getCurrentKeyboardFocusManager()`
+  in `addNotify()` and unregistered in `removeNotify()`. This
+  sits ABOVE the AWT focus-owner-level dispatch, so it sees
+  modifier + C/V/X/A `KEY_PRESSED` events before AWT can
+  consume them. The dispatcher gates on the AWT focus owner
+  being the component or a descendant, calls
+  `EmbeddedWebView.executeEditingCommand(cmd)`, and returns
+  `true` to consume the event. The same pattern is reusable
+  in the lightweight component (see
+  [[swing-lightweight-webview-embedding]]); that integration
+  is a separate Canvas update.
+- **Editing-command JNI bridge dispatches the action directly
+  to the engine.** Initial design used
+  `[NSApp sendAction:@selector(...) to:nil from:webview]` so
+  AppKit would walk the responder chain to the inner focused
+  element. **That doesn't work for the AWT-embedded case**:
+  the WKWebView is parented under `NSWindow.contentView` (an
+  AWT-owned NSView), and even after the user clicks inside the
+  WebView, AppKit's first responder is not reliably the
+  WKWebView — AWT installs its own NSView keyDown handling on
+  contentView and the AppKit first responder ends up on AWT's
+  view rather than the WKWebView (consistent with the
+  pre-existing "AWT keeps system focus until told otherwise"
+  comment on `EmbeddedWebView.requestFocus`). With `to:nil`,
+  `sendAction` walks the chain starting at first responder
+  and never reaches WKWebView, so `copy:` / `paste:` / etc.
+  no-op. The fix is to **send the action directly to the
+  WKWebView**: `[webview cut:nil]` / `[webview copy:nil]` /
+  `[webview paste:nil]` / `[webview selectAll:nil]`.
+  WKWebView's implementations of these four standard
+  `NSResponder` selectors delegate to the WebKit page's
+  current selection / focused element internally — they do
+  NOT require WKWebView to be first responder. Guard with
+  `respondsToSelector:` so older SDKs without one of the
+  selectors fail gracefully. Linux uses
+  `webkit_web_view_execute_editing_command`, which already
+  targets the focused frame's selection internally. Windows
+  uses `document.execCommand` via `ExecuteScript` for the
+  same focus-aware semantics.
 
 ## S · Structure
 - `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
@@ -196,8 +364,13 @@ generated_at: 2026-05-16T07:19:13-07:00
 - `src/ca/weblite/webview/WebViewNative.java:131`–
   `src/ca/weblite/webview/WebViewNative.java:177` — native
   entry points (`webview_embed_create`,
-  `webview_embed_navigate`, etc.). Adds one new declaration:
-  `native static int webview_embed_open_devtools(long w)`.
+  `webview_embed_navigate`, etc.). Adds two new declarations:
+  `native static int webview_embed_open_devtools(long w)` and
+  `native static void webview_embed_execute_editing_command(long w, int cmdId)`.
+- `src/ca/weblite/webview/EditingCommand.java` (new) — public
+  enum with `CUT(1)`, `COPY(2)`, `PASTE(3)`, `SELECT_ALL(4)`
+  and `int getNativeId()`. The enum is the only thing callers
+  pass through `EmbeddedWebView.executeEditingCommand`.
 - `src/ca/weblite/webview/ConsoleDispatcher.java` (from
   [[swing-webview-component-mode-selection]]) — owned by the
   component; receives raw payloads from the internal
@@ -211,7 +384,14 @@ generated_at: 2026-05-16T07:19:13-07:00
   the Windows file gains the WebView2-worker-marshalled
   implementation. The macOS `cocoa_create_engine` block is
   extended to call `setInspectable:YES` under
-  `respondsToSelector` when `debug=true`.
+  `respondsToSelector` when `debug=true`. Both native sources
+  also gain a function exported as
+  `Java_..._webview_1embed_1execute_1editing_1command` that
+  marshals to the correct UI thread (AppKit main / GTK main /
+  WebView2 worker) and invokes the per-platform editing-command
+  primitive (`[NSApp sendAction:to:nil from:webview]` /
+  `webkit_web_view_execute_editing_command` /
+  `webview->ExecuteScript("document.execCommand(...)")`).
 - `demos/WebViewHeavyweightDemo/...` — interactive demo that
   exercises the trickier scenarios (combo-box popups over the
   WebView, `JTabbedPane` tab visibility).
@@ -273,6 +453,16 @@ File: `src/ca/weblite/webview/EmbeddedWebView.java`
    - `dispose(): void` — if `peer != 0`, zero it, call
      `webview_embed_destroy`, clear `heap` and `bindings`
      (`EmbeddedWebView.java:194`).
+   - `executeEditingCommand(EditingCommand cmd): EmbeddedWebView` (new)
+     - Logic: null-check `cmd` (throw `NullPointerException`
+       with a message naming the parameter); `checkAlive`;
+       call
+       `WebViewNative.webview_embed_execute_editing_command(peer, cmd.getNativeId())`;
+       `return this`. Pure side-effect; does NOT touch
+       `heap` or `bindings`. The native call is responsible
+       for marshalling to the correct UI thread; the Java
+       caller MUST be allowed to invoke this from the EDT
+       without blocking.
    - `openDevTools(): boolean` (new)
      - Logic: `checkAlive`; call
        `WebViewNative.webview_embed_open_devtools(peer)`;
@@ -521,6 +711,314 @@ inside the `if (e->debug)` branch).
    - This change is wholly inside `if (e->debug) { ... }`;
      `debug=false` runs are entirely unaffected.
 
+### 10. Editing-Command Shortcut Dispatch
+Files:
+- `src/ca/weblite/webview/EditingCommand.java` (new enum)
+- `src/ca/weblite/webview/EmbeddedWebView.java`
+  (`executeEditingCommand` — see Operation 1)
+- `src/ca/weblite/webview/WebViewNative.java`
+  (new `webview_embed_execute_editing_command` declaration)
+- `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
+  (dispatcher install / uninstall + dispatch logic)
+- `src_c/webview_embed.cpp` (cocoa + gtk native bodies)
+- `windows/webview_embed.cc` (WebView2 native body)
+
+1. Responsibility: turn AWT platform-shortcut + C/V/X/A
+   `KEY_PRESSED` events whose focus owner is inside the
+   `WebViewHeavyweightComponent` into the correct
+   editing-command invocation against whatever has in-page
+   focus inside the native WebView, on every supported
+   platform.
+2. EditingCommand enum:
+   - Declared `public enum EditingCommand` in package
+     `ca.weblite.webview` with values `CUT(1)`, `COPY(2)`,
+     `PASTE(3)`, `SELECT_ALL(4)`.
+   - `private final int nativeId` set by the constructor;
+     public accessor `int getNativeId()`.
+   - Numeric IDs are part of the JNI ABI: they MUST match
+     the switch statement in the native bodies. Reusing or
+     shifting an existing ID is a breaking change.
+3. Java entry point declaration (`WebViewNative.java`):
+   - `native static void webview_embed_execute_editing_command(long w, int cmdId)`.
+   - Header regeneration is required (see
+     [[native-library-loading-and-packaging]]).
+4. Dispatcher install / remove in
+   `WebViewHeavyweightComponent`:
+   - Add field
+     `private KeyEventDispatcher editingShortcutDispatcher`
+     (default `null`).
+   - Override `addNotify()`: call `super.addNotify()` first;
+     if `editingShortcutDispatcher == null`, build a new
+     `KeyEventDispatcher` (lambda or inner class) with the
+     logic in step 5; assign to the field; register via
+     `KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(...)`.
+   - Override `removeNotify()`: if
+     `editingShortcutDispatcher != null`, call
+     `KeyboardFocusManager.getCurrentKeyboardFocusManager().removeKeyEventDispatcher(editingShortcutDispatcher)`,
+     then null the field. Call `super.removeNotify()` last
+     (matching the existing `dispose()`-before-super ordering
+     used by `EmbeddedCanvas.removeNotify`).
+5. Dispatcher logic (executed for every AWT key event in the
+   JVM, MUST short-circuit cheaply for events it does not
+   handle):
+   - Return `false` immediately if
+     `e.getID() != KeyEvent.KEY_PRESSED`.
+   - Compute `int shortcutMask =
+     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()`
+     (Java 8 compatible — the project targets 1.8 in
+     `pom.xml`, so `getMenuShortcutKeyMaskEx` is unavailable).
+     Cache it in a `static final` field on the dispatcher
+     class to avoid re-reading on every key event.
+   - Return `false` if
+     `(e.getModifiers() & shortcutMask) != shortcutMask`.
+   - Switch on `e.getKeyCode()`:
+     - `VK_C` → `EditingCommand.COPY`
+     - `VK_V` → `EditingCommand.PASTE`
+     - `VK_X` → `EditingCommand.CUT`
+     - `VK_A` → `EditingCommand.SELECT_ALL`
+     - default → return `false`.
+   - Return `false` if `embedded == null` — the component is
+     mid-attach or mid-teardown; let Swing's default handler
+     run.
+   - Return `false` if the component is not currently showing
+     (`isShowing()`).
+   - Return `false` if the component's window ancestor is
+     not focused
+     (`SwingUtilities.getWindowAncestor(this).isFocused()`).
+     `KeyEventDispatcher` fires for every key event in the
+     JVM; this gate keeps a key press in another window from
+     triggering an editing command in this WebView.
+   - Resolve the AWT focus owner via
+     `KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner()`.
+     If it is a `javax.swing.text.JTextComponent`, query the
+     native first-responder state via
+     `embedded.isNativeFirstResponder()`. If the WebView IS
+     the native first responder, override the Swing deferral
+     and continue with the WebView dispatch — the user has
+     clicked into the WebView and is interacting with it
+     even though AWT's focus owner stayed on the Swing
+     text widget. Only if the WebView is NOT the native
+     first responder do we return `false` to defer to
+     Swing's own Cut/Copy/Paste bindings on the focused
+     text widget (preserving sibling `JTextField` behaviour
+     when the user has genuinely clicked back on it).
+   - **Do NOT also require focus owner to be `this` or a
+     descendant.** On macOS the heavyweight peer holds the
+     real keyboard focus natively, and AWT's focus owner
+     stays on whatever Swing component had it before (often
+     the root pane of the JFrame, which is an ANCESTOR of
+     this component, so an `isDescendingFrom(focusOwner, this)`
+     check returns false and the dispatcher silently bails
+     out — the exact failure mode that the first iteration
+     of this Canvas hit on macOS).
+   - Otherwise call
+     `embedded.executeEditingCommand(cmd)` and return `true`
+     to consume the event.
+6. macOS native body (`src_c/webview_embed.cpp`,
+   `cocoa_*` branch):
+   - Marshal to the AppKit main thread via
+     `cocoa_run_on_main_async` (the existing helper used by
+     `cocoa_navigate` / `cocoa_eval`).
+   - Switch on `cmdId`: build the appropriate `SEL` from
+     `sel("cut:")`, `sel("copy:")`, `sel("paste:")`,
+     `sel("selectAll:")`. Default branch returns without
+     dispatching.
+   - Send the action **directly to the WKWebView**, NOT via
+     the responder chain. Use the existing `msg<>()` helper:
+     `msg<void, id>(e->webview, action, (id)nullptr)`.
+     Guard with `respondsToSelector:` so a missing selector
+     on an older WebKit fails silently instead of aborting
+     the process. Do NOT use
+     `[NSApp sendAction:to:nil from:webview]` — see Approach
+     for the AWT first-responder mismatch that makes
+     responder-chain dispatch unreliable in this embedded
+     setup.
+7. Linux native body (`src_c/webview_embed.cpp`,
+   `gtk_*` branch):
+   - Marshal to the GTK main thread via the existing
+     `gtk_run_on_main_async` (or equivalent dispatch) used by
+     `gtk_navigate`.
+   - Switch on `cmdId`: pick
+     `WEBKIT_EDITING_COMMAND_CUT` /
+     `WEBKIT_EDITING_COMMAND_COPY` /
+     `WEBKIT_EDITING_COMMAND_PASTE` /
+     `WEBKIT_EDITING_COMMAND_SELECT_ALL` (the WebKitGTK
+     header defines these as `const char*` macros).
+   - Call
+     `webkit_web_view_execute_editing_command(WEBKIT_WEB_VIEW(e->web), command)`.
+8. Windows native body (`windows/webview_embed.cc`):
+   - Marshal to the WebView2 worker thread via the existing
+     `PostThreadMessage` pattern.
+   - Switch on `cmdId` to a string literal
+     `"document.execCommand('cut')"`,
+     `"document.execCommand('copy')"`,
+     `"document.execCommand('paste')"`,
+     `"document.execCommand('selectAll')"`.
+   - Call `webview->ExecuteScript(js, nullptr)` (no
+     callback — fire-and-forget; logging on failure
+     `HRESULT` only).
+   - If a follow-up confirms WebView2 already handles these
+     shortcuts natively when the embedded HWND has focus,
+     the implementation MAY become an early return after the
+     thread-marshal — but the JNI entry MUST stay so the Java
+     caller is unchanged.
+9. Constraints / Invariants:
+   - The native function is `void` and MUST NOT raise a JNI
+     exception for any failure path (unsupported `cmdId`,
+     missing engine pointer, native error). The Java side
+     does NOT wrap calls in try/catch.
+   - The integer `cmdId` contract is fixed:
+     `1=CUT, 2=COPY, 3=PASTE, 4=SELECT_ALL`. Any future
+     command MUST use a new positive integer; existing IDs
+     MUST NOT be reused.
+
+### 11. Bidirectional Focus Cooperation
+Files:
+- `src/ca/weblite/webview/WebViewFocusCallback.java` (new
+  functional interface)
+- `src/ca/weblite/webview/EmbeddedWebView.java`
+  (`isNativeFirstResponder()`, `setFocusCallback(...)`)
+- `src/ca/weblite/webview/WebViewNative.java` (two new JNI
+  declarations)
+- `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
+  (focus callback install + caret-suppression handler)
+- `src_c/webview_embed.cpp` (WKWebView class swizzle + engine
+  map + JNI bodies)
+- `src_c/ca_weblite_webview_WebViewNative.h` + Windows header
+  (declarations)
+- `windows/webview_embed.cc` (no-op stubs)
+
+1. Responsibility: bridge the AWT focus chain and the
+   AppKit responder chain so (a) `Cmd+C/V/X/A` works in the
+   WebView even when AWT focus owner is a sibling
+   `JTextComponent`, and (b) visual focus indicators
+   (`JTextComponent` carets) reflect where the user is
+   actually interacting.
+2. New public Java functional interface
+   `ca.weblite.webview.WebViewFocusCallback`:
+   - Single method `void invoke(boolean became)`. `became`
+     is `true` when WKWebView gained native first responder,
+     `false` when it resigned.
+3. `EmbeddedWebView` additions:
+   - `isNativeFirstResponder(): boolean` — JNI sync query;
+     returns `false` if `peer == 0`. Implemented natively as
+     a walk up the NSView superview chain from the
+     `NSWindow.firstResponder` looking for the WKWebView
+     (so both the WKWebView itself and any inner WebKit
+     content view count as "the WebView is focused").
+   - `setFocusCallback(WebViewFocusCallback cb): EmbeddedWebView`
+     — anchors `cb` in `heap` (so JVM doesn't GC it while
+     native holds a global ref) and calls
+     `WebViewNative.webview_embed_set_focus_callback(peer, cb)`.
+     Passing `null` clears any prior callback.
+4. New JNI declarations on `WebViewNative`:
+   - `native static int webview_embed_is_native_first_responder(long w)`.
+     Returns 1 if the engine's WKWebView (or one of its
+     descendants) is the current `firstResponder` of its
+     `NSWindow`, 0 otherwise. macOS-only behaviour;
+     Linux / Windows return 0.
+   - `native static void webview_embed_set_focus_callback(long w, WebViewFocusCallback cb)`.
+     Stores a JNI global ref to `cb` on the engine. Passing
+     `null` clears + deletes any prior global ref.
+5. Native swizzle (`src_c/webview_embed.cpp`, Cocoa branch):
+   - Maintain a process-global `std::map<id, Engine *>
+     g_webview_to_engine` guarded by `g_webview_map_mutex`.
+     Populated in `cocoa_create_engine` after WKWebView
+     alloc; cleared in `cocoa_destroy_engine`.
+   - On first engine creation (guard with `std::call_once`),
+     swizzle `-[WKWebView becomeFirstResponder]` and
+     `-[WKWebView resignFirstResponder]` via
+     `class_getInstanceMethod` +
+     `method_setImplementation`. Save the original IMPs in
+     statics so the swizzled implementations can call
+     through.
+   - Swizzled implementations: call the original IMP first
+     (capturing the BOOL result); if it returned YES, look
+     up the receiver in `g_webview_to_engine` (under the
+     mutex). If an `Engine *` is found AND that engine has
+     a non-null `focus_callback` global ref, invoke the
+     Java callback on a thread that's attached to the JVM.
+     **Marshal to the EDT via the callback itself**: the
+     Java callback is a small lambda that schedules
+     `handleNativeFocusChange(became)` via
+     `SwingUtilities.invokeLater`, so the JNI call only
+     needs to invoke a non-EDT callback method.
+   - The swizzle affects all WKWebViews in the process,
+     including any unrelated ones. The engine-map lookup
+     returns null for those, and we just skip the callback —
+     the original implementation is still called, so
+     behaviour for non-our WKWebViews is unaffected.
+6. `Engine` struct (Cocoa) additions:
+   - `jobject focus_callback` — JNI global ref to the
+     registered `WebViewFocusCallback`, or `nullptr`. Set
+     by `webview_embed_set_focus_callback`; deleted on
+     replace and on `cocoa_destroy_engine`.
+7. `WebViewHeavyweightComponent` integration:
+   - Add fields:
+     - `private javax.swing.text.JTextComponent suppressedCaretOwner` (null when no caret is suppressed).
+     - `private boolean originalCaretVisible` — value to
+       restore when WKWebView resigns.
+   - In `createPeer()` after `EmbeddedWebView.attach`
+     succeeds, call
+     `embedded.setFocusCallback(became -> SwingUtilities.invokeLater(() -> handleNativeFocusChange(became)))`.
+     (The lambda must be anchored — `EmbeddedWebView.heap`
+     handles this via `setFocusCallback`.)
+   - `handleNativeFocusChange(boolean became)` runs on the
+     EDT:
+     - If `became == true`:
+       - If `suppressedCaretOwner != null`, return
+         (idempotent; we already suppressed a caret in a
+         previous transition).
+       - Query the AWT focus owner. If it is a
+         `JTextComponent`, record it as
+         `suppressedCaretOwner`, record its
+         `getCaret().isVisible()` as
+         `originalCaretVisible`, and call
+         `getCaret().setVisible(false)`.
+     - If `became == false`:
+       - If `suppressedCaretOwner != null`, call
+         `getCaret().setVisible(originalCaretVisible)` to
+         restore, then null the field.
+8. Reverse direction (Swing component gains focus → WKWebView
+   resigns) is handled implicitly:
+   - User clicks `JTextField` → AWT moves focus to
+     `JTextField` → AWT calls AppKit
+     `makeFirstResponder:` on its NSView → WKWebView
+     resigns first responder → swizzled
+     `resignFirstResponder` fires → callback with
+     `became = false` → `handleNativeFocusChange(false)` →
+     caret restored on `suppressedCaretOwner`.
+9. Constraints / Invariants:
+   - The swizzle MUST be installed exactly once per JVM —
+     guard with `std::call_once`. `method_setImplementation`
+     is destructive on re-application and would corrupt
+     the original-IMP save.
+   - The Engine ↔ WKWebView map MUST be guarded by a
+     mutex — `becomeFirstResponder` can fire on the AppKit
+     main thread while `cocoa_create_engine` /
+     `cocoa_destroy_engine` run on EDT-driven native code.
+   - `handleNativeFocusChange` MUST run on the EDT. The
+     native callback path itself does NOT need to be on
+     the EDT; the Java-side lambda invokes
+     `SwingUtilities.invokeLater` to marshal.
+   - The handler MUST NOT call `requestFocusInWindow()` or
+     any other AWT method that would propagate focus to
+     AppKit — that would kick WKWebView back out of first
+     responder AND cut off keyboard input to the page.
+     Caret suppression is purely a Swing-side cosmetic
+     change.
+   - Caret restoration on `became == false` MUST happen
+     even if AWT focus has since moved to a different
+     `JTextComponent`. The handler restores the
+     previously-recorded caret (whichever was suppressed
+     on the prior `became == true`), not the current focus
+     owner's caret.
+   - `setFocusCallback(null)` clears the global ref and
+     deletes it cleanly. `EmbeddedWebView.dispose()` also
+     clears via `setFocusCallback(null)` BEFORE
+     `webview_embed_destroy` so the swizzled hooks don't
+     fire into a freed callback.
+
 ## N · Norms
 - All AWT/JAWT interaction must respect the rule that the
   native peer is only valid while the host AWT Component is
@@ -552,6 +1050,38 @@ inside the `if (e->debug)` branch).
   bounded wait; Linux dispatches to the GTK pump thread.
   Native bugs that would block must be diagnosed and fixed,
   not worked around with timeouts in Java.
+- The editing-shortcut `KeyEventDispatcher` MUST return
+  `true` for every event it forwards to
+  `EmbeddedWebView.executeEditingCommand`, so AWT does not
+  also deliver the same event to the focus owner. Returning
+  `false` after forwarding would let Swing's default
+  `Ctrl+C`/`Ctrl+V` action (e.g. on a focused `JTextField`
+  sibling — but the dispatcher only acts when the focus owner
+  is inside the WebView, so this is more about consuming
+  AWT's own native-shortcut consumption path) run a second
+  time.
+- The editing-shortcut dispatcher MUST detect the platform
+  shortcut modifier via
+  `Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()` and
+  compare it against `KeyEvent.getModifiers()`. The Ex
+  variants (`getMenuShortcutKeyMaskEx` /
+  `getModifiersEx`) are Java 10+ only; the project's Maven
+  source/target is Java 8 (see `pom.xml` properties), so the
+  legacy modifier API is the correct choice. Hardcoding
+  `InputEvent.CTRL_MASK` or `InputEvent.META_MASK` is wrong
+  — it would break the other platform.
+- The editing-shortcut dispatcher MUST be registered in
+  `addNotify()` and unregistered in `removeNotify()`. A
+  dispatcher left registered across a removeNotify would
+  keep the WebViewHeavyweightComponent reachable from the
+  focus manager's strong reference and prevent both Java GC
+  and native peer release.
+- `WebViewNative.webview_embed_execute_editing_command` is
+  `void` and MUST NOT raise a JNI exception. All failure
+  paths (bad `cmdId`, null engine, native call failure) MUST
+  fall through silently or log via the existing
+  `WV_LOG`/`fprintf(stderr, ...)` pattern. Java callers must
+  not need to wrap the call in try/catch.
 
 ## S · Safeguards
 - `EmbeddedWebView.attach` validates `parent != null` AND
@@ -597,3 +1127,17 @@ inside the `if (e->debug)` branch).
 - The native `webview_embed_open_devtools` returns 0 (never
   raises a JNI exception) for every failure path so the Java
   side never has to wrap the call in a try/catch.
+- The editing-shortcut `KeyEventDispatcher` MUST short-circuit
+  to `false` when `embedded == null` so a key event that
+  arrives during teardown (between `dispose()` clearing the
+  field and `removeNotify` unregistering the dispatcher) does
+  not call JNI on a disposed peer. The dispatcher MUST also
+  short-circuit when the AWT focus owner is `null` or not a
+  descendant of the component — keystrokes typed into a
+  sibling `JTextField` or another window MUST continue to use
+  Swing's default handling untouched.
+- `EmbeddedWebView.executeEditingCommand` rejects a `null`
+  `EditingCommand` argument with `NullPointerException` BEFORE
+  calling `checkAlive`, so callers get a clear error rather
+  than the JNI layer mishandling an undefined `cmdId`. The
+  exception message MUST name the parameter (`"cmd"`).

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -1002,7 +1002,7 @@ Files:
          `getCaret().setVisible(originalCaretVisible)` to
          restore, then null the field.
 8. Reverse direction (Swing component gains focus → WKWebView
-   resigns) is handled implicitly:
+   resigns) is handled implicitly on macOS:
    - User clicks `JTextField` → AWT moves focus to
      `JTextField` → AWT calls AppKit
      `makeFirstResponder:` on its NSView → WKWebView
@@ -1010,6 +1010,105 @@ Files:
      `resignFirstResponder` fires → callback with
      `became = false` → `handleNativeFocusChange(false)` →
      caret restored on `suppressedCaretOwner`.
+   - **On Windows the same implicit path does not work.**
+     When the WebView2 HWND holds Win32 keyboard focus and
+     the user clicks a Swing widget rendered inside the
+     AWT JFrame's HWND area (e.g. the URL `JTextField` in
+     the toolbar), AWT moves its Java-side focus owner to
+     the `JTextField`, but Win32 keyboard focus stays on
+     the WebView2 HWND because AWT does not automatically
+     `SetFocus` away from a focused child HWND. Subsequent
+     keystrokes (`Ctrl+V` etc.) still route to WebView2 via
+     Win32, bypassing AWT and the editing-shortcut
+     dispatcher entirely. The fix is a Windows-only
+     "release native focus" path described in Operation 12
+     below.
+
+### 12. Release Native Keyboard Focus on AWT Focus Move (Windows)
+Files:
+- `src/ca/weblite/webview/EmbeddedWebView.java`
+  (`releaseNativeFocus()` method)
+- `src/ca/weblite/webview/WebViewNative.java` (one new
+  JNI declaration)
+- `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
+  (global `KeyboardFocusManager` property listener that
+  calls `releaseNativeFocus()` when AWT focus moves to a
+  non-WebView component)
+- `src_c/webview_embed.cpp` (no-op body on macOS / Linux)
+- `windows/webview_embed.cc` (Win32 `SetFocus` body with
+  `AttachThreadInput` for the cross-thread case)
+- Headers: declarations on both `src_c` and `windows` header.
+
+1. Responsibility: ensure Win32 keyboard focus follows AWT
+   focus on Windows. When the user shifts AWT focus away
+   from the embedded WebView, force Win32 to deliver
+   subsequent keyboard input to the AWT-owned parent HWND
+   instead of the WebView2 child HWND.
+2. New JNI declaration on `WebViewNative`:
+   `native static void webview_embed_release_native_focus(long w)`.
+   Returns void; never throws.
+3. New method on `EmbeddedWebView`:
+   `releaseNativeFocus(): EmbeddedWebView` — `checkAlive`,
+   then call the JNI entry. Pure side-effect; does not
+   touch `heap` or `bindings`.
+4. Native bodies:
+   - macOS (Cocoa branch): no-op. AppKit already handles
+     focus correctly via the responder chain — when AWT
+     moves focus to a Swing component it calls
+     `makeFirstResponder:` on its own NSView, which kicks
+     WKWebView out of first responder. The swizzled
+     `resignFirstResponder` hook fires and restores Swing
+     caret state. No native action needed here.
+   - Linux (GTK branch): no-op. AWT/X11 focus handling is
+     adequate for the heavyweight path on Linux today;
+     re-introducing native focus mutation from Java would
+     risk the rendering regression documented at
+     `WebViewHeavyweightComponent.java:223`.
+   - Windows (WebView2): dispatch to the WebView2 worker
+     thread via the existing
+     `embed_win::dispatch_to_thread` helper. On the worker
+     thread: obtain the AWT parent HWND from `e->parent`;
+     attach the worker thread's input state to the AWT
+     thread (via `AttachThreadInput(workerTid, parentTid,
+     TRUE)`); call `SetFocus(e->parent)`; detach. The
+     `AttachThreadInput` step is mandatory — Win32 focus
+     is per-thread, and `SetFocus` from a thread that does
+     not own the target HWND silently no-ops without the
+     attach.
+5. `WebViewHeavyweightComponent` integration:
+   - Add field `private PropertyChangeListener focusOwnerListener`
+     (null until `addNotify`).
+   - In `addNotify()`, after the editing-shortcut dispatcher
+     is installed, build a `PropertyChangeListener` for the
+     `"focusOwner"` property and register it on
+     `KeyboardFocusManager.getCurrentKeyboardFocusManager()`.
+     The listener:
+     - Reads the new value (the new focus owner).
+     - Returns immediately if `embedded == null` or the new
+       value is `null`.
+     - Returns immediately if the new value is `this` or a
+       descendant of `this` (focus moved INTO the WebView;
+       no native release needed).
+     - Returns immediately if the new value's window
+       ancestor is not this component's window (focus
+       moved to an unrelated window).
+     - Otherwise calls `embedded.releaseNativeFocus()`.
+   - In `removeNotify()`, before the editing-shortcut
+     dispatcher is unregistered, unregister the
+     `focusOwnerListener` and null the field.
+6. Constraints / Invariants:
+   - The listener is global (fires for every focus change
+     in the JVM). Short-circuit checks MUST be cheap to
+     avoid burdening unrelated focus traffic.
+   - `releaseNativeFocus()` is `void` and MUST NOT raise a
+     JNI exception; failure paths (bad HWND, no
+     controller, AttachThreadInput failure) log via the
+     existing `WV_LOG` pattern and return without
+     throwing.
+   - The listener MUST be unregistered in `removeNotify()`
+     to avoid leaking the component through the
+     `KeyboardFocusManager`'s strong reference (same
+     lifecycle norm as the editing-shortcut dispatcher).
 9. Constraints / Invariants:
    - The swizzle MUST be installed exactly once per JVM —
      guard with `std::call_once`. `method_setImplementation`

--- a/spdd/prompt/7-20260516-0719-[Feat]-Swing-Lightweight-Webview-Embedding.md
+++ b/spdd/prompt/7-20260516-0719-[Feat]-Swing-Lightweight-Webview-Embedding.md
@@ -757,21 +757,33 @@ Files:
      (`SwingUtilities.getWindowAncestor(this).isFocused()`).
    - Resolve the focus owner via
      `KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner()`.
-     If it is a `javax.swing.text.JTextComponent`, return
-     `false` — defer to Swing's own Cut/Copy/Paste bindings
-     on the focused text widget so a sibling `JTextField` in
-     the same window keeps working.
-   - **Do NOT also require the focus owner to be `this` or a
-     descendant.** The same rationale as Canvas 6 applies:
-     window-focus + non-text-component gating is sufficient
-     and avoids the focus-owner-mismatch failure mode that
-     hit the heavyweight component on macOS. On Linux the
-     lightweight component is the AWT focus owner once the
-     user has clicked into it (via `requestFocusInWindow()`
-     in the mouse-pressed handler), so the gate normally
-     passes anyway — but the more permissive form is safer
-     for edge cases (focus stolen by a non-text Swing
-     widget, focus owner not yet set on first display, etc.).
+     **Default to deferring to Swing.** Only dispatch to
+     the WebView when the AWT focus owner is non-null AND
+     is either this component itself or a descendant
+     (`focusOwner == this ||
+     SwingUtilities.isDescendingFrom(focusOwner, this)`).
+     The lightweight component calls `requestFocusInWindow()`
+     in its mouse-pressed handler, so AWT focus reliably
+     reflects user intent. If the focus owner is anything
+     else — a sibling `JTextField`, a `JFrame` content
+     pane, `null` during a focus transition — return
+     `false` so AWT delivers the event to its focus owner
+     via the normal dispatch path.
+   - The heavyweight Canvas 6 dispatcher additionally
+     consults a native first-responder query for the
+     macOS-specific case where AWT focus stays on a Swing
+     component while WKWebView holds AppKit's first
+     responder. That signal does not apply on Linux
+     lightweight: the offscreen widget has no AppKit-style
+     first-responder semantics, and the AWT focus owner is
+     authoritative because the component grants itself
+     focus on every mouse-press into the widget.
+   - The earlier "defer iff focus owner is a
+     `JTextComponent`" gate was too permissive — any
+     non-text focus owner (a `JFrame`'s content pane, a
+     `null` focus owner during a focus transition) caused
+     the WebView to hijack the shortcut even when the user
+     was nowhere near it.
    - Otherwise call
      `engine.executeEditingCommand(cmd)` and return `true`
      to consume the event so the existing `KeyAdapter`

--- a/spdd/prompt/7-20260516-0719-[Feat]-Swing-Lightweight-Webview-Embedding.md
+++ b/spdd/prompt/7-20260516-0719-[Feat]-Swing-Lightweight-Webview-Embedding.md
@@ -61,6 +61,36 @@ generated_at: 2026-05-16T07:19:13-07:00
     that routes the raw payload into
     `ConsoleDispatcher.dispatch`.  Both happen inside
     `addNotify()` immediately after engine creation.
+- Clipboard & editing-command shortcuts (Linux only — the
+  lightweight engine is a stub on macOS / Windows): pressing
+  `Ctrl + C` / `V` / `X` / `A` while the AWT focus owner is
+  inside the lightweight component performs Copy / Paste /
+  Cut / Select-All against whatever has the in-page focus
+  inside the offscreen WebView. The implementation reuses
+  the `EditingCommand` enum defined in
+  [[swing-heavyweight-webview-embedding]] (same stable JNI
+  ABI: `CUT=1`, `COPY=2`, `PASTE=3`, `SELECT_ALL=4`) and
+  follows the same Java-side mechanism: a
+  `KeyEventDispatcher` installed in `addNotify` and removed
+  in `removeNotify`, plus a new JNI entry
+  `webview_offscreen_execute_editing_command(long peer, int cmdId)`
+  that on the GTK main thread calls
+  `webkit_web_view_execute_editing_command(WEBKIT_WEB_VIEW(e->web),
+  WEBKIT_EDITING_COMMAND_*)`. The existing AWT
+  `KeyListener` → `GdkInput.translateKeyCode` →
+  `engine.keyEvent` forwarding does NOT handle these
+  shortcuts: for `Ctrl+letter` AWT delivers `keyChar` as the
+  control character (e.g. `Ctrl+C` yields `0x03`), so
+  `GdkInput.translateKeyCode` falls through to `keyChar` and
+  the synthesized GDK event arrives at WebKit as
+  `(keyval=0x03, state=GDK_CONTROL_MASK)` — which WebKit's
+  accelerator handler does not recognise as the Cut/Copy/
+  Paste shortcut. Going directly to
+  `webkit_web_view_execute_editing_command` bypasses the
+  accelerator pipeline entirely. macOS / Windows lightweight
+  remain stubs — the dispatcher is still installed there but
+  its `engine == null` short-circuit makes it a no-op,
+  matching the existing rendering-path stub semantics.
 - Definition of Done: documented at `README.md ("Quick start" section)`,
   exercised by the `WebViewHeavyweightDemo` (which uses
   `WebViewComponent.create()` so the lightweight engine is the
@@ -98,6 +128,31 @@ generated_at: 2026-05-16T07:19:13-07:00
   - Overrides `addJavascriptCallback(name, cb)` to reject any
     name starting with `__webview_` (matches the canvas-5
     reserved-prefix norm).
+  - `editingShortcutDispatcher: KeyEventDispatcher` —
+    `null` until `addNotify`, non-null and registered on
+    `KeyboardFocusManager.getCurrentKeyboardFocusManager()`
+    between `addNotify` and the matching `removeNotify`.
+    Detects the standard platform shortcut + `C` / `V` /
+    `X` / `A` on `KEY_PRESSED` whose AWT focus owner is the
+    component or a descendant, forwards them to
+    `OffscreenWebView.executeEditingCommand`, and returns
+    `true` to consume the event so the AWT `KeyAdapter`
+    forwarding in `installKeyListener()` does NOT also feed
+    the Ctrl+letter event into the offscreen WebView (which
+    would arrive as a stray `Ctrl+\x03` synthesized GDK
+    event that the page's text field would not interpret as
+    a copy command and might insert as a control glyph).
+    Short-circuits to `false` when `engine == null` so the
+    dispatcher is a no-op on macOS / Windows where the
+    offscreen engine never creates, and during teardown
+    between `engine.dispose()` and `removeNotify`
+    unregistering the dispatcher.
+- **EditingCommand** — defined in
+  [[swing-heavyweight-webview-embedding]] at
+  `src/ca/weblite/webview/EditingCommand.java`; reused here
+  verbatim. The lightweight path does NOT redefine it; it
+  consumes the same enum with the same stable JNI ABI
+  (`CUT=1, COPY=2, PASTE=3, SELECT_ALL=4`).
 - **OffscreenWebView** (`OffscreenWebView.java:24`) — Low-level
   JNI wrapper for the offscreen engine.  Owns:
   - `peer: long` — native pointer; `0` means unsupported
@@ -113,6 +168,14 @@ generated_at: 2026-05-16T07:19:13-07:00
     Mirrors `EmbeddedWebView.bindings`
     (`EmbeddedWebView.java:34`).
   Invariants:
+  - New method `executeEditingCommand(EditingCommand cmd): OffscreenWebView`
+    — rejects null `cmd` with `NullPointerException("cmd")`
+    BEFORE `checkAlive`; otherwise calls
+    `WebViewNative.webview_offscreen_execute_editing_command(peer, cmd.getNativeId())`.
+    Pure side-effect; does NOT touch `heap` or `bindings`.
+    Mirrors `EmbeddedWebView.executeEditingCommand` from
+    [[swing-heavyweight-webview-embedding]] — same signature,
+    same null-arg semantics, same checkAlive guard.
   - `addOnBeforeLoad(js)`, `eval(js)`,
     `addJavascriptCallback(name, cb)`,
     `dispatch(Runnable r)`, and `openDevTools(): boolean`
@@ -191,6 +254,44 @@ generated_at: 2026-05-16T07:19:13-07:00
   underlying `webkit_user_script_new` /
   `register_script_message_handler` machinery re-fires for
   every new document at document-start.
+- **Editing-command shortcuts bypass synthetic key dispatch.**
+  The existing AWT-`KeyListener` → `GdkInput.translateKeyCode`
+  → `engine.keyEvent` forwarding cannot deliver Ctrl+C/V/X/A
+  to WebKit's accelerator handler:
+  - On `Ctrl+letter`, AWT delivers `KeyEvent.getKeyChar()`
+    as the control character (e.g. `0x03` for Ctrl+C, the
+    ASCII ETX), not the letter `'c'` (`0x63`).
+    `GdkInput.translateKeyCode` first looks up
+    `vkToGdkKeysym(vkCode)`, which only maps non-character
+    special keys; for `VK_C` it returns 0, so the function
+    falls through to `keyChar` and synthesizes the GDK
+    event with `keyval=0x03`. WebKit's clipboard
+    accelerator handler is bound to `(Ctrl, 'c')`
+    (`keyval=0x63`), so the event is ignored.
+  - Fixing `GdkInput.translateKeyCode` to prefer the letter
+    keysym for `Ctrl+letter` is not enough on its own:
+    WebKit's accelerator handling on synthetic key events
+    injected via `gtk_main_do_event` into an offscreen
+    widget is known to be unreliable (the same family of
+    bugs that already required `gtk-im-context-simple` to
+    keep Backspace from being committed as `0x08`). The
+    fix needs to bypass the accelerator pipeline.
+  Solution: install a `KeyEventDispatcher` on
+  `KeyboardFocusManager.getCurrentKeyboardFocusManager()`
+  in `addNotify` (above AWT focus-owner dispatch, so it
+  sees the event before the component's existing
+  `KeyAdapter` does). When the modifier+letter combination
+  matches, dispatch directly to a new JNI entry point
+  that calls `webkit_web_view_execute_editing_command` on
+  the GTK pump thread, then consume the event by returning
+  `true` so the existing `KeyAdapter` does NOT also forward
+  a stray `Ctrl+\x03` synthesized key event. The
+  editing-command primitive targets the focused frame's
+  selection internally, matching the heavyweight path's
+  behaviour exactly (see Canvas 6's "Editing-command JNI
+  bridge resolves against the in-page responder, not the
+  engine itself"). The same `EditingCommand` enum is reused
+  so the JNI ABI is identical across both modes.
 
 ## S · Structure
 - `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
@@ -205,7 +306,11 @@ generated_at: 2026-05-16T07:19:13-07:00
   `webview_offscreen_mouse_*`, `webview_offscreen_key_event`,
   `webview_offscreen_init`, `webview_offscreen_eval`,
   `webview_offscreen_bind`, `webview_offscreen_dispatch`,
-  `webview_offscreen_open_devtools`).
+  `webview_offscreen_open_devtools`,
+  `webview_offscreen_execute_editing_command`).
+- `src/ca/weblite/webview/EditingCommand.java` —
+  defined in [[swing-heavyweight-webview-embedding]];
+  consumed here without modification.
 - `src/ca/weblite/webview/ConsoleDispatcher.java` (from
   [[swing-webview-component-mode-selection]]) — owned by the
   component; receives raw payloads from the internal
@@ -215,9 +320,17 @@ generated_at: 2026-05-16T07:19:13-07:00
   with embed path on Linux).  Stubs on macOS/Windows.  New
   implementations of the five offscreen JNI methods listed
   above, in the offscreen-engine block around line 880-ff.
+  Adds one further entry under the Linux branch:
+  `gtk_off_execute_editing_command(OffEngine *e, int cmdId)`,
+  exported via `Java_..._webview_1offscreen_1execute_1editing_1command`.
 - `src_c/ca_weblite_webview_WebViewNative.h` — generated JNI
   header; declares the five new offscreen entries alongside
-  the existing ones.
+  the existing ones, plus the new
+  `webview_offscreen_execute_editing_command` declaration.
+- `windows/webview_embed.cc` and
+  `windows/ca_weblite_webview_WebViewNative.h` — Windows
+  stub of the new offscreen JNI entry, matching the existing
+  offscreen-stub pattern (the offscreen engine is Linux-only).
 
 ## O · Operations
 
@@ -565,6 +678,151 @@ File: `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`,
      and then calling `openDevTools()` again must re-open
      it; native behaviour is idempotent.
 
+### 10. Lightweight Editing-Command Shortcut Dispatch
+Files:
+- `src/ca/weblite/webview/OffscreenWebView.java`
+  (`executeEditingCommand` method — see Operation 2)
+- `src/ca/weblite/webview/WebViewNative.java`
+  (new `webview_offscreen_execute_editing_command` declaration)
+- `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
+  (dispatcher install / uninstall + dispatch logic)
+- `src_c/webview_embed.cpp` (offscreen-engine block:
+  `gtk_off_execute_editing_command` + JNI export)
+- `windows/webview_embed.cc` (offscreen stub JNI export)
+
+1. Responsibility: turn AWT platform-shortcut + C/V/X/A
+   `KEY_PRESSED` events whose focus owner is inside the
+   `WebViewLightweightComponent` into the correct
+   editing-command invocation against whatever has in-page
+   focus inside the offscreen WebView, on Linux.
+2. EditingCommand enum: reused unchanged from
+   [[swing-heavyweight-webview-embedding]] (Operation 10).
+   This Canvas does NOT redefine it.
+3. Java entry point declaration (`WebViewNative.java`):
+   - `native static void webview_offscreen_execute_editing_command(long w, int cmdId)`.
+   - Header regeneration is required (see
+     [[native-library-loading-and-packaging]]).
+4. Dispatcher install / remove in
+   `WebViewLightweightComponent`:
+   - Add field
+     `private KeyEventDispatcher editingShortcutDispatcher`
+     (default `null`).
+   - Override `addNotify()`: call `super.addNotify()` first;
+     do the existing engine-creation / console-bridge /
+     replay / repaint-timer work; then, if
+     `editingShortcutDispatcher == null`, build a new
+     `KeyEventDispatcher` with the logic in step 5; assign
+     to the field; register via
+     `KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(...)`.
+     The dispatcher MUST be installed even when
+     `OffscreenWebView.create` returned `null` (macOS /
+     Windows) — its `engine == null` short-circuit makes it
+     a no-op there, matching the existing graceful-degrade
+     semantics.
+   - Override `removeNotify()`: BEFORE the existing
+     `engine.dispose()` / buffer clear / super sequence, if
+     `editingShortcutDispatcher != null` call
+     `KeyboardFocusManager.getCurrentKeyboardFocusManager().removeKeyEventDispatcher(editingShortcutDispatcher)`
+     and null the field. Doing this before
+     `engine.dispose()` means a late event mid-teardown
+     either sees the dispatcher already gone (Swing's
+     default handling runs) or sees the dispatcher still
+     installed but `engine` already cleared (the
+     `engine == null` short-circuit absorbs it).
+5. Dispatcher logic — byte-identical to Canvas 6 Operation
+   10 step 5 except for the
+   `embedded == null` check, which becomes `engine == null`:
+   - Return `false` immediately if
+     `e.getID() != KeyEvent.KEY_PRESSED`.
+   - Read the cached
+     `static final int SHORTCUT_MASK =
+     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()`
+     (Java 8 compat — the Ex variants are Java 10+, and the
+     project targets 1.8 per `pom.xml`).
+   - Return `false` if
+     `(e.getModifiers() & SHORTCUT_MASK) != SHORTCUT_MASK`.
+   - Switch on `e.getKeyCode()`:
+     - `VK_C` → `EditingCommand.COPY`
+     - `VK_V` → `EditingCommand.PASTE`
+     - `VK_X` → `EditingCommand.CUT`
+     - `VK_A` → `EditingCommand.SELECT_ALL`
+     - default → return `false`.
+   - Return `false` if `engine == null` — the component is
+     mid-attach or mid-teardown, or running on macOS /
+     Windows where the offscreen engine never created.
+   - Return `false` if the component is not currently showing
+     (`isShowing()`).
+   - Return `false` if the component's window ancestor is not
+     focused
+     (`SwingUtilities.getWindowAncestor(this).isFocused()`).
+   - Resolve the focus owner via
+     `KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner()`.
+     If it is a `javax.swing.text.JTextComponent`, return
+     `false` — defer to Swing's own Cut/Copy/Paste bindings
+     on the focused text widget so a sibling `JTextField` in
+     the same window keeps working.
+   - **Do NOT also require the focus owner to be `this` or a
+     descendant.** The same rationale as Canvas 6 applies:
+     window-focus + non-text-component gating is sufficient
+     and avoids the focus-owner-mismatch failure mode that
+     hit the heavyweight component on macOS. On Linux the
+     lightweight component is the AWT focus owner once the
+     user has clicked into it (via `requestFocusInWindow()`
+     in the mouse-pressed handler), so the gate normally
+     passes anyway — but the more permissive form is safer
+     for edge cases (focus stolen by a non-text Swing
+     widget, focus owner not yet set on first display, etc.).
+   - Otherwise call
+     `engine.executeEditingCommand(cmd)` and return `true`
+     to consume the event so the existing `KeyAdapter`
+     (installed by `installKeyListener()`) does NOT also
+     forward a stray `Ctrl+\x03` synthesized GDK key event
+     into the offscreen WebView.
+6. Linux native body (`src_c/webview_embed.cpp`,
+   offscreen-engine block):
+   - `static void gtk_off_execute_editing_command(OffEngine *e, int cmdId)`.
+   - Switch on `cmdId`: pick
+     `WEBKIT_EDITING_COMMAND_CUT` /
+     `WEBKIT_EDITING_COMMAND_COPY` /
+     `WEBKIT_EDITING_COMMAND_PASTE` /
+     `WEBKIT_EDITING_COMMAND_SELECT_ALL`. Unknown cmdIds
+     return immediately without dispatching.
+   - Marshal to the GTK pump thread via the existing
+     `embed::GtkPump::instance().run_async(...)` helper used
+     elsewhere in the offscreen block (`webview_embed.cpp:284`).
+     The lambda null-guards `e` and `e->web` before calling
+     `webkit_web_view_execute_editing_command(WEBKIT_WEB_VIEW(e->web), command)`.
+   - Same shape as `gtk_execute_editing_command` for the
+     heavyweight engine (Canvas 6 Operation 10 step 7), just
+     reading from `OffEngine` instead of `Engine`.
+7. JNI export
+   `Java_..._webview_1offscreen_1execute_1editing_1command`
+   in `src_c/webview_embed.cpp`:
+   - `#ifdef WEBVIEW_GTK` — dispatches to
+     `gtk_off_execute_editing_command((OffEngine *)wv, (int)cmdId)`.
+   - `#else` — no-op stub matching the rest of the offscreen
+     exports' Linux-only pattern.
+8. Windows stub JNI export in `windows/webview_embed.cc`:
+   - No-op body (`{}`), matching the existing offscreen
+     stubs (`webview_offscreen_init`, `_eval`, etc.) at the
+     bottom of the file. The offscreen engine is Linux-only;
+     callers on Windows hit this stub via the Java side
+     when `engine == null`, which the dispatcher already
+     short-circuits — but the JNI symbol MUST exist or
+     `System.loadLibrary` would fail to link.
+9. Constraints / Invariants:
+   - The native function is `void` and MUST NOT raise a JNI
+     exception for any failure path (unsupported `cmdId`,
+     missing engine pointer, native error). The Java side
+     does NOT wrap calls in try/catch.
+   - The integer `cmdId` contract is fixed:
+     `1=CUT, 2=COPY, 3=PASTE, 4=SELECT_ALL`. This is the
+     same contract as
+     `webview_embed_execute_editing_command` in
+     [[swing-heavyweight-webview-embedding]] — they MUST
+     stay in sync. Renumbering or reusing existing IDs is a
+     breaking change across both native + Java boundaries.
+
 ## N · Norms
 - AWT event handlers always check `engine == null` and return
   early; do not assume the offscreen engine is alive
@@ -596,6 +854,49 @@ File: `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`,
   verbatim by the offscreen path.  Do NOT fork the shim for
   the lightweight engine — page authors expect identical
   semantics across both modes, and the shim is the contract.
+- The lightweight editing-shortcut `KeyEventDispatcher` MUST
+  return `true` for every event it forwards to
+  `OffscreenWebView.executeEditingCommand`. Returning `false`
+  would let the AWT `KeyAdapter` from
+  `installKeyListener()` ALSO forward the event via
+  `GdkInput.translateKeyCode` → `engine.keyEvent`, which on
+  `Ctrl+letter` synthesizes a GDK event with the control
+  character as the keysym. That stray event either fires
+  the editing command a second time inside an unexpected
+  context or — more commonly — inserts a control glyph into
+  the focused text field. Consuming the event is mandatory.
+- The lightweight editing-shortcut dispatcher MUST detect
+  the platform shortcut modifier via
+  `Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()` and
+  compare against `KeyEvent.getModifiers()`. The Ex variants
+  (`getMenuShortcutKeyMaskEx` / `getModifiersEx`) are Java
+  10+ only; the project's `pom.xml` targets Java 1.8, so
+  the legacy modifier API is the correct choice. Hardcoding
+  `InputEvent.CTRL_MASK` is wrong even though the
+  lightweight engine is currently Linux-only — the
+  dispatcher is still wired on macOS / Windows (where it
+  short-circuits on `engine == null`), and the cross-platform
+  helper is the convention the heavyweight Canvas already
+  established.
+- The lightweight editing-shortcut dispatcher MUST be
+  registered in `addNotify` and unregistered in
+  `removeNotify`, with unregistration happening BEFORE the
+  existing `engine.dispose()` / buffer clear sequence in
+  `removeNotify`. A dispatcher left registered across
+  `removeNotify` would keep the component reachable from
+  the focus manager's strong reference and prevent both
+  Java GC and the native peer release that
+  `OffscreenWebView.dispose` performs via
+  `webview_offscreen_destroy`.
+- `webview_offscreen_execute_editing_command` is `void` and
+  MUST NOT raise a JNI exception. All failure paths (bad
+  `cmdId`, null engine, native call failure) MUST fall
+  through silently or log via the existing
+  `WV_LOG`/`fprintf(stderr, ...)` pattern. Java callers
+  must not need to wrap the call in try/catch. This is the
+  same contract as the heavyweight
+  `webview_embed_execute_editing_command` norm in
+  [[swing-heavyweight-webview-embedding]].
 
 ## S · Safeguards
 - `OffscreenWebView.create` returns `null` for unsupported
@@ -656,3 +957,27 @@ File: `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`,
   wrappers passed to `dispatch` MUST live inside
   `OffscreenWebView.heap` for the duration of their native
   registration — the GC has no other reachability root.
+- The lightweight editing-shortcut `KeyEventDispatcher` MUST
+  short-circuit to `false` when `engine == null`. This
+  covers three cases: (a) macOS / Windows where
+  `OffscreenWebView.create` returned `null` — the
+  dispatcher is still registered (consistent install path
+  across platforms) but every event passes through; (b)
+  Linux during teardown between the dispatcher's
+  removeNotify-side unregistration and `engine.dispose`;
+  (c) any race window where `engine` is being assigned/cleared
+  by another thread (`addNotify` / `removeNotify` are both
+  EDT-driven, but a `KeyEventDispatcher` can fire from any
+  AWT-event-dispatch thread, and the JVM publishes the
+  field write before the dispatcher runs).
+- The dispatcher MUST also short-circuit when the AWT focus
+  owner is `null` or not a descendant of this component —
+  keystrokes typed into a sibling `JTextField` or another
+  window MUST continue to use Swing's default handling
+  untouched.
+- `OffscreenWebView.executeEditingCommand` rejects a `null`
+  `EditingCommand` argument with `NullPointerException`
+  BEFORE calling `checkAlive`, mirroring the heavyweight
+  `EmbeddedWebView.executeEditingCommand` safeguard from
+  [[swing-heavyweight-webview-embedding]]. The exception
+  message MUST name the parameter (`"cmd"`).

--- a/src/ca/weblite/webview/EditingCommand.java
+++ b/src/ca/weblite/webview/EditingCommand.java
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * Editing commands that can be dispatched into an embedded WebView via
+ * {@link EmbeddedWebView#executeEditingCommand(EditingCommand)}.
+ *
+ * <p>Each value carries a stable integer ID that is part of the JNI ABI
+ * between Java and the native {@code webview_embed_execute_editing_command}
+ * entry point.  The IDs are matched by the {@code switch} in the per-platform
+ * native bodies (Cocoa, GTK, WebView2).  Renumbering or reusing an existing
+ * ID is a breaking change across the native + Java boundary; new commands
+ * MUST be appended with a fresh positive integer.
+ */
+public enum EditingCommand {
+
+    CUT(1),
+    COPY(2),
+    PASTE(3),
+    SELECT_ALL(4);
+
+    private final int nativeId;
+
+    EditingCommand(int nativeId) {
+        this.nativeId = nativeId;
+    }
+
+    public int getNativeId() {
+        return nativeId;
+    }
+}

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -245,6 +245,19 @@ public class EmbeddedWebView {
     }
 
     /**
+     * Windows-only: force Win32 keyboard focus back to the AWT-owned parent
+     * HWND, so subsequent keystrokes route to AWT instead of the WebView2
+     * child HWND.  Used by the Java-side global focus-owner listener when
+     * AWT moves its focus owner to a Swing component outside the WebView.
+     * macOS / Linux: no-op.
+     */
+    public EmbeddedWebView releaseNativeFocus() {
+        checkAlive();
+        WebViewNative.webview_embed_release_native_focus(peer);
+        return this;
+    }
+
+    /**
      * Release the native resources and detach from the parent.
      */
     public void dispose() {

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -201,11 +201,64 @@ public class EmbeddedWebView {
     }
 
     /**
+     * Execute a platform editing command (Cut / Copy / Paste / Select-All)
+     * against the embedded WebView's current focused element.  The native
+     * call marshals to the correct UI thread (AppKit main / GTK main /
+     * WebView2 worker) on its own, so this is safe to invoke from the EDT
+     * without blocking.
+     *
+     * @param cmd the editing command to perform; must not be null.
+     */
+    public EmbeddedWebView executeEditingCommand(EditingCommand cmd) {
+        if (cmd == null) {
+            throw new NullPointerException("cmd");
+        }
+        checkAlive();
+        WebViewNative.webview_embed_execute_editing_command(peer, cmd.getNativeId());
+        return this;
+    }
+
+    /**
+     * @return {@code true} if the native WebView (or one of its inner views) is
+     * the current first responder of its window.  macOS-specific; Linux /
+     * Windows always return {@code false}.  Returns {@code false} after dispose
+     * without throwing.
+     */
+    public boolean isNativeFirstResponder() {
+        if (peer == 0L) return false;
+        return WebViewNative.webview_embed_is_native_first_responder(peer) == 1;
+    }
+
+    /**
+     * Register (or clear, by passing {@code null}) a callback invoked when the
+     * native WebView becomes / resigns first responder.  The callback runs on
+     * a native thread; implementations must marshal to the EDT before touching
+     * Swing state.
+     */
+    public EmbeddedWebView setFocusCallback(WebViewFocusCallback cb) {
+        checkAlive();
+        if (cb != null) {
+            heap.add(cb);
+        }
+        WebViewNative.webview_embed_set_focus_callback(peer, cb);
+        return this;
+    }
+
+    /**
      * Release the native resources and detach from the parent.
      */
     public void dispose() {
         if (peer != 0L) {
             long p = peer;
+            // Clear any native focus callback BEFORE we hand off to destroy,
+            // so the swizzled responder hooks never fire into a freed Java
+            // global ref.  checkAlive would still pass here since peer is
+            // not yet zero.
+            try {
+                WebViewNative.webview_embed_set_focus_callback(p, null);
+            } catch (Throwable ignored) {
+                // Don't let a clear-callback failure prevent destroy.
+            }
             peer = 0L;
             WebViewNative.webview_embed_destroy(p);
             heap.clear();

--- a/src/ca/weblite/webview/OffscreenWebView.java
+++ b/src/ca/weblite/webview/OffscreenWebView.java
@@ -193,6 +193,25 @@ public class OffscreenWebView {
         return WebViewNative.webview_offscreen_open_devtools(peer) == 1;
     }
 
+    /**
+     * Execute a platform editing command (Cut / Copy / Paste / Select-All)
+     * against the offscreen WebView's current focused element.  The native
+     * call marshals to the GTK pump thread on its own, so this is safe to
+     * invoke from the EDT without blocking.  No-op on macOS / Windows
+     * (the offscreen engine is Linux-only).
+     *
+     * @param cmd the editing command to perform; must not be null.
+     */
+    public OffscreenWebView executeEditingCommand(EditingCommand cmd) {
+        if (cmd == null) {
+            throw new NullPointerException("cmd");
+        }
+        checkAlive();
+        WebViewNative.webview_offscreen_execute_editing_command(
+            peer, cmd.getNativeId());
+        return this;
+    }
+
     /** Release native resources. */
     public void dispose() {
         if (peer != 0L) {

--- a/src/ca/weblite/webview/WebViewFocusCallback.java
+++ b/src/ca/weblite/webview/WebViewFocusCallback.java
@@ -1,0 +1,24 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * Callback invoked when the native WebView's first-responder / focus state
+ * changes.  Registered on {@link EmbeddedWebView#setFocusCallback}.
+ *
+ * <p>The callback is invoked from a native thread (AppKit main thread on
+ * macOS); implementations MUST marshal to the EDT themselves before
+ * touching any Swing state.
+ */
+@FunctionalInterface
+public interface WebViewFocusCallback {
+
+    /**
+     * @param became {@code true} when the native WebView gained first-responder
+     *               status; {@code false} when it resigned.
+     */
+    void invoke(boolean became);
+}

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -227,6 +227,14 @@ native static int webview_embed_is_native_first_responder(long w);
 // between Swing widgets and the WebView.  Linux / Windows: stub (no-op).
 native static void webview_embed_set_focus_callback(long w, WebViewFocusCallback cb);
 
+// Force Win32 keyboard focus back to the AWT-owned parent HWND, so
+// subsequent keystrokes route to AWT instead of the WebView2 child
+// HWND.  Called from the Java-side global focus-owner listener when
+// AWT moves its focus owner to a Swing component outside the WebView.
+// macOS / Linux: no-op (AppKit / X11 focus handling is already
+// adequate on those platforms).  Never throws via JNI.
+native static void webview_embed_release_native_focus(long w);
+
 
 // ---------------------------------------------------------------------------
 // Lightweight / offscreen API (currently Linux-only).

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -195,6 +195,38 @@ native static void webview_embed_request_focus(long w);
 //              thread.  Returns 0 if AreDevToolsEnabled is FALSE.
 native static int webview_embed_open_devtools(long w);
 
+// Execute a platform editing command (Cut / Copy / Paste / Select-All)
+// against the embedded WebView's current focused element.  cmdId is the
+// stable integer from {@link EditingCommand#getNativeId()}; the contract
+// is 1=CUT, 2=COPY, 3=PASTE, 4=SELECT_ALL.  Never throws via JNI -- bad
+// cmdIds or null engines fall through silently.
+//
+// Per-platform behaviour:
+//   - macOS:   [NSApp sendAction:@selector(cut:|copy:|paste:|selectAll:)
+//              to:nil from:webview] on the AppKit main thread.  to:nil
+//              resolves against the first responder, which under a
+//              focused contentEditable or <input> is the inner DOM
+//              element.
+//   - Linux:   webkit_web_view_execute_editing_command on the GTK main
+//              thread.
+//   - Windows: webview->ExecuteScript("document.execCommand(...)") on
+//              the WebView2 worker thread.
+native static void webview_embed_execute_editing_command(long w, int cmdId);
+
+// Returns 1 if the engine's WKWebView (or one of its inner views) is the
+// current first responder of its NSWindow, 0 otherwise.  macOS only;
+// Linux / Windows return 0 unconditionally.  Used by the editing-shortcut
+// dispatcher to override the JTextComponent-deferral when the user has
+// clicked into the WebView but AWT focus stayed on a sibling text widget.
+native static int webview_embed_is_native_first_responder(long w);
+
+// Register (or clear, by passing null) a callback to be invoked when the
+// engine's WKWebView becomes / resigns first responder.  Used by the
+// heavyweight component to drive visual focus cooperation -- suppress and
+// restore Swing JTextComponent carets as the user shifts interaction
+// between Swing widgets and the WebView.  Linux / Windows: stub (no-op).
+native static void webview_embed_set_focus_callback(long w, WebViewFocusCallback cb);
+
 
 // ---------------------------------------------------------------------------
 // Lightweight / offscreen API (currently Linux-only).
@@ -288,6 +320,14 @@ native static void webview_offscreen_dispatch(long peer, Runnable callback);
 // not enabled at create time, the engine has no inspector, or this
 // platform doesn't support the offscreen engine.  Never throws via JNI.
 native static int webview_offscreen_open_devtools(long peer);
+
+// Execute a platform editing command (Cut / Copy / Paste / Select-All)
+// against the offscreen WebView's current focused element.  cmdId is the
+// stable integer from {@link EditingCommand#getNativeId()} -- the same
+// 1=CUT, 2=COPY, 3=PASTE, 4=SELECT_ALL ABI as
+// webview_embed_execute_editing_command.  Linux only; macOS / Windows
+// stubs no-op.  Never throws via JNI.
+native static void webview_offscreen_execute_editing_command(long peer, int cmdId);
 
 
 }

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -10,6 +10,8 @@ import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.EmbeddedWebView;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewFocusCallback;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import javax.swing.text.JTextComponent;
 
 import java.awt.BorderLayout;
@@ -81,6 +83,7 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
     private final Map<String, WebView.JavascriptCallback> pendingBindings =
             new LinkedHashMap<String, WebView.JavascriptCallback>();
     private KeyEventDispatcher editingShortcutDispatcher;
+    private PropertyChangeListener focusOwnerListener;
     private JTextComponent suppressedCaretOwner;
     private boolean originalCaretVisible;
 
@@ -200,10 +203,27 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
                 .getCurrentKeyboardFocusManager()
                 .addKeyEventDispatcher(editingShortcutDispatcher);
         }
+        if (focusOwnerListener == null) {
+            focusOwnerListener = new PropertyChangeListener() {
+                @Override
+                public void propertyChange(PropertyChangeEvent evt) {
+                    handleFocusOwnerChange(evt.getNewValue());
+                }
+            };
+            KeyboardFocusManager
+                .getCurrentKeyboardFocusManager()
+                .addPropertyChangeListener("focusOwner", focusOwnerListener);
+        }
     }
 
     @Override
     public void removeNotify() {
+        if (focusOwnerListener != null) {
+            KeyboardFocusManager
+                .getCurrentKeyboardFocusManager()
+                .removePropertyChangeListener("focusOwner", focusOwnerListener);
+            focusOwnerListener = null;
+        }
         if (editingShortcutDispatcher != null) {
             KeyboardFocusManager
                 .getCurrentKeyboardFocusManager()
@@ -211,6 +231,28 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
             editingShortcutDispatcher = null;
         }
         super.removeNotify();
+    }
+
+    private void handleFocusOwnerChange(Object newOwner) {
+        if (embedded == null) return;
+        if (!(newOwner instanceof Component)) return;
+        Component owner = (Component) newOwner;
+        // Focus moved INTO the WebView -- no native release needed.
+        if (owner == this || SwingUtilities.isDescendingFrom(owner, this)) {
+            return;
+        }
+        // Focus moved to an unrelated top-level window -- not our problem.
+        Window myWindow = SwingUtilities.getWindowAncestor(this);
+        Window ownerWindow = SwingUtilities.getWindowAncestor(owner);
+        if (myWindow == null || ownerWindow != myWindow) {
+            return;
+        }
+        // AWT moved focus to a Swing component in our window that isn't
+        // part of the WebView.  On Windows, Win32 keyboard focus may still
+        // be on the WebView2 child HWND; force it back to the AWT parent
+        // HWND so the new Swing focus owner actually receives keystrokes.
+        // No-op on macOS / Linux.
+        embedded.releaseNativeFocus();
     }
 
     private boolean handleEditingShortcut(KeyEvent e) {

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -285,6 +285,14 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
             "[webview-focus] mouse-press releaseNativeFocus on target="
             + target.getClass().getName());
         embedded.releaseNativeFocus();
+        // Also restore the suppressed caret in case the native LostFocus
+        // event won't fire reliably -- WebView2 only fires LostFocus when
+        // its hosted content (an inner DOM element) loses focus.  If the
+        // user clicked the page background without selecting anything,
+        // no inner element ever held focus, so LostFocus never fires when
+        // we forcibly release Win32 focus via SetFocus.  Restoring here
+        // makes the path independent of the native event.
+        restoreSuppressedCaret();
     }
 
     private void handleFocusOwnerChange(Object newOwner) {
@@ -452,11 +460,27 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
                 }
             }
         } else {
-            if (suppressedCaretOwner != null && suppressedCaretOwner.getCaret() != null) {
-                suppressedCaretOwner.getCaret().setVisible(originalCaretVisible);
-            }
-            suppressedCaretOwner = null;
+            restoreSuppressedCaret();
         }
+    }
+
+    private void restoreSuppressedCaret() {
+        if (suppressedCaretOwner == null) return;
+        JTextComponent jtc = suppressedCaretOwner;
+        suppressedCaretOwner = null;
+        if (jtc.getCaret() != null) {
+            jtc.getCaret().setVisible(true);
+        }
+        // setVisible(true) sets the field, but DefaultCaret only restarts
+        // its blink timer on a focusGained event.  In the AWT-vs-Win32
+        // focus-desync scenario (Win32 focus moved to WebView2 while
+        // AWT's focus owner stayed on the JTextField), AWT never fired
+        // a focusLost/focusGained pair on the JTextField, so DefaultCaret
+        // believes it never lost focus -- but its blink state may be
+        // dead anyway.  Dispatch a synthetic FOCUS_GAINED to retrigger
+        // DefaultCaret.focusGained, which restarts the blink timer.
+        jtc.dispatchEvent(new java.awt.event.FocusEvent(
+            jtc, java.awt.event.FocusEvent.FOCUS_GAINED));
     }
 
     private void sizeNative() {

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -238,25 +238,29 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         if (myWindow == null || !myWindow.isFocused()) {
             return false;
         }
+        // Default to deferring to Swing.  Only dispatch to the WebView
+        // when we have positive evidence the user is interacting with
+        // it: either AWT focus is inside the component (Linux
+        // lightweight / sometimes Windows), or the native WebView is
+        // first responder (macOS, where AWT focus stays on the previously
+        // focused Swing component while WKWebView holds AppKit focus).
         Component focusOwner = KeyboardFocusManager
             .getCurrentKeyboardFocusManager()
             .getFocusOwner();
-        if (focusOwner instanceof JTextComponent) {
-            // Only defer to Swing if the user has genuinely focused the
-            // text widget.  If they have since clicked into the WebView
-            // (so WKWebView is the native first responder but AWT focus
-            // owner is still the JTextComponent), override the deferral
-            // and route the shortcut to the WebView.
-            if (!embedded.isNativeFirstResponder()) {
-                return false;
-            }
+        boolean focusInWebView = focusOwner != null
+            && (focusOwner == this
+                || SwingUtilities.isDescendingFrom(focusOwner, this));
+        boolean nativeFocusOnWebView = embedded.isNativeFirstResponder();
+        if (!focusInWebView && !nativeFocusOnWebView) {
+            return false;
         }
         if (Boolean.getBoolean("ca.weblite.webview.debugShortcut")) {
             System.err.println(
                 "[webview-editing-shortcut] heavyweight dispatch cmd="
                 + cmd + " focusOwner="
                 + (focusOwner == null ? "null" : focusOwner.getClass().getName())
-                + " nativeFR=" + embedded.isNativeFirstResponder());
+                + " focusInWebView=" + focusInWebView
+                + " nativeFR=" + nativeFocusOnWebView);
         }
         embedded.executeEditingCommand(cmd);
         return true;

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -6,14 +6,20 @@
 package ca.weblite.webview.swing;
 
 import ca.weblite.webview.ConsoleDispatcher;
+import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.EmbeddedWebView;
 import ca.weblite.webview.WebView;
+import ca.weblite.webview.WebViewFocusCallback;
+import javax.swing.text.JTextComponent;
 
 import java.awt.BorderLayout;
 import java.awt.Canvas;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Insets;
+import java.awt.KeyboardFocusManager;
 import java.awt.Point;
+import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -21,8 +27,10 @@ import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.event.HierarchyEvent;
 import java.awt.event.HierarchyListener;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.KeyEventDispatcher;
 import javax.swing.SwingUtilities;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -49,6 +57,21 @@ import java.util.Map;
  */
 public class WebViewHeavyweightComponent extends WebViewComponent {
 
+    /**
+     * Cached value of {@link Toolkit#getMenuShortcutKeyMask()}.  The mask
+     * never changes once the JVM is up, but reading it is a JNI call that
+     * we would otherwise repeat for every key event globally.  Static-final
+     * keeps the dispatcher hot-path branch-free.
+     *
+     * <p>The Ex variant ({@code getMenuShortcutKeyMaskEx}) is Java 10+ only
+     * and this project targets Java 1.8; the legacy API returns the
+     * old-style {@code InputEvent.CTRL_MASK} / {@code META_MASK} that pairs
+     * with {@code KeyEvent.getModifiers()}.
+     */
+    @SuppressWarnings("deprecation")
+    private static final int SHORTCUT_MASK =
+            Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
+
     private final EmbeddedCanvas canvas;
     private EmbeddedWebView embedded;
 
@@ -57,6 +80,9 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
     private final List<String> pendingInit = new ArrayList<String>();
     private final Map<String, WebView.JavascriptCallback> pendingBindings =
             new LinkedHashMap<String, WebView.JavascriptCallback>();
+    private KeyEventDispatcher editingShortcutDispatcher;
+    private JTextComponent suppressedCaretOwner;
+    private boolean originalCaretVisible;
 
     public WebViewHeavyweightComponent() {
         setLayout(new BorderLayout());
@@ -160,6 +186,82 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         return d;
     }
 
+    @Override
+    public void addNotify() {
+        super.addNotify();
+        if (editingShortcutDispatcher == null) {
+            editingShortcutDispatcher = new KeyEventDispatcher() {
+                @Override
+                public boolean dispatchKeyEvent(KeyEvent e) {
+                    return handleEditingShortcut(e);
+                }
+            };
+            KeyboardFocusManager
+                .getCurrentKeyboardFocusManager()
+                .addKeyEventDispatcher(editingShortcutDispatcher);
+        }
+    }
+
+    @Override
+    public void removeNotify() {
+        if (editingShortcutDispatcher != null) {
+            KeyboardFocusManager
+                .getCurrentKeyboardFocusManager()
+                .removeKeyEventDispatcher(editingShortcutDispatcher);
+            editingShortcutDispatcher = null;
+        }
+        super.removeNotify();
+    }
+
+    private boolean handleEditingShortcut(KeyEvent e) {
+        if (e.getID() != KeyEvent.KEY_PRESSED) {
+            return false;
+        }
+        if ((e.getModifiers() & SHORTCUT_MASK) != SHORTCUT_MASK) {
+            return false;
+        }
+        EditingCommand cmd;
+        switch (e.getKeyCode()) {
+            case KeyEvent.VK_C: cmd = EditingCommand.COPY;       break;
+            case KeyEvent.VK_V: cmd = EditingCommand.PASTE;      break;
+            case KeyEvent.VK_X: cmd = EditingCommand.CUT;        break;
+            case KeyEvent.VK_A: cmd = EditingCommand.SELECT_ALL; break;
+            default: return false;
+        }
+        if (embedded == null) {
+            return false;
+        }
+        if (!isShowing()) {
+            return false;
+        }
+        Window myWindow = SwingUtilities.getWindowAncestor(this);
+        if (myWindow == null || !myWindow.isFocused()) {
+            return false;
+        }
+        Component focusOwner = KeyboardFocusManager
+            .getCurrentKeyboardFocusManager()
+            .getFocusOwner();
+        if (focusOwner instanceof JTextComponent) {
+            // Only defer to Swing if the user has genuinely focused the
+            // text widget.  If they have since clicked into the WebView
+            // (so WKWebView is the native first responder but AWT focus
+            // owner is still the JTextComponent), override the deferral
+            // and route the shortcut to the WebView.
+            if (!embedded.isNativeFirstResponder()) {
+                return false;
+            }
+        }
+        if (Boolean.getBoolean("ca.weblite.webview.debugShortcut")) {
+            System.err.println(
+                "[webview-editing-shortcut] heavyweight dispatch cmd="
+                + cmd + " focusOwner="
+                + (focusOwner == null ? "null" : focusOwner.getClass().getName())
+                + " nativeFR=" + embedded.isNativeFirstResponder());
+        }
+        embedded.executeEditingCommand(cmd);
+        return true;
+    }
+
     private void createPeer() {
         if (embedded != null || !canvas.isDisplayable()) {
             return;
@@ -192,6 +294,50 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         }
         embedded.navigate(pendingUrl);
         sizeNative();
+        // Install the native focus callback so we can mirror WKWebView's
+        // first-responder state into Swing's visual focus indicators.
+        // The lambda is anchored in EmbeddedWebView.heap via
+        // setFocusCallback so the JVM doesn't collect it while the
+        // native side holds a global ref.
+        embedded.setFocusCallback(new WebViewFocusCallback() {
+            @Override
+            public void invoke(boolean became) {
+                SwingUtilities.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        handleNativeFocusChange(became);
+                    }
+                });
+            }
+        });
+    }
+
+    private void handleNativeFocusChange(boolean became) {
+        if (became) {
+            if (suppressedCaretOwner != null) {
+                // Already suppressed a caret in a prior transition; the
+                // native first-responder state can flip during page
+                // navigation or transient widget focus inside the page,
+                // and we don't want to overwrite the saved restore state.
+                return;
+            }
+            Component owner = KeyboardFocusManager
+                .getCurrentKeyboardFocusManager()
+                .getFocusOwner();
+            if (owner instanceof JTextComponent) {
+                JTextComponent jtc = (JTextComponent) owner;
+                suppressedCaretOwner = jtc;
+                if (jtc.getCaret() != null) {
+                    originalCaretVisible = jtc.getCaret().isVisible();
+                    jtc.getCaret().setVisible(false);
+                }
+            }
+        } else {
+            if (suppressedCaretOwner != null && suppressedCaretOwner.getCaret() != null) {
+                suppressedCaretOwner.getCaret().setVisible(originalCaretVisible);
+            }
+            suppressedCaretOwner = null;
+        }
     }
 
     private void sizeNative() {

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -10,6 +10,8 @@ import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.EmbeddedWebView;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewFocusCallback;
+import java.awt.AWTEvent;
+import java.awt.event.AWTEventListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import javax.swing.text.JTextComponent;
@@ -84,6 +86,7 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
             new LinkedHashMap<String, WebView.JavascriptCallback>();
     private KeyEventDispatcher editingShortcutDispatcher;
     private PropertyChangeListener focusOwnerListener;
+    private AWTEventListener globalMouseListener;
     private JTextComponent suppressedCaretOwner;
     private boolean originalCaretVisible;
 
@@ -214,10 +217,32 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
                 .getCurrentKeyboardFocusManager()
                 .addPropertyChangeListener("focusOwner", focusOwnerListener);
         }
+        // Belt-and-suspenders mouse listener: PropertyChangeListener on
+        // focusOwner may not fire on Windows when Win32 keyboard focus is
+        // on a foreign HWND (WebView2's child HWND) -- AWT's internal
+        // focus tracking can desync.  An AWTEventListener for mouse
+        // events fires for every mouse press in the JVM regardless of
+        // focus state, so it can reliably trigger the native focus
+        // release when the user clicks outside the WebView.
+        if (globalMouseListener == null) {
+            globalMouseListener = new AWTEventListener() {
+                @Override
+                public void eventDispatched(AWTEvent event) {
+                    handleGlobalMouseEvent(event);
+                }
+            };
+            Toolkit.getDefaultToolkit().addAWTEventListener(
+                globalMouseListener, AWTEvent.MOUSE_EVENT_MASK);
+        }
     }
 
     @Override
     public void removeNotify() {
+        if (globalMouseListener != null) {
+            Toolkit.getDefaultToolkit()
+                .removeAWTEventListener(globalMouseListener);
+            globalMouseListener = null;
+        }
         if (focusOwnerListener != null) {
             KeyboardFocusManager
                 .getCurrentKeyboardFocusManager()
@@ -231,6 +256,35 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
             editingShortcutDispatcher = null;
         }
         super.removeNotify();
+    }
+
+    private void handleGlobalMouseEvent(AWTEvent event) {
+        if (embedded == null) return;
+        if (event.getID() != java.awt.event.MouseEvent.MOUSE_PRESSED) return;
+        Object src = event.getSource();
+        if (!(src instanceof Component)) return;
+        Component target = (Component) src;
+        boolean debug = Boolean.getBoolean("ca.weblite.webview.debugShortcut");
+        // Click landed inside the WebView -- WebView2 is taking focus
+        // legitimately, no native release needed.
+        if (target == this || SwingUtilities.isDescendingFrom(target, this)) {
+            if (debug) System.err.println(
+                "[webview-focus] mouse-press ignored (inside WebView): "
+                + target.getClass().getName());
+            return;
+        }
+        Window myWindow = SwingUtilities.getWindowAncestor(this);
+        Window targetWindow = SwingUtilities.getWindowAncestor(target);
+        if (myWindow == null || targetWindow != myWindow) {
+            if (debug) System.err.println(
+                "[webview-focus] mouse-press ignored (different window): "
+                + target.getClass().getName());
+            return;
+        }
+        if (debug) System.err.println(
+            "[webview-focus] mouse-press releaseNativeFocus on target="
+            + target.getClass().getName());
+        embedded.releaseNativeFocus();
     }
 
     private void handleFocusOwnerChange(Object newOwner) {

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -234,19 +234,38 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
     }
 
     private void handleFocusOwnerChange(Object newOwner) {
-        if (embedded == null) return;
-        if (!(newOwner instanceof Component)) return;
+        boolean debug = Boolean.getBoolean("ca.weblite.webview.debugShortcut");
+        if (embedded == null) {
+            if (debug) System.err.println(
+                "[webview-focus] focusOwner change ignored: embedded == null");
+            return;
+        }
+        if (!(newOwner instanceof Component)) {
+            if (debug) System.err.println(
+                "[webview-focus] focusOwner change ignored: newOwner not Component ("
+                + (newOwner == null ? "null" : newOwner.getClass().getName()) + ")");
+            return;
+        }
         Component owner = (Component) newOwner;
         // Focus moved INTO the WebView -- no native release needed.
         if (owner == this || SwingUtilities.isDescendingFrom(owner, this)) {
+            if (debug) System.err.println(
+                "[webview-focus] focusOwner change ignored: focus moved into WebView ("
+                + owner.getClass().getName() + ")");
             return;
         }
         // Focus moved to an unrelated top-level window -- not our problem.
         Window myWindow = SwingUtilities.getWindowAncestor(this);
         Window ownerWindow = SwingUtilities.getWindowAncestor(owner);
         if (myWindow == null || ownerWindow != myWindow) {
+            if (debug) System.err.println(
+                "[webview-focus] focusOwner change ignored: different window ("
+                + owner.getClass().getName() + ")");
             return;
         }
+        if (debug) System.err.println(
+            "[webview-focus] releaseNativeFocus on focusOwner="
+            + owner.getClass().getName());
         // AWT moved focus to a Swing component in our window that isn't
         // part of the WebView.  On Windows, Win32 keyboard focus may still
         // be on the WebView2 child HWND; force it back to the AWT parent

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -288,10 +288,21 @@ public class WebViewLightweightComponent extends WebViewComponent {
         if (myWindow == null || !myWindow.isFocused()) {
             return false;
         }
+        // Default to deferring to Swing.  Only dispatch to the WebView
+        // when AWT focus is actually inside this component -- the
+        // lightweight requestFocusInWindow() on mouse-press means
+        // focusOwner reliably reflects user intent here.  Any other
+        // focus state (sibling Swing component, JFrame content pane,
+        // null during a focus transition) means the user is not
+        // interacting with the WebView and the shortcut should go to
+        // its Swing target unchanged.
         Component focusOwner = KeyboardFocusManager
             .getCurrentKeyboardFocusManager()
             .getFocusOwner();
-        if (focusOwner instanceof javax.swing.text.JTextComponent) {
+        boolean focusInWebView = focusOwner != null
+            && (focusOwner == this
+                || SwingUtilities.isDescendingFrom(focusOwner, this));
+        if (!focusInWebView) {
             return false;
         }
         if (Boolean.getBoolean("ca.weblite.webview.debugShortcut")) {

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -6,13 +6,18 @@
 package ca.weblite.webview.swing;
 
 import ca.weblite.webview.ConsoleDispatcher;
+import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.GdkInput;
 import ca.weblite.webview.OffscreenWebView;
 import ca.weblite.webview.WebView;
 
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Graphics;
+import java.awt.KeyEventDispatcher;
+import java.awt.KeyboardFocusManager;
+import java.awt.Toolkit;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.KeyAdapter;
@@ -28,6 +33,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 
 /**
@@ -64,6 +70,16 @@ public class WebViewLightweightComponent extends WebViewComponent {
 
     private static final int REPAINT_INTERVAL_MS = 33; // ~30fps
 
+    /**
+     * Cached value of {@link Toolkit#getMenuShortcutKeyMask()}.  The Ex
+     * variant is Java 10+ and this project targets Java 1.8 in
+     * {@code pom.xml}; the legacy API pairs with
+     * {@code KeyEvent.getModifiers()}.
+     */
+    @SuppressWarnings("deprecation")
+    private static final int SHORTCUT_MASK =
+            Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
+
     private OffscreenWebView engine;
     private BufferedImage buffer;
     private int[] pixelArray;
@@ -74,6 +90,7 @@ public class WebViewLightweightComponent extends WebViewComponent {
     private final List<String> pendingInit = new ArrayList<String>();
     private final Map<String, WebView.JavascriptCallback> pendingBindings =
             new LinkedHashMap<String, WebView.JavascriptCallback>();
+    private KeyEventDispatcher editingShortcutDispatcher;
 
     public WebViewLightweightComponent() {
         setOpaque(true);
@@ -178,7 +195,11 @@ public class WebViewLightweightComponent extends WebViewComponent {
         if (engine == null) {
             // Unsupported platform or native failure -- leave the
             // engine null so subsequent ops are no-ops.  paintComponent
-            // will fall back to the default Swing background.
+            // will fall back to the default Swing background.  Still
+            // install the editing-shortcut dispatcher so its install
+            // path is uniform across platforms; its engine-null
+            // short-circuit makes it a no-op here.
+            installEditingShortcutDispatcher();
             return;
         }
         // Install the console bridge BEFORE replaying user config so the
@@ -204,10 +225,17 @@ public class WebViewLightweightComponent extends WebViewComponent {
         repaintTimer = new Timer(REPAINT_INTERVAL_MS, e -> repaint());
         repaintTimer.setRepeats(true);
         repaintTimer.start();
+        installEditingShortcutDispatcher();
     }
 
     @Override
     public void removeNotify() {
+        if (editingShortcutDispatcher != null) {
+            KeyboardFocusManager
+                .getCurrentKeyboardFocusManager()
+                .removeKeyEventDispatcher(editingShortcutDispatcher);
+            editingShortcutDispatcher = null;
+        }
         if (repaintTimer != null) {
             repaintTimer.stop();
             repaintTimer = null;
@@ -220,6 +248,60 @@ public class WebViewLightweightComponent extends WebViewComponent {
         buffer = null;
         pixelArray = null;
         super.removeNotify();
+    }
+
+    private void installEditingShortcutDispatcher() {
+        if (editingShortcutDispatcher != null) return;
+        editingShortcutDispatcher = new KeyEventDispatcher() {
+            @Override
+            public boolean dispatchKeyEvent(KeyEvent e) {
+                return handleEditingShortcut(e);
+            }
+        };
+        KeyboardFocusManager
+            .getCurrentKeyboardFocusManager()
+            .addKeyEventDispatcher(editingShortcutDispatcher);
+    }
+
+    private boolean handleEditingShortcut(KeyEvent e) {
+        if (e.getID() != KeyEvent.KEY_PRESSED) {
+            return false;
+        }
+        if ((e.getModifiers() & SHORTCUT_MASK) != SHORTCUT_MASK) {
+            return false;
+        }
+        EditingCommand cmd;
+        switch (e.getKeyCode()) {
+            case KeyEvent.VK_C: cmd = EditingCommand.COPY;       break;
+            case KeyEvent.VK_V: cmd = EditingCommand.PASTE;      break;
+            case KeyEvent.VK_X: cmd = EditingCommand.CUT;        break;
+            case KeyEvent.VK_A: cmd = EditingCommand.SELECT_ALL; break;
+            default: return false;
+        }
+        if (engine == null) {
+            return false;
+        }
+        if (!isShowing()) {
+            return false;
+        }
+        java.awt.Window myWindow = SwingUtilities.getWindowAncestor(this);
+        if (myWindow == null || !myWindow.isFocused()) {
+            return false;
+        }
+        Component focusOwner = KeyboardFocusManager
+            .getCurrentKeyboardFocusManager()
+            .getFocusOwner();
+        if (focusOwner instanceof javax.swing.text.JTextComponent) {
+            return false;
+        }
+        if (Boolean.getBoolean("ca.weblite.webview.debugShortcut")) {
+            System.err.println(
+                "[webview-editing-shortcut] lightweight dispatch cmd="
+                + cmd + " focusOwner="
+                + (focusOwner == null ? "null" : focusOwner.getClass().getName()));
+        }
+        engine.executeEditingCommand(cmd);
+        return true;
     }
 
     @Override

--- a/src_c/ca_weblite_webview_WebViewNative.h
+++ b/src_c/ca_weblite_webview_WebViewNative.h
@@ -281,6 +281,30 @@ JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1ope
 
 /*
  * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_execute_editing_command
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1execute_1editing_1command
+  (JNIEnv *, jclass, jlong, jint);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_is_native_first_responder
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1is_1native_1first_1responder
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_set_focus_callback
+ * Signature: (JLca/weblite/webview/WebViewFocusCallback;)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1focus_1callback
+  (JNIEnv *, jclass, jlong, jobject);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
  * Method:    webview_offscreen_init
  * Signature: (JLjava/lang/String;)V
  */
@@ -318,6 +342,14 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
  */
 JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1open_1devtools
   (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_offscreen_execute_editing_command
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1execute_1editing_1command
+  (JNIEnv *, jclass, jlong, jint);
 
 #ifdef __cplusplus
 }

--- a/src_c/ca_weblite_webview_WebViewNative.h
+++ b/src_c/ca_weblite_webview_WebViewNative.h
@@ -305,6 +305,14 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
 
 /*
  * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_release_native_focus
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1release_1native_1focus
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
  * Method:    webview_offscreen_init
  * Signature: (JLjava/lang/String;)V
  */

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -2446,6 +2446,14 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
 #endif
 }
 
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1release_1native_1focus
+  (JNIEnv *, jclass, jlong wv) {
+    // No-op on macOS and Linux: AppKit / X11 focus handling is already
+    // adequate.  Windows has its own implementation in
+    // windows/webview_embed.cc that performs the cross-thread SetFocus.
+    (void)wv;
+}
+
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1init
   (JNIEnv *env, jclass, jlong wv, jstring js) {
     const char *s = env->GetStringUTFChars(js, nullptr);

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -1159,6 +1159,30 @@ static int gtk_off_open_devtools(OffEngine *e) {
     return result;
 }
 
+// Execute Cut/Copy/Paste/SelectAll against the focused frame of the
+// offscreen WebKitGTK widget.  Mirrors gtk_execute_editing_command for
+// the heavyweight engine -- same switch-on-cmdId + GtkPump::run_async +
+// webkit_web_view_execute_editing_command pattern, just over OffEngine.
+//
+// cmdId values are the EditingCommand contract: 1=CUT, 2=COPY, 3=PASTE,
+// 4=SELECT_ALL.  Unknown cmdIds are silently dropped.
+static void gtk_off_execute_editing_command(OffEngine *e, int cmdId) {
+    if (!e || !e->web) return;
+    const char *command = nullptr;
+    switch (cmdId) {
+        case 1: command = WEBKIT_EDITING_COMMAND_CUT;        break;
+        case 2: command = WEBKIT_EDITING_COMMAND_COPY;       break;
+        case 3: command = WEBKIT_EDITING_COMMAND_PASTE;      break;
+        case 4: command = WEBKIT_EDITING_COMMAND_SELECT_ALL; break;
+        default: return;
+    }
+    GtkPump::instance().run_async([e, command] {
+        if (!e || !e->web) return;
+        webkit_web_view_execute_editing_command(
+            WEBKIT_WEB_VIEW(e->web), command);
+    });
+}
+
 // Same idea for the heavyweight embed-path engine.  Lives here next to
 // the offscreen variant so both implementations are visible side by side.
 static int gtk_open_devtools(Engine *e) {
@@ -1176,6 +1200,30 @@ static int gtk_open_devtools(Engine *e) {
         result = 1;
     });
     return result;
+}
+
+// Execute Cut/Copy/Paste/SelectAll on the focused frame of the embedded
+// WebKitGTK widget.  Marshals to the GTK pump thread asynchronously; the
+// editing-command primitive operates against the WebView's current focused
+// frame internally, so we don't have to do focus-routing ourselves.
+//
+// cmdId values are the EditingCommand contract: 1=CUT, 2=COPY, 3=PASTE,
+// 4=SELECT_ALL.  Unknown cmdIds are silently dropped.
+static void gtk_execute_editing_command(Engine *e, int cmdId) {
+    if (!e || !e->web) return;
+    const char *command = nullptr;
+    switch (cmdId) {
+        case 1: command = WEBKIT_EDITING_COMMAND_CUT;        break;
+        case 2: command = WEBKIT_EDITING_COMMAND_COPY;       break;
+        case 3: command = WEBKIT_EDITING_COMMAND_PASTE;      break;
+        case 4: command = WEBKIT_EDITING_COMMAND_SELECT_ALL; break;
+        default: return;
+    }
+    GtkPump::instance().run_async([e, command] {
+        if (!e || !e->web) return;
+        webkit_web_view_execute_editing_command(
+            WEBKIT_WEB_VIEW(e->web), command);
+    });
 }
 
 // Mouse event injection.  Java listeners on WebViewLightweightComponent
@@ -1440,7 +1488,20 @@ struct Engine {
     // host_view is NSWindow.contentView and we have to honor the caller's
     // (x,y) and translate AWT top-left coords into Cocoa bottom-left.
     bool host_is_awt = false;
+
+    // JNI global ref to the registered WebViewFocusCallback, or nullptr.
+    // Invoked by the swizzled becomeFirstResponder / resignFirstResponder
+    // implementations.
+    jobject focus_callback = nullptr;
 };
+
+// Process-global map from WKWebView (id) to its owning Engine*.  Populated
+// in cocoa_create_engine after WKWebView alloc; cleared in
+// cocoa_destroy_engine.  Guarded by g_webview_map_mutex because the
+// swizzled responder hooks fire on the AppKit main thread while
+// create/destroy run on EDT-driven native code.
+static std::mutex g_webview_map_mutex;
+static std::map<id, Engine *> g_webview_map;
 
 static void cocoa_run_on_main(std::function<void()> f) {
     // If we're already on the AppKit main thread, just run f inline; otherwise
@@ -1509,6 +1570,142 @@ static void engine_on_message(Engine *e, const char *msg) {
     if (detach) e->jvm->DetachCurrentThread();
 }
 
+// ---------------------------------------------------------------------------
+// First-responder hook on WKWebView.
+//
+// We swizzle becomeFirstResponder / resignFirstResponder on the WKWebView
+// class so we can mirror the native focus state back into Swing.  Swizzling
+// is class-wide: it affects every WKWebView in the process, including any
+// the host application created independently of this library.  That's
+// fine because each swizzled implementation looks up the receiver in
+// g_webview_map and silently no-ops if we don't own it.
+//
+// The Java callback is invoked via JNI on whatever thread AppKit drove
+// the responder change on (typically the AppKit main thread).  Java-side
+// callers MUST marshal to the EDT before touching Swing state -- the
+// callback contract documents this explicitly.
+// ---------------------------------------------------------------------------
+
+typedef BOOL (*BoolFromIdSel)(id, SEL);
+static BoolFromIdSel g_orig_becomeFirstResponder = nullptr;
+static BoolFromIdSel g_orig_resignFirstResponder = nullptr;
+static std::once_flag g_focus_swizzle_once;
+
+static void fire_focus_callback(Engine *e, bool became) {
+    if (!e || !e->focus_callback) return;
+    JavaVM *jvm = e->jvm;
+    if (!jvm) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        jvm->AttachCurrentThread((void **)&env, nullptr);
+        detach = true;
+    }
+    if (env) {
+        jclass cls = env->GetObjectClass(e->focus_callback);
+        if (cls) {
+            jmethodID m = env->GetMethodID(cls, "invoke", "(Z)V");
+            if (m) {
+                env->CallVoidMethod(e->focus_callback, m, (jboolean)became);
+            }
+            env->DeleteLocalRef(cls);
+        }
+    }
+    if (detach) jvm->DetachCurrentThread();
+}
+
+static BOOL swizzled_become_first_responder(id self, SEL _cmd) {
+    BOOL result = g_orig_becomeFirstResponder
+        ? g_orig_becomeFirstResponder(self, _cmd)
+        : NO;
+    if (result) {
+        Engine *eng = nullptr;
+        {
+            std::lock_guard<std::mutex> lk(g_webview_map_mutex);
+            auto it = g_webview_map.find(self);
+            if (it != g_webview_map.end()) eng = it->second;
+        }
+        if (eng) fire_focus_callback(eng, true);
+    }
+    return result;
+}
+
+static BOOL swizzled_resign_first_responder(id self, SEL _cmd) {
+    BOOL result = g_orig_resignFirstResponder
+        ? g_orig_resignFirstResponder(self, _cmd)
+        : NO;
+    if (result) {
+        Engine *eng = nullptr;
+        {
+            std::lock_guard<std::mutex> lk(g_webview_map_mutex);
+            auto it = g_webview_map.find(self);
+            if (it != g_webview_map.end()) eng = it->second;
+        }
+        if (eng) fire_focus_callback(eng, false);
+    }
+    return result;
+}
+
+static void install_focus_swizzle() {
+    std::call_once(g_focus_swizzle_once, [] {
+        Class wk = (Class)objc_cls("WKWebView");
+        if (!wk) return;
+        Method become = class_getInstanceMethod(wk, sel("becomeFirstResponder"));
+        Method resign = class_getInstanceMethod(wk, sel("resignFirstResponder"));
+        if (!become || !resign) return;
+        g_orig_becomeFirstResponder = (BoolFromIdSel)method_setImplementation(
+            become, (IMP)swizzled_become_first_responder);
+        g_orig_resignFirstResponder = (BoolFromIdSel)method_setImplementation(
+            resign, (IMP)swizzled_resign_first_responder);
+    });
+}
+
+// Returns 1 if the engine's WKWebView (or a descendant view in its
+// subview hierarchy -- WebKit content view, etc.) is currently the
+// first responder of its NSWindow.  Synchronous query against AppKit
+// main thread state; safe to call from EDT during a key press
+// (NOT during NSEventTrackingRunLoopMode, but Cmd+C isn't a tracking
+// event).
+static int cocoa_is_first_responder(Engine *e) {
+    if (!e || !e->webview) return 0;
+    int result = 0;
+    cocoa_run_on_main([&] {
+        if (!e->webview) return;
+        id window = msg(e->webview, sel("window"));
+        if (!window) return;
+        id fr = msg(window, sel("firstResponder"));
+        if (!fr) return;
+        // Walk the responder's view-hierarchy chain looking for the
+        // WKWebView.  The actual first responder is often an inner
+        // WebKit content view, not the WKWebView itself.
+        SEL is_kind_of_view = sel("isKindOfClass:");
+        id view_cls = objc_cls("NSView");
+        if (!msg<BOOL, id>(fr, is_kind_of_view, view_cls)) {
+            // First responder isn't an NSView (e.g. NSWindow itself) --
+            // not us.
+            return;
+        }
+        for (id v = fr; v; v = msg(v, sel("superview"))) {
+            if (v == e->webview) {
+                result = 1;
+                return;
+            }
+        }
+    });
+    return result;
+}
+
+static void cocoa_set_focus_callback(Engine *e, JNIEnv *env, jobject cb) {
+    if (!e) return;
+    if (e->focus_callback) {
+        env->DeleteGlobalRef(e->focus_callback);
+        e->focus_callback = nullptr;
+    }
+    if (cb) {
+        e->focus_callback = env->NewGlobalRef(cb);
+    }
+}
+
 static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
                                    jlong /*display*/, jint debug) {
     auto *e = new Engine();
@@ -1535,12 +1732,24 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
 
     bool ok = false;
     cocoa_run_on_main([&] {
+        // Install the WKWebView first-responder swizzle once per JVM
+        // BEFORE creating the WKWebView, so any becomeFirstResponder
+        // calls during init are routed through our hook from the start.
+        install_focus_swizzle();
+
         e->config = msg(objc_cls("WKWebViewConfiguration"), sel("new"));
         e->manager = msg(e->config, sel("userContentController"));
         e->webview = msg(objc_cls("WKWebView"), sel("alloc"));
         e->webview = msg<id, CGRect, id>(
             e->webview, sel("initWithFrame:configuration:"),
             CGRectMake(0, 0, 800, 600), e->config);
+
+        // Register the WKWebView in the engine map so the swizzled
+        // responder hooks can find their Engine pointer.
+        {
+            std::lock_guard<std::mutex> lk(g_webview_map_mutex);
+            g_webview_map[e->webview] = e;
+        }
 
         // Find a hostable NSView.  Walk up the windowLayer's superlayer
         // chain and use whatever NSView class we encounter to reach the
@@ -1680,6 +1889,28 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
 
 static void cocoa_destroy_engine(Engine *e) {
     if (!e) return;
+    // Drop the webview from the engine map BEFORE any teardown work --
+    // the swizzled responder hooks can fire at any moment during destroy
+    // (AppKit unwinds the view hierarchy and resigns first responder),
+    // and we don't want them invoking a callback into a freed Engine.
+    if (e->webview) {
+        std::lock_guard<std::mutex> lk(g_webview_map_mutex);
+        g_webview_map.erase(e->webview);
+    }
+    // Drop the focus-callback global ref (if any) on the EDT-driven
+    // thread that holds the JNIEnv -- we cannot delete a global ref
+    // from inside the AppKit-main lambda below without re-attaching.
+    if (e->focus_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->focus_callback);
+        e->focus_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     cocoa_run_on_main([&] {
         if (e->webview) {
             // If we added the WKWebView as a subview, remove it before
@@ -1811,6 +2042,54 @@ static void cocoa_bind(Engine *e, Binding *b) { e->bindings[b->name] = b; }
 static int cocoa_open_devtools(Engine *e) {
     (void)e;
     return 0;
+}
+
+// Dispatch Cut/Copy/Paste/SelectAll directly to the embedded WKWebView.
+// Initial design used [NSApp sendAction:... to:nil from:webview] so the
+// responder chain would route to the inner focused DOM element, but in
+// the AWT-embedded setup (WKWebView parented under NSWindow.contentView,
+// which is AWT's NSView) the AppKit first responder is not reliably the
+// WKWebView -- AWT keeps system focus on its own view -- so the
+// responder walk never reaches WKWebView and the action no-ops.
+//
+// Sending the action directly to WKWebView side-steps the chain entirely.
+// WKWebView's implementations of cut:/copy:/paste:/selectAll: delegate to
+// the WebKit page's current selection / focused element internally, so
+// the operation hits the correct in-page target regardless of AppKit
+// first-responder state.  Guard with respondsToSelector: so a missing
+// selector on an older SDK fails silently instead of aborting.
+//
+// cmdId values are the EditingCommand contract: 1=CUT, 2=COPY, 3=PASTE,
+// 4=SELECT_ALL.  Unknown cmdIds are silently dropped.
+static void cocoa_execute_editing_command(Engine *e, int cmdId) {
+    if (!e || !e->webview) return;
+    SEL action = nullptr;
+    const char *name = nullptr;
+    switch (cmdId) {
+        case 1: action = sel("cut:");        name = "cut:";        break;
+        case 2: action = sel("copy:");       name = "copy:";       break;
+        case 3: action = sel("paste:");      name = "paste:";      break;
+        case 4: action = sel("selectAll:");  name = "selectAll:";  break;
+        default: return;
+    }
+    cocoa_run_on_main_async([=] {
+        if (!e->webview) return;
+        if (!msg<BOOL, SEL>(e->webview, sel("respondsToSelector:"),
+                            action)) {
+            if (getenv("WEBVIEW_DEBUG_SHORTCUT")) {
+                fprintf(stderr,
+                    "[webview-editing-shortcut] cocoa: WKWebView does not "
+                    "respond to %s, dropping\n", name);
+            }
+            return;
+        }
+        if (getenv("WEBVIEW_DEBUG_SHORTCUT")) {
+            fprintf(stderr,
+                "[webview-editing-shortcut] cocoa: dispatching %s "
+                "directly to WKWebView %p\n", name, (void *)e->webview);
+        }
+        msg<void, id>(e->webview, action, (id)nullptr);
+    });
 }
 
 #endif // WEBVIEW_COCOA
@@ -2137,6 +2416,36 @@ JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1ope
 #endif
 }
 
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1execute_1editing_1command
+  (JNIEnv *, jclass, jlong wv, jint cmdId) {
+#ifdef WEBVIEW_GTK
+    embed::gtk_execute_editing_command((Engine *)wv, (int)cmdId);
+#elif defined(WEBVIEW_COCOA)
+    embed::cocoa_execute_editing_command((Engine *)wv, (int)cmdId);
+#else
+    (void)wv; (void)cmdId;
+#endif
+}
+
+JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1is_1native_1first_1responder
+  (JNIEnv *, jclass, jlong wv) {
+#ifdef WEBVIEW_COCOA
+    return (jint)embed::cocoa_is_first_responder((Engine *)wv);
+#else
+    (void)wv;
+    return 0;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1focus_1callback
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+#ifdef WEBVIEW_COCOA
+    embed::cocoa_set_focus_callback((Engine *)wv, env, cb);
+#else
+    (void)env; (void)wv; (void)cb;
+#endif
+}
+
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1init
   (JNIEnv *env, jclass, jlong wv, jstring js) {
     const char *s = env->GetStringUTFChars(js, nullptr);
@@ -2232,5 +2541,15 @@ JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
 #else
     (void)wv;
     return 0;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1execute_1editing_1command
+  (JNIEnv *, jclass, jlong wv, jint cmdId) {
+#ifdef WEBVIEW_GTK
+    embed::gtk_off_execute_editing_command(
+        (embed::OffEngine *)wv, (int)cmdId);
+#else
+    (void)wv; (void)cmdId;
 #endif
 }

--- a/windows/ca_weblite_webview_WebViewNative.h
+++ b/windows/ca_weblite_webview_WebViewNative.h
@@ -281,6 +281,30 @@ JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1ope
 
 /*
  * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_execute_editing_command
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1execute_1editing_1command
+  (JNIEnv *, jclass, jlong, jint);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_is_native_first_responder
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1is_1native_1first_1responder
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_set_focus_callback
+ * Signature: (JLca/weblite/webview/WebViewFocusCallback;)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1focus_1callback
+  (JNIEnv *, jclass, jlong, jobject);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
  * Method:    webview_offscreen_init
  * Signature: (JLjava/lang/String;)V
  */
@@ -310,6 +334,14 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
  */
 JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1open_1devtools
   (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_offscreen_execute_editing_command
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1execute_1editing_1command
+  (JNIEnv *, jclass, jlong, jint);
 
 #ifdef __cplusplus
 }

--- a/windows/ca_weblite_webview_WebViewNative.h
+++ b/windows/ca_weblite_webview_WebViewNative.h
@@ -305,6 +305,14 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
 
 /*
  * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_release_native_focus
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1release_1native_1focus
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
  * Method:    webview_offscreen_init
  * Signature: (JLjava/lang/String;)V
  */

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -765,6 +765,45 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
     // JNI symbol must exist for System.loadLibrary to resolve.
 }
 
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1release_1native_1focus
+  (JNIEnv *, jclass, jlong wv) {
+    // When AWT moves its Java-side focus owner to a Swing component, Win32
+    // keyboard focus does NOT automatically follow -- if the user had
+    // clicked into the WebView2 child HWND first, that HWND keeps focus
+    // and steals subsequent keystrokes from AWT.  Force focus back to
+    // the AWT-owned parent HWND so the new Swing focus owner actually
+    // receives keystrokes.
+    //
+    // Win32 focus is per-thread.  The WebView2 worker thread is the one
+    // currently holding focus (on the WebView2 HWND it owns); AWT's
+    // parent HWND is owned by the AWT EDT thread.  SetFocus across
+    // threads silently no-ops unless the calling thread has attached
+    // input state to the target thread via AttachThreadInput.  Dispatch
+    // the work to the WebView2 worker (so we're on the thread holding
+    // focus), attach input to the AWT thread, then SetFocus on the
+    // parent HWND.
+    auto *e = (Engine *)wv;
+    if (!e || !e->parent) return;
+    embed_win::dispatch_to_thread(e, [e] {
+        HWND parent = e->parent;
+        if (!parent) return;
+        DWORD self_tid = GetCurrentThreadId();
+        DWORD parent_tid = GetWindowThreadProcessId(parent, nullptr);
+        if (parent_tid == 0) return;
+        if (parent_tid != self_tid) {
+            if (!AttachThreadInput(self_tid, parent_tid, TRUE)) {
+                WV_LOG("AttachThreadInput failed: %lu",
+                       (unsigned long)GetLastError());
+                return;
+            }
+            SetFocus(parent);
+            AttachThreadInput(self_tid, parent_tid, FALSE);
+        } else {
+            SetFocus(parent);
+        }
+    });
+}
+
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1execute_1editing_1command
   (JNIEnv *, jclass, jlong wv, jint cmdId) {
     auto *e = (Engine *)wv;

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -105,11 +105,39 @@ struct Engine {
     ICoreWebView2Controller *controller = nullptr;
     ICoreWebView2 *webview = nullptr;
     EventRegistrationToken message_token{};
+    EventRegistrationToken got_focus_token{};
+    EventRegistrationToken lost_focus_token{};
     std::map<std::string, Binding *> bindings;
     JavaVM *jvm = nullptr;
     bool debug = false;
     std::mutex bindings_mutex;
+    // JNI global ref to the registered WebViewFocusCallback, or nullptr.
+    // Invoked from the WebView2 controller's GotFocus / LostFocus events.
+    jobject focus_callback = nullptr;
 };
+
+static void fire_focus_callback(Engine *e, bool became) {
+    if (!e || !e->focus_callback) return;
+    JavaVM *jvm = e->jvm;
+    if (!jvm) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        jvm->AttachCurrentThread((void **)&env, nullptr);
+        detach = true;
+    }
+    if (env) {
+        jclass cls = env->GetObjectClass(e->focus_callback);
+        if (cls) {
+            jmethodID m = env->GetMethodID(cls, "invoke", "(Z)V");
+            if (m) {
+                env->CallVoidMethod(e->focus_callback, m, (jboolean)became);
+            }
+            env->DeleteLocalRef(cls);
+        }
+    }
+    if (detach) jvm->DetachCurrentThread();
+}
 
 // IUnknown helper -- gives each WebView2 callback proper refcounting and
 // QueryInterface support.  The interfaces we implement are all single-
@@ -170,6 +198,20 @@ private:
 // Forward declarations.
 static void engine_on_message(Engine *e, LPCWSTR msg);
 static std::wstring utf8_to_wide(const char *s);
+
+class FocusHandler : public CallbackBase<
+    ICoreWebView2FocusChangedEventHandler> {
+public:
+    FocusHandler(Engine *e, bool became) : m_engine(e), m_became(became) {}
+    HRESULT STDMETHODCALLTYPE Invoke(ICoreWebView2Controller *,
+                                     IUnknown *) override {
+        fire_focus_callback(m_engine, m_became);
+        return S_OK;
+    }
+private:
+    Engine *m_engine;
+    bool m_became;
+};
 
 class MsgHandler : public CallbackBase<
     ICoreWebView2WebMessageReceivedEventHandler> {
@@ -338,6 +380,19 @@ static void engine_thread(Engine *e, HWND /*parent*/, int width, int height,
                     e->webview->add_WebMessageReceived(mh, &e->message_token);
                     mh->Release();
 
+                    // Hook GotFocus / LostFocus on the controller so the
+                    // Java side can suppress and restore the previously-
+                    // focused JTextComponent's caret while WebView2 holds
+                    // Win32 keyboard focus.  Two separate handler
+                    // instances because the same callback signature has
+                    // no way to distinguish got vs lost from the args.
+                    auto *gh = new FocusHandler(e, true);
+                    ctrl->add_GotFocus(gh, &e->got_focus_token);
+                    gh->Release();
+                    auto *lh = new FocusHandler(e, false);
+                    ctrl->add_LostFocus(lh, &e->lost_focus_token);
+                    lh->Release();
+
                     init_done.clear();
                 });
             HRESULT r2 = env->CreateCoreWebView2Controller(
@@ -458,6 +513,22 @@ static void destroy_engine(Engine *e) {
     if (!e) return;
     if (e->thread_id) {
         PostThreadMessage(e->thread_id, WM_EMBED_QUIT, 0, 0);
+    }
+    // Release the focus callback global ref BEFORE the WebView2 worker
+    // thread tears down -- the GotFocus / LostFocus handlers can fire
+    // during teardown (LostFocus in particular fires when the controller
+    // is closed) and we don't want them invoking a callback into a freed
+    // Java global ref.
+    if (e->focus_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->focus_callback);
+        e->focus_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
     }
     {
         std::lock_guard<std::mutex> lk(e->bindings_mutex);
@@ -759,10 +830,22 @@ JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1is_
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1focus_1callback
-  (JNIEnv *, jclass, jlong, jobject) {
-    // No-op on Windows: the macOS-specific WKWebView swizzle has no
-    // counterpart on WebView2.  The Java side still calls this so the
-    // JNI symbol must exist for System.loadLibrary to resolve.
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+    // Store the Java callback (JNI global ref) on the Engine.  The
+    // ICoreWebView2 GotFocus / LostFocus handlers (registered during
+    // engine creation) read this field and invoke the callback so the
+    // Java side can mirror WebView2's focus state into Swing -- e.g.,
+    // suppress and restore the previously-focused JTextComponent's
+    // caret while WebView2 holds Win32 keyboard focus.
+    auto *e = (Engine *)wv;
+    if (!e) return;
+    if (e->focus_callback) {
+        env->DeleteGlobalRef(e->focus_callback);
+        e->focus_callback = nullptr;
+    }
+    if (cb) {
+        e->focus_callback = env->NewGlobalRef(cb);
+    }
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1release_1native_1focus

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -711,6 +711,9 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
 JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1open_1devtools
   (JNIEnv *, jclass, jlong) { return 0; }
 
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1execute_1editing_1command
+  (JNIEnv *, jclass, jlong, jint) {}
+
 JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1open_1devtools
   (JNIEnv *, jclass, jlong wv) {
     auto *e = (Engine *)wv;
@@ -745,6 +748,44 @@ JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1ope
         Sleep(1);
     }
     return (jint)result.load();
+}
+
+JNIEXPORT jint JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1is_1native_1first_1responder
+  (JNIEnv *, jclass, jlong) {
+    // Windows has no notion of "first responder"; the focus-cooperation
+    // dispatcher heuristic is macOS-only.  Returning 0 means the Java
+    // dispatcher falls back to its standard AWT-focus-owner gating.
+    return 0;
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1focus_1callback
+  (JNIEnv *, jclass, jlong, jobject) {
+    // No-op on Windows: the macOS-specific WKWebView swizzle has no
+    // counterpart on WebView2.  The Java side still calls this so the
+    // JNI symbol must exist for System.loadLibrary to resolve.
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1execute_1editing_1command
+  (JNIEnv *, jclass, jlong wv, jint cmdId) {
+    auto *e = (Engine *)wv;
+    if (!e) return;
+    // WebView2 exposes no first-class editing-command IPC; route via
+    // document.execCommand on the WebView2 worker thread.  This reliably
+    // triggers the focused element's clipboard handlers and matches the
+    // semantics we get from the Cocoa / GTK sides.  Fire-and-forget --
+    // no callback, no result wait.
+    const wchar_t *js = nullptr;
+    switch (cmdId) {
+        case 1: js = L"document.execCommand('cut')";       break;
+        case 2: js = L"document.execCommand('copy')";      break;
+        case 3: js = L"document.execCommand('paste')";     break;
+        case 4: js = L"document.execCommand('selectAll')"; break;
+        default: return;
+    }
+    std::wstring wjs = js;
+    embed_win::dispatch_to_thread(e, [e, wjs] {
+        if (e->webview) e->webview->ExecuteScript(wjs.c_str(), nullptr);
+    });
 }
 
 } // extern "C"

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -789,7 +789,14 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1rel
     // queue to the parent HWND in the EDT's queue.
     auto *e = (Engine *)wv;
     if (!e || !e->parent) return;
-    HWND parent = e->parent;
+    // The JAWT-provided HWND on Windows is the heavyweight Canvas peer,
+    // NOT the JFrame's HWND.  The URL JTextField is a lightweight Swing
+    // component drawn inside the JFrame's HWND area; for Win32 keystrokes
+    // to reach AWT and be routed to the JTextField, we need focus on the
+    // top-level window, not on the Canvas (which is a sibling of the
+    // toolbar containing the JTextField).
+    HWND target = GetAncestor(e->parent, GA_ROOT);
+    if (!target) target = e->parent;
     DWORD edt_tid = GetCurrentThreadId();
     DWORD wv2_tid = e->thread_id;
     bool debug = getenv("WEBVIEW_DEBUG_SHORTCUT") != nullptr;
@@ -804,22 +811,22 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1rel
             return;
         }
         HWND prev = GetFocus();
-        HWND now = SetFocus(parent);
+        HWND now = SetFocus(target);
         AttachThreadInput(edt_tid, wv2_tid, FALSE);
         if (debug) {
-            WV_LOG("[webview-focus] SetFocus(parent=%p) prev=%p after=%p "
-                   "now=%p edt=%lu wv2=%lu",
-                   (void *)parent, (void *)prev, (void *)now,
-                   (void *)GetFocus(),
+            WV_LOG("[webview-focus] SetFocus(target=%p canvas=%p) prev=%p "
+                   "after=%p now=%p edt=%lu wv2=%lu",
+                   (void *)target, (void *)e->parent,
+                   (void *)prev, (void *)now, (void *)GetFocus(),
                    (unsigned long)edt_tid, (unsigned long)wv2_tid);
         }
     } else {
         HWND prev = GetFocus();
-        HWND now = SetFocus(parent);
+        HWND now = SetFocus(target);
         if (debug) {
-            WV_LOG("[webview-focus] same-thread SetFocus(parent=%p) "
+            WV_LOG("[webview-focus] same-thread SetFocus(target=%p) "
                    "prev=%p after=%p now=%p",
-                   (void *)parent, (void *)prev, (void *)now,
+                   (void *)target, (void *)prev, (void *)now,
                    (void *)GetFocus());
         }
     }

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -774,34 +774,55 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1rel
     // the AWT-owned parent HWND so the new Swing focus owner actually
     // receives keystrokes.
     //
-    // Win32 focus is per-thread.  The WebView2 worker thread is the one
-    // currently holding focus (on the WebView2 HWND it owns); AWT's
-    // parent HWND is owned by the AWT EDT thread.  SetFocus across
-    // threads silently no-ops unless the calling thread has attached
-    // input state to the target thread via AttachThreadInput.  Dispatch
-    // the work to the WebView2 worker (so we're on the thread holding
-    // focus), attach input to the AWT thread, then SetFocus on the
-    // parent HWND.
+    // Win32 focus is per-thread.  The WebView2 worker thread holds focus
+    // on its own HWND; the AWT-owned parent HWND lives on the EDT.  We
+    // need to share input state between the two before SetFocus can
+    // transfer focus across them.
+    //
+    // Done synchronously on the calling thread (the EDT, since this
+    // JNI is invoked from the global focus-owner PropertyChangeListener
+    // on the EDT) -- not via dispatch_to_thread, because the WebView2
+    // worker may be busy with rendering or JS and we want SetFocus to
+    // happen BEFORE the user's next keystroke.  AttachThreadInput merges
+    // the two threads' input queues, so SetFocus from the EDT will
+    // transfer focus from the WebView2 HWND in the worker thread's
+    // queue to the parent HWND in the EDT's queue.
     auto *e = (Engine *)wv;
     if (!e || !e->parent) return;
-    embed_win::dispatch_to_thread(e, [e] {
-        HWND parent = e->parent;
-        if (!parent) return;
-        DWORD self_tid = GetCurrentThreadId();
-        DWORD parent_tid = GetWindowThreadProcessId(parent, nullptr);
-        if (parent_tid == 0) return;
-        if (parent_tid != self_tid) {
-            if (!AttachThreadInput(self_tid, parent_tid, TRUE)) {
-                WV_LOG("AttachThreadInput failed: %lu",
+    HWND parent = e->parent;
+    DWORD edt_tid = GetCurrentThreadId();
+    DWORD wv2_tid = e->thread_id;
+    bool debug = getenv("WEBVIEW_DEBUG_SHORTCUT") != nullptr;
+    if (wv2_tid != 0 && wv2_tid != edt_tid) {
+        if (!AttachThreadInput(edt_tid, wv2_tid, TRUE)) {
+            if (debug) {
+                WV_LOG("[webview-focus] AttachThreadInput(edt=%lu,wv2=%lu) "
+                       "failed: %lu",
+                       (unsigned long)edt_tid, (unsigned long)wv2_tid,
                        (unsigned long)GetLastError());
-                return;
             }
-            SetFocus(parent);
-            AttachThreadInput(self_tid, parent_tid, FALSE);
-        } else {
-            SetFocus(parent);
+            return;
         }
-    });
+        HWND prev = GetFocus();
+        HWND now = SetFocus(parent);
+        AttachThreadInput(edt_tid, wv2_tid, FALSE);
+        if (debug) {
+            WV_LOG("[webview-focus] SetFocus(parent=%p) prev=%p after=%p "
+                   "now=%p edt=%lu wv2=%lu",
+                   (void *)parent, (void *)prev, (void *)now,
+                   (void *)GetFocus(),
+                   (unsigned long)edt_tid, (unsigned long)wv2_tid);
+        }
+    } else {
+        HWND prev = GetFocus();
+        HWND now = SetFocus(parent);
+        if (debug) {
+            WV_LOG("[webview-focus] same-thread SetFocus(parent=%p) "
+                   "prev=%p after=%p now=%p",
+                   (void *)parent, (void *)prev, (void *)now,
+                   (void *)GetFocus());
+        }
+    }
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1execute_1editing_1command


### PR DESCRIPTION
## Summary
- `Cmd/Ctrl + C/V/X/A` now performs Cut / Copy / Paste / Select-All inside the embedded `WebView` on all three platforms.
- A `KeyEventDispatcher` on the heavyweight + lightweight components routes the shortcut to the native editing primitive (`[WKWebView copy:/paste:/cut:/selectAll:]` on macOS, `webkit_web_view_execute_editing_command` on Linux, `document.execCommand` on Windows). A new public `EditingCommand` enum is the stable JNI ABI.
- AWT focus chain cooperates with the native focus chain on macOS + Windows heavyweight: when the user clicks into the WebView, the previously-focused Swing `JTextComponent`'s caret is hidden; when they click back, it's restored and its blink timer is restarted via a synthetic `FocusEvent.FOCUS_GAINED`. macOS hooks `WKWebView.becomeFirstResponder` via a one-shot runtime class swizzle; Windows hooks `ICoreWebView2Controller::add_GotFocus` / `add_LostFocus`.
- Windows-specific: when AWT moves focus to a Swing component, force Win32 keyboard focus back to the JFrame HWND via cross-thread `SetFocus` + `AttachThreadInput`. Without this, WebView2's child HWND keeps Win32 focus and the Swing component can't even receive typing. Driven by a global mouse-press `AWTEventListener` (the `KeyboardFocusManager` property listener is also installed as a fallback signal).
- SPDD canvases 6 (Heavyweight) and 7 (Lightweight) updated to spec all of the above; README's Platform support + Heavyweight notes updated.

## Test plan
- [x] **macOS** heavyweight: Cmd+C/V/X/A in WebView textarea (e.g. google.com search), Cmd+V into URL `JTextField` after WebView interaction. JTextField caret hides while WebView has focus, restores + blinks on return.
- [x] **Linux** lightweight (default on Linux): Ctrl+C/V/X/A in WebView, no hijack of sibling Swing component shortcuts.
- [x] **Windows** heavyweight: Ctrl+V into WebView Google search field; Ctrl+V into URL `JTextField` after clicking into WebView; typing into URL field after clicking WebView (Win32 focus must release from WebView2 child HWND). JTextField caret hides on WebView focus, restores + blinks on click-back including the no-selection-clicked-background case.
- [x] Sanity checks on macOS + Linux after the Windows-specific commits to confirm no regressions.

## Debug flags
- `-Dca.weblite.webview.debugShortcut=true` — Java side; logs `KeyEventDispatcher` decisions, `releaseNativeFocus` paths, focus listener firings.
- `WEBVIEW_DEBUG_SHORTCUT=1` — native side; logs `[WKWebView ...]` dispatches and Windows `SetFocus` / `AttachThreadInput` results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)