### PR TITLE
Restrict build workflow to master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: Build cross-platform jar
 
 on:
   push:
-    branches: ['**']
+    branches: [master]
   pull_request:
+    branches: [master]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Restricts the GitHub Actions build workflow to run only on the `master` branch, reducing unnecessary CI runs on feature branches.

## Changes
- Modified `.github/workflows/build.yml` to limit `push` trigger to `master` branch only (previously ran on all branches via `['**']`)
- Added explicit `branches: [master]` filter to `pull_request` trigger for consistency

## Details
This change ensures the cross-platform jar build workflow only executes for commits to `master` and pull requests targeting `master`, rather than running on every branch push. This reduces CI resource consumption and noise while maintaining build verification for the main development line.

https://claude.ai/code/session_019TLFcHiSPP4JZ7NpRZnzgh