### PR TITLE
Fix issue #21: macOS WKWebView multi-instance crash

### DIFF
--- a/demos/WebViewHeavyweightDemo/src/ca/weblite/webview/demos/WebViewHeavyweightDemo.java
+++ b/demos/WebViewHeavyweightDemo/src/ca/weblite/webview/demos/WebViewHeavyweightDemo.java
@@ -162,6 +162,21 @@ public class WebViewHeavyweightDemo {
                 lightweightToggle.isSelected());
         });
 
+        // ----- Tabs -----
+        JTabbedPane tabs = new JTabbedPane();
+
+        // "+ New WebView Tab" instantiates a second (third, ...) WebView in
+        // the same JVM.  Before the fix for issue #21 this reliably crashed
+        // the JVM with SIGSEGV in objc_registerClassPair on macOS the first
+        // time it was clicked (second WebView in the process).  After the
+        // fix the new tab opens normally.
+        JButton newTabBtn = new JButton("+ New WebView Tab");
+        newTabBtn.setToolTipText(
+            "Create an additional WebView in a new tab.  Reproduces " +
+            "issue #21 on macOS: instantiating a second WKWebView in the " +
+            "same process used to crash in objc_registerClassPair.");
+        newTabBtn.addActionListener(e -> addWebViewTab(tabs));
+
         JPanel toolbar = new JPanel(new BorderLayout(8, 4));
         JPanel toolbarWest = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 4));
         toolbarWest.add(new JLabel("URL:"));
@@ -169,12 +184,10 @@ public class WebViewHeavyweightDemo {
         toolbarWest.add(go);
         JPanel toolbarEast = new JPanel(new FlowLayout(FlowLayout.RIGHT, 4, 4));
         toolbarEast.add(bookmark);
+        toolbarEast.add(newTabBtn);
         toolbarEast.add(lightweightToggle);
         toolbar.add(toolbarWest, BorderLayout.CENTER);
         toolbar.add(toolbarEast, BorderLayout.EAST);
-
-        // ----- Tabs -----
-        JTabbedPane tabs = new JTabbedPane();
 
         JPanel webviewTab = new JPanel(new BorderLayout());
         webviewTab.add(wv, BorderLayout.CENTER);
@@ -255,6 +268,50 @@ public class WebViewHeavyweightDemo {
     private static String resolveUrl(String input) {
         String trimmed = input == null ? "" : input.trim();
         return TEST_PAGE_LABEL.equals(trimmed) ? TEST_PAGE_URL : trimmed;
+    }
+
+    // Running count of additional WebView tabs spawned by the "+ New
+    // WebView Tab" button, used for the tab title.
+    private static int extraWebViewCount = 0;
+
+    private static void addWebViewTab(JTabbedPane tabs) {
+        extraWebViewCount++;
+        int n = extraWebViewCount + 1;   // first extra tab is "WebView 2"
+
+        WebViewComponent extra = WebViewComponent.create();
+        extra.setDebug(true);
+        extra.setUrl("https://example.com");
+        extra.setPreferredSize(new Dimension(900, 600));
+
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(extra, BorderLayout.CENTER);
+
+        String title = "WebView " + n;
+        tabs.addTab(title, panel);
+        int idx = tabs.indexOfComponent(panel);
+
+        // Tab header with a small "x" close button so the user can dispose
+        // the extra WebView without leaking native peers.
+        JPanel tabHeader = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 0));
+        tabHeader.setOpaque(false);
+        tabHeader.add(new JLabel(title));
+        JButton close = new JButton("x");
+        close.setMargin(new java.awt.Insets(0, 4, 0, 4));
+        close.setFocusable(false);
+        close.setToolTipText("Close this WebView tab.");
+        close.addActionListener(ev -> {
+            int curIdx = tabs.indexOfComponent(panel);
+            if (curIdx >= 0) tabs.removeTabAt(curIdx);
+            // removeNotify() on the WebViewComponent will dispose the
+            // native peer.
+        });
+        tabHeader.add(close);
+        tabs.setTabComponentAt(idx, tabHeader);
+
+        tabs.setSelectedIndex(idx);
+
+        System.err.println("[demo] Spawned " + title
+            + " (heavyweight=" + extra.isHeavyweight() + ")");
     }
 
     /**

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -1133,6 +1133,25 @@ Files:
      guard with `std::call_once`. `method_setImplementation`
      is destructive on re-application and would corrupt
      the original-IMP save.
+   - The `WebviewEmbedDelegate` Objective-C class — the
+     `WKScriptMessageHandler` used inside
+     `cocoa_create_engine` to receive
+     `window.external.invoke` messages — MUST be allocated
+     and registered exactly once per JVM, using the same
+     `std::call_once` pattern as the focus swizzle above,
+     with the resulting `Class` cached in a file-scope
+     static. Every subsequent engine creation re-uses the
+     cached `Class` and instantiates a fresh delegate
+     object via `[Class new]` (then
+     `objc_setAssociatedObject(..., "eng", ...)` to bind
+     the per-engine receiver). `objc_allocateClassPair`
+     returns `Nil` when a class with the requested name is
+     already registered, so an unguarded re-allocation on
+     the second engine creation would feed a null `Class`
+     to `objc_registerClassPair` and crash the JVM with
+     SIGSEGV — see issue #21. `class_addProtocol`,
+     `class_addMethod`, and `objc_registerClassPair` MUST
+     run only inside the `std::call_once` body.
    - The Engine ↔ WKWebView map MUST be guarded by a
      mutex — `becomeFirstResponder` can fire on the AppKit
      main thread while `cocoa_create_engine` /

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -394,7 +394,11 @@ generated_at: 2026-05-16T07:19:13-07:00
   `webview->ExecuteScript("document.execCommand(...)")`).
 - `demos/WebViewHeavyweightDemo/...` — interactive demo that
   exercises the trickier scenarios (combo-box popups over the
-  WebView, `JTabbedPane` tab visibility).
+  WebView, `JTabbedPane` tab visibility, and on-demand
+  instantiation of additional WebView instances in the same
+  JVM via a "+ New WebView Tab" toolbar button — the issue
+  #21 repro for the macOS `WebviewEmbedDelegate` once-per-JVM
+  registration constraint).
 
 ## O · Operations
 

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -1591,6 +1591,14 @@ static BoolFromIdSel g_orig_becomeFirstResponder = nullptr;
 static BoolFromIdSel g_orig_resignFirstResponder = nullptr;
 static std::once_flag g_focus_swizzle_once;
 
+// WKScriptMessageHandler delegate class used by every Cocoa engine for the
+// window.external.invoke bridge.  objc_allocateClassPair returns Nil if the
+// class name is already registered, so the allocation/registration MUST run
+// exactly once per JVM -- the same pattern as g_focus_swizzle_once above.
+// See issue #21 and the Canvas constraint on cocoa_create_engine.
+static std::once_flag g_webview_embed_delegate_once;
+static Class g_webview_embed_delegate_cls = nil;
+
 static void fire_focus_callback(Engine *e, bool became) {
     if (!e || !e->focus_callback) return;
     JavaVM *jvm = e->jvm;
@@ -1658,6 +1666,27 @@ static void install_focus_swizzle() {
         g_orig_resignFirstResponder = (BoolFromIdSel)method_setImplementation(
             resign, (IMP)swizzled_resign_first_responder);
     });
+}
+
+static Class get_webview_embed_delegate_cls() {
+    std::call_once(g_webview_embed_delegate_once, [] {
+        Class c = objc_allocateClassPair((Class)objc_cls("NSObject"),
+                                         "WebviewEmbedDelegate", 0);
+        class_addProtocol(c, objc_getProtocol("WKScriptMessageHandler"));
+        class_addMethod(
+            c,
+            sel("userContentController:didReceiveScriptMessage:"),
+            (IMP)(+[](id self, SEL, id, id m) {
+                Engine *eng = (Engine *)objc_getAssociatedObject(self, "eng");
+                id body = msg(m, sel("body"));
+                const char *s = msg<const char *>(body, sel("UTF8String"));
+                engine_on_message(eng, s);
+            }),
+            "v@:@@");
+        objc_registerClassPair(c);
+        g_webview_embed_delegate_cls = c;
+    });
+    return g_webview_embed_delegate_cls;
 }
 
 // Returns 1 if the engine's WKWebView (or a descendant view in its
@@ -1828,22 +1857,10 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
         }
 
         // External-message bridge: register a script message handler.
-        // We allocate a tiny ObjC class on the fly to receive messages.
-        Class delegate_cls = objc_allocateClassPair((Class)objc_cls("NSObject"),
-                                                    "WebviewEmbedDelegate", 0);
-        class_addProtocol(delegate_cls,
-                          objc_getProtocol("WKScriptMessageHandler"));
-        class_addMethod(
-            delegate_cls,
-            sel("userContentController:didReceiveScriptMessage:"),
-            (IMP)(+[](id self, SEL, id, id m) {
-                Engine *eng = (Engine *)objc_getAssociatedObject(self, "eng");
-                id body = msg(m, sel("body"));
-                const char *s = msg<const char *>(body, sel("UTF8String"));
-                engine_on_message(eng, s);
-            }),
-            "v@:@@");
-        objc_registerClassPair(delegate_cls);
+        // The ObjC delegate class is registered exactly once per JVM (see
+        // get_webview_embed_delegate_cls); every engine instantiates a
+        // fresh delegate object from the cached Class.
+        Class delegate_cls = get_webview_embed_delegate_cls();
         id delegate = msg((id)delegate_cls, sel("new"));
         objc_setAssociatedObject(delegate, "eng", (id)e, OBJC_ASSOCIATION_ASSIGN);
         msg<void, id, id>(e->manager,


### PR DESCRIPTION
## Summary

Fixes a critical crash on macOS when instantiating multiple `WKWebView` instances in the same JVM process. The issue occurred because the `WebviewEmbedDelegate` Objective-C class was being allocated and registered multiple times, causing `objc_registerClassPair` to fail on the second engine creation.

## Changes

- **webview_embed.cpp**: Refactored `WebviewEmbedDelegate` class registration to use `std::call_once` pattern, ensuring the class is allocated and registered exactly once per JVM. The resulting `Class` is cached in a file-scope static and reused for all subsequent engine instances.

- **WebViewHeavyweightDemo.java**: Added interactive reproduction case for issue #21:
  - New "+ New WebView Tab" toolbar button that spawns additional `WebView` instances on demand
  - Tab header with close button to properly dispose native peers
  - Detailed tooltip documenting the issue and the fix
  - Logging output to track spawned WebView instances

- **Canvas documentation**: Updated to reflect the once-per-JVM registration constraint and the demo's role in reproducing/validating the fix.

## Implementation Details

The fix applies the same `std::call_once` guard pattern already used for focus swizzling to the `WebviewEmbedDelegate` class registration. This ensures:
- `objc_allocateClassPair`, `class_addProtocol`, `class_addMethod`, and `objc_registerClassPair` run exactly once
- Subsequent engine creations reuse the cached `Class` and instantiate fresh delegate objects via `[Class new]`
- Each delegate instance is bound to its engine via `objc_setAssociatedObject`

The demo's new tab feature provides a reliable way to test the fix and prevent regression.

https://claude.ai/code/session_015XfykrkdnzMdrTfFFCAMi3