### PR TITLE
Feat: Browser-initiated UI dialogs (alert/confirm/prompt/file picker)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,9 +240,18 @@ jobs:
         shell: bash
         # source/target 1.8 in pom.xml keeps the assembled jar runnable on
         # JRE 8 even though we build it with JDK 11.
+        #
+        # `mvn package` (no -DskipTests) runs the unit-test phase
+        # first: DialogDispatcherTest, EvalDispatcherTest, and
+        # JavaScriptEvalExceptionTest.  All three are headless-safe --
+        # they exercise dispatcher Java contracts without spinning up a
+        # native peer or constructing a Window -- so they run cleanly on
+        # the CI runner with no display server.  GUI integration
+        # (WebViewDialogDemo, the heavyweight / context-menu demos)
+        # remains a manual verification step on a real desktop host.
         run: |
           set -euo pipefail
-          mvn -B -DskipTests package
+          mvn -B package
           echo "--- jar contents ---"
           jar tf target/webview-*.jar | sort | head -80
           ls -la target/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,7 @@ jobs:
 
           cl /nologo ^
               /D "WEBVIEW_API=__declspec(dllexport)" ^
+              /D "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" ^
               /I "%JAVA_HOME%\include" ^
               /I "%JAVA_HOME%\include\win32" ^
               /I "%REPO_DIR%\windows" ^

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -156,6 +156,7 @@ jobs:
 
           cl /nologo ^
               /D "WEBVIEW_API=__declspec(dllexport)" ^
+              /D "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" ^
               /I "%JAVA_HOME%\include" ^
               /I "%JAVA_HOME%\include\win32" ^
               /I "%REPO_DIR%\windows" ^

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@ dist
 build
 target
 natives
+# Native-lib output dropped by the run-*-demo.{sh,bat} scripts
+# (src/<arch>/libwebview.{so,dylib,dll}); the runtime extractor
+# picks the lib up from the assembled jar, not from src/.
+src/linux_*/
+src/osx_*/
+src/windows_*/
 .DS_Store
 private
 .litecode/

--- a/README.md
+++ b/README.md
@@ -299,13 +299,16 @@ wv.setDialogHandler(new WebViewDialogHandler() {
   routes all four dialog kinds through the handler (STORY-004-001).
   Linux WebKitGTK routes all four kinds through the handler in both
   heavyweight and lightweight modes via the `script-dialog` and
-  `run-file-chooser` signals (STORY-004-002).  On Windows,
-  `setDialogHandler` stores the handler reference but the embedded
-  engine continues to use its built-in dialogs until STORY-004-003
-  (WebView2 `ScriptDialogOpening` event) lands.  On Windows,
-  `<input type="file">` will continue to use the OS-native dialog
-  even after STORY-004-003 — WebView2 exposes no public hook for it,
-  so `filePickerOpened` never fires on Windows.
+  `run-file-chooser` signals (STORY-004-002).  Windows WebView2
+  routes alert / confirm / prompt (and before-unload) through the
+  handler via the `ScriptDialogOpening` event combined with
+  `put_AreDefaultScriptDialogsEnabled(FALSE)` (STORY-004-003).  On
+  Windows, `<input type="file">` continues to use the OS-native
+  Common Item Dialog — WebView2 exposes no public hook for the file
+  picker, so `filePickerOpened` never fires on Windows.  On Windows,
+  `frameUrl()` equals `pageUrl()` for now (top-level only) because
+  the `ScriptDialogOpening` event args do not expose a separate
+  frame URL.
 * **Linux file-picker `accept`-extension limitation.**  On Linux, the
   `WebViewFilePickerEvent.acceptedExtensions` list is always empty
   even when the page wrote `<input accept=".png,.jpg">` — WebKitGTK

--- a/README.md
+++ b/README.md
@@ -259,6 +259,56 @@ closes) returns an already-failed future whose cause is an
 [`demos/WebViewAsyncEvalDemo/`](demos/WebViewAsyncEvalDemo/README.md)
 for a runnable example.
 
+## Browser-initiated dialogs
+
+Pages can call `window.alert`, `window.confirm`, `window.prompt`, and
+they can include `<input type="file">` elements whose click opens a
+file picker.  `WebViewComponent.setDialogHandler` lets the host
+application customise — or fully suppress — what shows up:
+
+```java
+wv.setDialogHandler(new WebViewDialogHandler() {
+    @Override public boolean confirmOpened(WebViewConfirmEvent e) {
+        return JOptionPane.showConfirmDialog(
+            frame, e.message(), "Confirm",
+            JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION;
+    }
+});
+```
+
+* **Default behaviour.**  When no handler is installed (the initial
+  state), every dialog kind shows a Swing dialog — `JOptionPane` for
+  alert / confirm / prompt, `JFileChooser` for file picker — modal to
+  the host `JFrame` resolved via
+  `SwingUtilities.getWindowAncestor(component)`.  Override individual
+  methods to customise specific kinds; un-overridden methods fall
+  through to the Swing defaults.
+* **Drop mode for headless tests.**  Pass `null`:
+  `wv.setDialogHandler(null)` installs an internal drop handler that
+  returns the JS-spec cancel values synchronously without UI
+  (`alert` no-op, `confirm` → `false`, `prompt` → `null`, file
+  picker → empty list).  Required for unit tests in headless
+  environments.  To reset to the framework default, pass
+  `WebViewDialogHandler.DEFAULT` explicitly — `null` is NOT a reset.
+* **Threading.**  Handler methods run on the Swing EDT, marshaled
+  from whatever native thread fired the dialog.  Calling
+  `wv.evalAsync(js).get()` from inside a handler **deadlocks** (both
+  calls park on the EDT); use `.thenAccept(...)` instead, or
+  pre-compute the value before the dialog opens.
+* **Platform coverage (current).**  macOS heavyweight (WKWebView)
+  routes all four dialog kinds through the handler in this release
+  (STORY-004-001).  On Linux and Windows, `setDialogHandler` stores
+  the handler reference but the embedded engine continues to use its
+  built-in dialogs until STORY-004-002 (WebKitGTK signal handlers)
+  and STORY-004-003 (WebView2 `ScriptDialogOpening` event) land.
+  On Windows, `<input type="file">` will continue to use the
+  OS-native dialog even after STORY-004-003 — WebView2 exposes no
+  public hook for it, so `filePickerOpened` never fires on Windows.
+
+See [`demos/WebViewDialogDemo/`](demos/WebViewDialogDemo/README.md)
+for a runnable example that exercises all four dialog kinds in each
+of the three handler modes (default, custom, drop).
+
 ## Demo
 
 See [`demos/WebViewHeavyweightDemo/`](demos/WebViewHeavyweightDemo/README.md)
@@ -278,6 +328,11 @@ Additional demos:
   throws and Promise rejections surfacing as
   `JavaScriptEvalException`, concurrent in-flight calls, and EDT
   delivery of continuations.
+* `demos/WebViewDialogDemo/` — exercises the new
+  `WebViewDialogHandler` API: default Swing dialogs
+  (`alert` / `confirm` / `prompt` / file picker), a custom handler
+  returning programmatic answers, and the
+  `setDialogHandler(null)` drop mode for headless tests.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -296,14 +296,23 @@ wv.setDialogHandler(new WebViewDialogHandler() {
   calls park on the EDT); use `.thenAccept(...)` instead, or
   pre-compute the value before the dialog opens.
 * **Platform coverage (current).**  macOS heavyweight (WKWebView)
-  routes all four dialog kinds through the handler in this release
-  (STORY-004-001).  On Linux and Windows, `setDialogHandler` stores
-  the handler reference but the embedded engine continues to use its
-  built-in dialogs until STORY-004-002 (WebKitGTK signal handlers)
-  and STORY-004-003 (WebView2 `ScriptDialogOpening` event) land.
-  On Windows, `<input type="file">` will continue to use the
-  OS-native dialog even after STORY-004-003 — WebView2 exposes no
-  public hook for it, so `filePickerOpened` never fires on Windows.
+  routes all four dialog kinds through the handler (STORY-004-001).
+  Linux WebKitGTK routes all four kinds through the handler in both
+  heavyweight and lightweight modes via the `script-dialog` and
+  `run-file-chooser` signals (STORY-004-002).  On Windows,
+  `setDialogHandler` stores the handler reference but the embedded
+  engine continues to use its built-in dialogs until STORY-004-003
+  (WebView2 `ScriptDialogOpening` event) lands.  On Windows,
+  `<input type="file">` will continue to use the OS-native dialog
+  even after STORY-004-003 — WebView2 exposes no public hook for it,
+  so `filePickerOpened` never fires on Windows.
+* **Linux file-picker `accept`-extension limitation.**  On Linux, the
+  `WebViewFilePickerEvent.acceptedExtensions` list is always empty
+  even when the page wrote `<input accept=".png,.jpg">` — WebKitGTK
+  exposes the extension filter as an opaque `GtkFileFilter` rather
+  than the original extension strings.  The page's MIME-type hints
+  (`accept="image/png"` etc.) are surfaced via `acceptedMimeTypes`;
+  the page's own client-side `accept` validation continues to work.
 
 See [`demos/WebViewDialogDemo/`](demos/WebViewDialogDemo/README.md)
 for a runnable example that exercises all four dialog kinds in each

--- a/demos/WebViewDialogDemo/README.md
+++ b/demos/WebViewDialogDemo/README.md
@@ -1,0 +1,59 @@
+# WebViewDialogDemo
+
+Exercises the browser-initiated UI dialog API introduced by
+[`requirements/[User-story-4]browser-initiated-ui-dialogs.md`](../../requirements/%5BUser-story-4%5Dbrowser-initiated-ui-dialogs.md).
+
+Buttons in the embedded page raise `alert` / `confirm` / `prompt`, and
+two `<input type="file">` elements (single-select with `accept=".png,.jpg"`
+and multi-select with `accept="image/*,.pdf"`) raise the file picker.
+A combo box at the top switches among three handler modes:
+
+| Mode | What happens |
+|---|---|
+| **Default handler** | Standard Swing `JOptionPane` / `JFileChooser` dialogs anchored on the host JFrame. |
+| **Custom handler** | Each method records the event to the log pane and returns a fixed value (alert: no-op; confirm: `true`; prompt: `"hardcoded"`; file picker: `[/tmp/preselected.txt]`).  No UI. |
+| **Drop handler** | `setDialogHandler(null)` — every dispatch returns the JS-spec cancel value without UI (alert: void; confirm: `false`; prompt: `null`; file picker: empty list). |
+
+The bottom log pane shows every captured `console.log` line, so the
+JS-side return value of each dialog (e.g. `confirm = true`, `prompt =
+"hardcoded"`, `multi files = 2`) is visible without external tooling.
+
+## Acceptance Criteria coverage
+
+| AC | Verification |
+|---|---|
+| AC1 (default alert) | Mode = Default; click Alert → Swing message dialog appears with the message. |
+| AC2 / AC3 (default confirm OK / Cancel) | Mode = Default; click Confirm → Swing OK/Cancel dialog.  Log shows `confirm = true` or `confirm = false`. |
+| AC4–AC6 (default prompt entered text / null / default pre-fill) | Mode = Default; click Prompt → Swing input dialog pre-filled with `default`.  Log shows the typed value or `null`. |
+| AC7 (default file picker single) | Mode = Default; click the single-file picker, choose one `.png` → log shows `single files = 1`. |
+| AC8 (default file picker multi) | Mode = Default; click the multi picker, choose two files → log shows `multi files = 2`. |
+| AC9 (default file picker accept filter) | Mode = Default; click the single-file picker → JFileChooser filter is restricted to `.png`/`.jpg`. |
+| AC10 (custom alert) | Mode = Custom; click Alert → no UI, log shows `[custom] alertOpened: hello world`. |
+| AC11 (custom confirm) | Mode = Custom; click Confirm → no UI, log shows `[custom] confirmOpened: proceed?` and `confirm = true`. |
+| AC12 (custom prompt) | Mode = Custom; click Prompt → no UI, log shows `[custom] promptOpened: name? (default=default)` and `prompt = "hardcoded"`. |
+| AC13 (custom file picker) | Mode = Custom; click either picker → no UI, log shows `[custom] filePickerOpened: ...` and the `change` event reports `1` file. |
+| AC14 (null handler) | Mode = Drop; click any button → no UI, log shows the JS-spec cancel return (alert succeeds silently, confirm → `false`, prompt → `null`, file pickers → `0` files). |
+| AC15 (filePicker hints) | Mode = Custom; click multi picker → log shows `multiple=true extensions=[pdf] mimeTypes=[image/*]`. |
+| AC16 (EDT) | Implicit; the demo's log appends from the handler call sites must show up on the EDT.  No deadlock under heavy clicking. |
+| AC17 (getDialogHandler non-null) | Implicit; `wv.getDialogHandler()` is never null — the mode switcher always reads a real value. |
+| AC18 / AC19 (pageUrl / frameUrl) | Mode = Custom on a real `https://` page (not the inline demo's data: URL) — out of demo scope; verify via custom harness or browser. |
+| AC20 (handler exception) | Manual; modify the demo's custom handler to throw — exception goes to stderr via uncaughtExceptionHandler, app keeps running, JS returns the safe fallback. |
+
+## Build & run
+
+```sh
+ant run
+```
+
+Requires a built `dist/WebView.jar` at the project root (run any
+`run-{linux,mac,windows}-demo.sh` once first to produce it).
+
+## Platform status (this iteration)
+
+macOS heavyweight (WKWebView) is fully wired in STORY-004-001 — every
+mode listed above behaves as described.  On Linux and Windows the
+embedded WebView continues to use its built-in dialogs until
+STORY-004-002 (WebKitGTK signals) and STORY-004-003 (WebView2
+ScriptDialogOpening) land; on those platforms the demo's mode switcher
+still works for the JFrame and log pane but the embedded engine
+ignores the custom handler and continues to show its own dialogs.

--- a/demos/WebViewDialogDemo/build.xml
+++ b/demos/WebViewDialogDemo/build.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="WebViewDialogDemo" default="run" basedir=".">
+    <description>Build and run the browser-initiated UI dialogs demo.</description>
+
+    <property name="src.dir" value="src"/>
+    <property name="build.dir" value="build"/>
+    <property name="classes.dir" value="${build.dir}/classes"/>
+    <property name="webview.jar" value="../../dist/WebView.jar"/>
+    <property name="main.class" value="ca.weblite.webview.demos.WebViewDialogDemo"/>
+
+    <target name="check-webview-jar">
+        <available file="${webview.jar}" property="webview.jar.exists"/>
+        <fail unless="webview.jar.exists">
+WebView.jar not found at ${webview.jar}.
+Build it first from the project root, e.g. ./run-linux-demo.sh once to
+produce dist/WebView.jar, or invoke a platform run-*-demo.sh / .bat at
+the repo root.
+        </fail>
+    </target>
+
+    <target name="compile" depends="check-webview-jar">
+        <mkdir dir="${classes.dir}"/>
+        <javac srcdir="${src.dir}" destdir="${classes.dir}"
+               includeantruntime="false" source="1.8" target="1.8">
+            <classpath>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </javac>
+    </target>
+
+    <target name="run" depends="compile">
+        <java classname="${main.class}" fork="true">
+            <classpath>
+                <pathelement location="${classes.dir}"/>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </java>
+    </target>
+
+    <target name="clean">
+        <delete dir="${build.dir}"/>
+    </target>
+</project>

--- a/demos/WebViewDialogDemo/src/ca/weblite/webview/demos/WebViewDialogDemo.java
+++ b/demos/WebViewDialogDemo/src/ca/weblite/webview/demos/WebViewDialogDemo.java
@@ -157,19 +157,28 @@ public class WebViewDialogDemo {
         installHandler(wv, MODE_DEFAULT, line -> append(log, line));
         append(log, "[demo] handler mode → " + MODE_DEFAULT);
 
-        // Load the inline test page via data: URL.  Using a data: URL
-        // (rather than addOnBeforeLoad + about:blank) keeps the demo
-        // self-contained and ensures the page's history origin is
-        // stable for AC18's pageUrl/frameUrl checks.
+        // Load the inline test page via base64-encoded data: URL.  Using
+        // a data: URL (rather than addOnBeforeLoad + about:blank) keeps
+        // the demo self-contained and ensures the page's history origin
+        // is stable for AC18's pageUrl/frameUrl checks.
         //
-        // Pass the HTML raw -- WKWebView (macOS) does NOT percent-decode
-        // a `data:text/html` body before passing it to the HTML parser,
-        // so any %20-encoded space would render literally as "%20" and
-        // the buttons wouldn't appear.  WebKitGTK and WebView2 tolerate
-        // raw spaces and inline characters in data URL bodies the same
-        // way the existing WebViewAsyncEvalDemo does
-        // (demos/WebViewAsyncEvalDemo/...:74).
-        wv.setUrl("data:text/html;charset=utf-8," + html);
+        // Base64 encoding (not percent-encoding) avoids two distinct
+        // WKWebView pitfalls hit during this PR:
+        //
+        //   1. Percent-encoding the body so spaces -> %20 makes WKWebView
+        //      render the literal "%20" strings in <h2> text because it
+        //      does NOT percent-decode the body before parsing as HTML.
+        //   2. Passing the body raw lets WKWebView's URL parser treat the
+        //      first '#' character (we have #eef and #666 CSS colours)
+        //      as a fragment delimiter, truncating the HTML mid-CSS-rule
+        //      and rendering a blank page.
+        //
+        // Base64 sidesteps both: no URL-special characters in the
+        // encoded body, and the engines all decode base64 before
+        // passing to the HTML parser.  Universally supported.
+        String b64 = java.util.Base64.getEncoder().encodeToString(
+            html.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        wv.setUrl("data:text/html;charset=utf-8;base64," + b64);
     }
 
     private static void installHandler(

--- a/demos/WebViewDialogDemo/src/ca/weblite/webview/demos/WebViewDialogDemo.java
+++ b/demos/WebViewDialogDemo/src/ca/weblite/webview/demos/WebViewDialogDemo.java
@@ -1,0 +1,237 @@
+/*
+ * MIT License
+ *
+ * Exercises the browser-initiated UI dialog API on WebViewComponent.
+ * Designed for manual verification against the acceptance criteria in
+ *   requirements/[User-story-4]browser-initiated-ui-dialogs.md
+ *
+ * Switch among three handler modes via the combo box at the top:
+ *   - Default      : framework's stock Swing dialogs (JOptionPane / JFileChooser).
+ *   - Custom       : programmatic answers + log entries (no UI).
+ *   - Drop (null)  : suppress all dialogs without UI.
+ *
+ * macOS coverage is wired in STORY-004-001 (this demo's reference story).
+ * On Linux and Windows the embedded engine still uses its built-in
+ * dialogs until STORY-004-002 and STORY-004-003 land.
+ */
+package ca.weblite.webview.demos;
+
+import ca.weblite.webview.WebViewAlertEvent;
+import ca.weblite.webview.WebViewConfirmEvent;
+import ca.weblite.webview.WebViewDialogHandler;
+import ca.weblite.webview.WebViewFilePickerEvent;
+import ca.weblite.webview.WebViewPromptEvent;
+import ca.weblite.webview.ConsoleListener;
+import ca.weblite.webview.ConsoleMessage;
+import ca.weblite.webview.swing.WebViewComponent;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+
+public class WebViewDialogDemo {
+
+    private static final String MODE_DEFAULT = "Default handler (Swing dialogs)";
+    private static final String MODE_CUSTOM  = "Custom handler (programmatic answers)";
+    private static final String MODE_DROP    = "Drop handler (no UI)";
+
+    public static void main(String[] args) {
+        // Heavyweight popups so any nested JFileChooser / JOptionPane
+        // pop-ups render above the WebView region on macOS / Windows
+        // heavyweight.  Safe in lightweight mode (no-op).
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+        EventQueue.invokeLater(WebViewDialogDemo::run);
+    }
+
+    private static void run() {
+        final WebViewComponent wv = WebViewComponent.create();
+
+        // Inline test page: four buttons + two file inputs, each
+        // logging its result through console.log so the bottom pane
+        // shows the JS-side return value (and proves the JS thread
+        // actually resumed after the dialog closed).
+        final String html =
+            "<!doctype html><html><head><meta charset='utf-8'>"
+          + "<title>WebView Dialog Demo</title>"
+          + "<style>"
+          + "  body{font:14px/1.4 system-ui,sans-serif;padding:1em;"
+          + "    max-width:48em;margin:0 auto;}"
+          + "  h1{font-size:1.2em;margin:0 0 .4em 0;}"
+          + "  button{font-size:14px;margin:0 .4em .4em 0;"
+          + "    padding:.3em .6em;}"
+          + "  .row{margin:.5em 0;}"
+          + "  code{background:#eef;padding:0 .3em;border-radius:.2em;}"
+          + "</style></head><body>"
+          + "<h1>WebView Dialog Demo</h1>"
+          + "<div class='row'>"
+          + "  <button onclick=\"alert('hello world'); console.log('alert returned');\">Alert</button>"
+          + "  <button onclick=\"console.log('confirm =', confirm('proceed?'));\">Confirm</button>"
+          + "  <button onclick=\"console.log('prompt =', JSON.stringify(prompt('name?', 'default')));\">Prompt</button>"
+          + "</div>"
+          + "<div class='row'>"
+          + "  <label>Single file (.png/.jpg): "
+          + "    <input type='file' accept='.png,.jpg' "
+          + "      onchange=\"console.log('single files =', this.files.length); "
+          + "        for(var i=0;i&lt;this.files.length;i++) console.log('  -', this.files[i].name);\">"
+          + "  </label>"
+          + "</div>"
+          + "<div class='row'>"
+          + "  <label>Multiple files (image/* + .pdf): "
+          + "    <input type='file' accept='image/*,.pdf' multiple "
+          + "      onchange=\"console.log('multi files =', this.files.length); "
+          + "        for(var i=0;i&lt;this.files.length;i++) console.log('  -', this.files[i].name);\">"
+          + "  </label>"
+          + "</div>"
+          + "<p style='color:#666;font-size:12px'>"
+          + "Switch handler mode via the combo box above.  Watch the log "
+          + "pane to confirm the JS thread resumes after each dialog."
+          + "</p>"
+          + "</body></html>";
+
+        // Top: handler-mode picker + label.
+        final JComboBox<String> modeCombo = new JComboBox<String>(
+            new String[] { MODE_DEFAULT, MODE_CUSTOM, MODE_DROP });
+        final JLabel modeLabel = new JLabel(
+            "  Handler mode: ", JLabel.LEFT);
+
+        // Bottom: log pane.  Captures both the demo's append() output
+        // and the console.* output from the embedded page.
+        final JTextArea log = new JTextArea(8, 80);
+        log.setEditable(false);
+        log.setLineWrap(true);
+        log.setWrapStyleWord(false);
+        final JScrollPane logScroll = new JScrollPane(log);
+
+        // Wire the mode picker.
+        modeCombo.addActionListener(ev -> {
+            String mode = (String) modeCombo.getSelectedItem();
+            installHandler(wv, mode, line -> append(log, line));
+            append(log, "[demo] handler mode → " + mode);
+        });
+
+        // Capture console.* into the log pane.
+        wv.addConsoleListener(new ConsoleListener() {
+            @Override public void onMessage(ConsoleMessage msg) {
+                append(log, "[console] " + msg.toString());
+            }
+        });
+
+        // Top control bar.
+        final JPanel topBar = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        topBar.add(modeLabel);
+        topBar.add(modeCombo);
+
+        // Center: WebView + bottom log.
+        final JSplitPane center = new JSplitPane(
+            JSplitPane.VERTICAL_SPLIT, wv, logScroll);
+        center.setResizeWeight(0.7);
+
+        final JFrame frame = new JFrame("WebView Dialog Demo");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.getContentPane().setLayout(new BorderLayout());
+        frame.getContentPane().add(topBar, BorderLayout.NORTH);
+        frame.getContentPane().add(center, BorderLayout.CENTER);
+        frame.setPreferredSize(new Dimension(900, 700));
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+
+        // Install the initial handler before navigating so the very
+        // first alert / confirm / prompt the page might issue is
+        // routed through Java.
+        installHandler(wv, MODE_DEFAULT, line -> append(log, line));
+        append(log, "[demo] handler mode → " + MODE_DEFAULT);
+
+        // Load the inline test page via data: URL.  Using a data: URL
+        // (rather than addOnBeforeLoad + about:blank) keeps the demo
+        // self-contained and ensures the page's history origin is
+        // stable for AC18's pageUrl/frameUrl checks.
+        wv.setUrl("data:text/html;charset=utf-8," + urlEncode(html));
+    }
+
+    private static void installHandler(
+            WebViewComponent wv, String mode, LogSink log) {
+        if (MODE_DEFAULT.equals(mode)) {
+            wv.setDialogHandler(WebViewDialogHandler.DEFAULT);
+            return;
+        }
+        if (MODE_DROP.equals(mode)) {
+            wv.setDialogHandler(null);
+            return;
+        }
+        // MODE_CUSTOM
+        wv.setDialogHandler(new WebViewDialogHandler() {
+            @Override
+            public void alertOpened(WebViewAlertEvent e) {
+                log.print("[custom] alertOpened: " + e.message());
+            }
+            @Override
+            public boolean confirmOpened(WebViewConfirmEvent e) {
+                log.print("[custom] confirmOpened: " + e.message()
+                    + " → returning true");
+                return true;
+            }
+            @Override
+            public String promptOpened(WebViewPromptEvent e) {
+                log.print("[custom] promptOpened: " + e.message()
+                    + " (default=" + e.defaultValue()
+                    + ") → returning \"hardcoded\"");
+                return "hardcoded";
+            }
+            @Override
+            public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+                log.print("[custom] filePickerOpened: multiple="
+                    + e.multiple()
+                    + " extensions=" + e.acceptedExtensions()
+                    + " mimeTypes=" + e.acceptedMimeTypes()
+                    + " → returning [/tmp/preselected.txt]");
+                return Collections.singletonList(
+                    new File("/tmp/preselected.txt"));
+            }
+        });
+    }
+
+    private static void append(JTextArea log, String line) {
+        SwingUtilities.invokeLater(() -> {
+            log.append(line + "\n");
+            log.setCaretPosition(log.getDocument().getLength());
+        });
+    }
+
+    /** Tiny URL-encoder for the data: URL.  Only escapes characters
+     *  that confuse the URL parsers we care about (space, # / ? & %)
+     *  — the inline HTML contains none of those except spaces. */
+    private static String urlEncode(String s) {
+        StringBuilder sb = new StringBuilder(s.length() * 2);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == ' ') sb.append("%20");
+            else if (c == '#') sb.append("%23");
+            else if (c == '%') sb.append("%25");
+            else if (c == '?') sb.append("%3F");
+            else if (c == '&') sb.append("%26");
+            else if (c == '"') sb.append("%22");
+            else if (c == '\n') sb.append("%0A");
+            else sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    @FunctionalInterface
+    private interface LogSink { void print(String line); }
+}

--- a/demos/WebViewDialogDemo/src/ca/weblite/webview/demos/WebViewDialogDemo.java
+++ b/demos/WebViewDialogDemo/src/ca/weblite/webview/demos/WebViewDialogDemo.java
@@ -161,7 +161,15 @@ public class WebViewDialogDemo {
         // (rather than addOnBeforeLoad + about:blank) keeps the demo
         // self-contained and ensures the page's history origin is
         // stable for AC18's pageUrl/frameUrl checks.
-        wv.setUrl("data:text/html;charset=utf-8," + urlEncode(html));
+        //
+        // Pass the HTML raw -- WKWebView (macOS) does NOT percent-decode
+        // a `data:text/html` body before passing it to the HTML parser,
+        // so any %20-encoded space would render literally as "%20" and
+        // the buttons wouldn't appear.  WebKitGTK and WebView2 tolerate
+        // raw spaces and inline characters in data URL bodies the same
+        // way the existing WebViewAsyncEvalDemo does
+        // (demos/WebViewAsyncEvalDemo/...:74).
+        wv.setUrl("data:text/html;charset=utf-8," + html);
     }
 
     private static void installHandler(
@@ -211,25 +219,6 @@ public class WebViewDialogDemo {
             log.append(line + "\n");
             log.setCaretPosition(log.getDocument().getLength());
         });
-    }
-
-    /** Tiny URL-encoder for the data: URL.  Only escapes characters
-     *  that confuse the URL parsers we care about (space, # / ? & %)
-     *  — the inline HTML contains none of those except spaces. */
-    private static String urlEncode(String s) {
-        StringBuilder sb = new StringBuilder(s.length() * 2);
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            if (c == ' ') sb.append("%20");
-            else if (c == '#') sb.append("%23");
-            else if (c == '%') sb.append("%25");
-            else if (c == '?') sb.append("%3F");
-            else if (c == '&') sb.append("%26");
-            else if (c == '"') sb.append("%22");
-            else if (c == '\n') sb.append("%0A");
-            else sb.append(c);
-        }
-        return sb.toString();
     }
 
     @FunctionalInterface

--- a/requirements/[User-story-4]browser-initiated-ui-dialogs.md
+++ b/requirements/[User-story-4]browser-initiated-ui-dialogs.md
@@ -1,0 +1,567 @@
+# Story Decomposition: Browser-Initiated UI Dialogs (alert / confirm / prompt / file picker)
+
+## INVEST Analysis
+
+### Abstract Task: "Let JavaScript-driven UI dialogs originating inside the embedded page surface to the Swing host across every supported platform/mode, with consistent default behaviour and a single override hook"
+
+**Analysis Dimensions**:
+- **Core Responsibility**: A page running inside `WebViewComponent` can call `window.alert(msg)`, `window.confirm(msg)`, `window.prompt(msg, default)`, and can include `<input type="file">` elements whose click opens a file picker. Today the behaviour of these four dialog kinds is inconsistent across platforms and silently broken on macOS. This task gives `WebViewComponent` a single, uniform dialog channel so:
+  - **By default**, every platform shows a Swing dialog (`JOptionPane` for alert / confirm / prompt, `JFileChooser` for file picker) anchored to the host `JFrame` and modal to it. Behaviour looks identical to the user regardless of which native backend is underneath.
+  - **By override**, a Java caller can register a `WebViewDialogHandler` that takes over and decides what (if anything) to show — including returning a programmatic answer without showing UI, which is essential for headless tests.
+- **Primary Operations**:
+  1. Intercept the four dialog kinds at the native layer on each backend, defer the JS-side completion until the Java host has produced an answer, and pass the answer back without freezing the page beyond the dialog's intended modal lifetime.
+  2. Marshal the dialog request onto the Swing EDT, invoke the active `WebViewDialogHandler` (default or caller-supplied), and pass the result back to the native layer.
+  3. Expose a public Java API (`WebViewDialogHandler`, `setDialogHandler`, event POJOs) shared by all backends.
+  4. Provide a default `WebViewDialogHandler` implementation that shows `JOptionPane` / `JFileChooser` modal to the host window.
+- **Key Constraints**:
+  - `alert` / `confirm` / `prompt` are **synchronous** in the JS contract — the page's microtask queue is blocked until the dialog returns. Every backend's native API provides a completion-handler / signal-handler model that supports this; Java just must not deadlock by trying to invoke the EDT from a thread that's holding back the UI thread the EDT depends on.
+  - `<input type="file">` is **asynchronous** in the JS contract — the file picker fires after a user click and the page receives the chosen files via the `change` event.
+  - The default Swing dialog must be modal to the **host `JFrame`** (`SwingUtilities.getWindowAncestor(component)`) so it doesn't get hidden behind other windows.
+  - On `LIGHTWEIGHT` mode (Linux) the offscreen WebKit window has no `transient_for` — the native default GTK dialogs cannot position themselves and the right-click / `<select>` story already documents this constraint. Routing through Swing dialogs sidesteps it.
+  - On Windows, WebView2's built-in dialogs already work; the only motivation to route through Swing there is **uniform look and feel and testability**. This is in scope — see STORY-004-003.
+  - Behaviour must be observable from a small Swing harness; the handler-override path must be usable from a unit test (programmatic answer without showing UI) so headless test environments stay viable.
+  - The reserved-binding convention (`__webview_` prefix) introduced by STORY-001-002 / STORY-002-001 is **not** the right channel for this — dialog requests originate from native browser-engine APIs, not from page-injected JS. No new reserved JS binding is introduced.
+- **Technical Complexity**: Medium-High overall, split across three platform-shaped pieces:
+  - macOS: implement a `WKUIDelegate` (currently nil — alerts/confirms/prompts are silently dropped, file pickers do nothing) and bridge each delegate method to the Java handler synchronously, releasing the native completion handler when Java returns.
+  - Linux: connect handlers for `script-dialog` and `run-file-chooser` on `WebKitWebView`, suppress the default, and bridge them to Java. Identical wiring for heavyweight (X11-reparented) and lightweight (offscreen) modes — the GTK signal model is the same.
+  - Windows: register `add_ScriptDialogOpening` and call `put_AreDefaultScriptDialogsEnabled(FALSE)` to take over alert/confirm/prompt. WebView2 exposes no public hook for `<input type="file">`; file picker keeps WebView2's built-in OS dialog (already works).
+- **Business Complexity**: Low — the user-facing semantics of `alert / confirm / prompt / file picker` are already specified by the HTML spec. The work is bridging plumbing, not new business behaviour.
+
+### INVEST Evaluation (whole feature)
+
+- ✅ **Independent**: No story-level dependency on previously-shipped Canvases beyond the existing native-engine plumbing (canvases 6 / 7 / 2). Each per-platform sub-story is independently shippable; the Java API designed in STORY-004-001 is the contract the other two conform to.
+- ✅ **Negotiable**: Specific defaults agreed with user — Swing dialogs anchored on the host JFrame; single `WebViewDialogHandler` per component replacing any default; null handler suppresses dialogs entirely.
+- ✅ **Valuable**: Without this work, large classes of real-world web content (auth flows that call `confirm`, upload pages that use `<input type=file>`, third-party SDKs that show `alert`-based onboarding) silently fail on macOS and behave inconsistently elsewhere. With it, embedded pages "just work" the way callers expect.
+- ✅ **Estimable**: Each backend has a well-documented native-API surface for these four interceptions. The Java side is one interface + four POJOs + a default implementation.
+- ⚠️ **Small (as a single story)**: Combined, the work spans three native backends and the public Java API — realistically 7-10 days. **This exceeds the 1-5 day INVEST sizing target.** Splitting is required (see below).
+- ✅ **Testable**: Default behaviour is observable from a Swing harness; override behaviour is observable from a unit test by registering a programmatic handler.
+
+**Conclusion**: Needs splitting along platform-backend boundaries. The Java API contract is established in STORY-004-001 (which also delivers the macOS implementation, the platform that is currently fully broken). STORY-004-002 (Linux) and STORY-004-003 (Windows) extend coverage to the remaining backends while conforming to the same Java contract.
+
+### Split Strategy
+
+Split by **technical dependency / native backend**, because:
+
+- Each native backend's interception API is distinct (ObjC delegate protocol on macOS, GTK signal handlers on Linux, COM event-source on Windows). The work to wire each one is independent of the others.
+- The Java contract is shared and must be designed once — that's STORY-004-001's primary responsibility, co-delivered with macOS because macOS is the platform with zero current coverage.
+- Each story delivers independent value: shipping STORY-004-001 alone fixes macOS (currently silent) without regressing Linux or Windows; STORY-004-002 alone fixes Linux lightweight (currently broken via the `transient_for` constraint already documented in README.md); STORY-004-003 alone gives Windows uniform Swing-style dialogs.
+- Each story is 2-4 days, well within INVEST sizing.
+
+Story dependency graph:
+
+```
+STORY-004-001 (Java API contract + macOS)
+        │
+        ├──► STORY-004-002 (Linux heavyweight + lightweight) — depends on the Java contract from 004-001
+        │
+        └──► STORY-004-003 (Windows) — depends on the Java contract from 004-001
+```
+
+STORY-004-002 and STORY-004-003 can be developed in parallel once STORY-004-001 has landed.
+
+---
+
+## [STORY-004-001] WebViewDialogHandler API and macOS WKWebView Coverage
+
+### Background
+
+JavaScript inside the embedded page can call `window.alert(msg)`, `window.confirm(msg)`, `window.prompt(msg, default)`, and the page can include `<input type="file">` elements whose click opens a file picker. Today, behaviour of these four dialog kinds is inconsistent across the platforms `WebViewComponent` supports, and **on macOS all four are silently broken** because no `WKUIDelegate` is attached to the `WKWebView`:
+
+- `WKWebView` consults its `uiDelegate` to know what to do for `runJavaScriptAlertPanelWithMessage:` / `runJavaScriptConfirmPanel:` / `runJavaScriptTextInputPanel:` / `runOpenPanelWithParameters:`. If the delegate is `nil` — which is the case in this codebase — `WKWebView` simply discards the request. The JS-side `alert(...)` returns immediately, `confirm(...)` returns `false`, `prompt(...)` returns `null`, and `<input type="file">` clicks open no picker at all. Real-world pages relying on these (auth flows, file uploads, embedded SDKs that call `alert` for errors) silently misbehave.
+
+This story does two things at once:
+
+1. **Designs and exposes the cross-platform Java contract** for browser-initiated UI dialogs — one `WebViewDialogHandler` interface with default implementations that show Swing dialogs, four event POJOs, and a setter on `WebViewComponent`. The same contract is the one STORY-004-002 (Linux) and STORY-004-003 (Windows) will conform to.
+2. **Implements that contract on macOS** by attaching a `WKUIDelegate` to the `WKWebView` that bridges each of the four delegate methods to the Java handler, marshals to the EDT, and releases the native completion handler when the handler returns. The default `WebViewDialogHandler` shows `JOptionPane` (alert / confirm / prompt) and `JFileChooser` (file picker), modal to the host `JFrame`.
+
+The chosen design — handler override defaulting to Swing dialogs anchored on the host frame — was selected for these reasons:
+
+- A Swing-dialog default is **portable**: the same `JOptionPane.showMessageDialog(host, msg)` call works identically on every platform's JVM. There is no per-platform "native dialog" code path to maintain on the Java side.
+- A single-handler model (`setDialogHandler(handler)` replacing the default) keeps the call site simple. Callers don't need to compose listeners; they either accept the default or supply their own implementation. Tests register a programmatic handler that returns a fixed answer without showing UI.
+- The handler is **per-component-instance**. Two `WebViewComponent`s in the same JVM can have different handlers (or share one).
+
+Key points:
+- Business value: every desktop app embedding a WebView needs basic dialog interop to host real-world content. macOS is the most broken today (silent failure), so this is the highest-leverage place to start.
+- Relationship with other features: orthogonal to console capture (canvas-2 / STORY-001-002) and to right-click context menus (STORY-002-001). The reserved `__webview_` binding prefix is not used — these dialog requests come from native browser-engine callbacks, not page-injected JS.
+- Why now: STORY-002-001 (right-click menus + DOM event channel) landed the precedent for "structured, EDT-marshaled events surfaced from the embedded page to Swing." This story extends that precedent to the second of the two most common Swing-Web interop needs.
+
+### Business Value
+
+- Provide **working `alert / confirm / prompt`** on macOS, restoring a baseline of HTML-spec behaviour that is currently silently broken.
+- Provide a **working `<input type="file">`** picker on macOS, enabling upload flows that today do nothing when clicked.
+- Provide a **single Java contract** (`WebViewDialogHandler`) that the Linux and Windows coverage stories will conform to, ensuring the embedded page sees the same behaviour regardless of platform.
+- Provide a **default Swing dialog look-and-feel** out of the box, so callers who do nothing get a sensible cross-platform experience.
+- Provide a **deterministic override hook** so unit tests and headless environments can answer dialogs programmatically without spawning UI.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: Canvases 5, 6, 7 (mode selection, heavyweight, lightweight) in place. The macOS heavyweight engine already creates a `WKWebView` and attaches a `WKScriptMessageHandler` — this story adds a `WKUIDelegate` to the same `WKWebView`. No dependency on STORY-001-x or STORY-002-x.
+- **Data assumptions**: No persisted state. The active handler is a per-component-instance reference. Default handler is shared (stateless `JOptionPane` / `JFileChooser` calls).
+- **Integration points**: `WKWebView` (macOS) — adds a `WKUIDelegate` to the existing webview. The `WKUIDelegate` selectors `webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:`, `webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:`, `webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:`, and `webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:` are the four bridging points.
+- **Business constraints**:
+  - `alert` / `confirm` / `prompt` are **synchronous** in JS — the JS thread is paused until the completion handler is invoked. The Swing dialog must therefore run modal on the EDT and the native completion handler must be invoked only after the EDT has produced an answer. The bridging must not deadlock the WebKit UI thread by waiting on the EDT while the EDT is waiting on the WebKit UI thread.
+  - `<input type="file">` is **asynchronous** in JS — `webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:` completes when the picker is dismissed; the page receives the chosen files via the `change` event. The completion handler accepts `nil` or `NSArray<NSURL *> *`.
+  - The default Swing dialog is anchored on `SwingUtilities.getWindowAncestor(component)` — the host `JFrame`. If the component is not yet attached to a window, the default falls back to anchoring on the component itself (which Swing will reparent to a hidden frame). Callers who construct a `WebViewComponent` without attaching it to a window before triggering a dialog get the same fallback behaviour `JOptionPane` already gives them.
+  - The `runOpenPanelWithParameters:` parameters carry `allowsMultipleSelection` and `acceptedMIMETypes` / `acceptedFileExtensions` (via the page's `<input accept="..." multiple>` attributes). The default file-picker handler honours both — `JFileChooser.setMultiSelectionEnabled` and a `FileNameExtensionFilter` derived from the extensions / MIME-to-extension mapping.
+
+### Scope In
+
+- New public interface `ca.weblite.webview.WebViewDialogHandler` with four `default` methods, all invoked on the Swing EDT:
+  - `default void alertOpened(WebViewAlertEvent event)` — default impl: `JOptionPane.showMessageDialog(host, event.message(), event.source().getName(), JOptionPane.PLAIN_MESSAGE)`.
+  - `default boolean confirmOpened(WebViewConfirmEvent event)` — default impl: `JOptionPane.showConfirmDialog(host, event.message(), event.source().getName(), JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION`.
+  - `default String promptOpened(WebViewPromptEvent event)` — default impl: `JOptionPane.showInputDialog(host, event.message(), event.defaultValue())`. Returns `null` on cancel.
+  - `default java.util.List<java.io.File> filePickerOpened(WebViewFilePickerEvent event)` — default impl: a modal `JFileChooser` honouring `event.multiple()` and `event.acceptedExtensions()`. Returns empty list on cancel.
+- New public POJOs in `ca.weblite.webview`, all immutable with public accessors:
+  - `WebViewAlertEvent` — `WebViewComponent source()`, `String message()`, `String pageUrl()`, `String frameUrl()`.
+  - `WebViewConfirmEvent` — `WebViewComponent source()`, `String message()`, `String pageUrl()`, `String frameUrl()`.
+  - `WebViewPromptEvent` — `WebViewComponent source()`, `String message()`, `String defaultValue()`, `String pageUrl()`, `String frameUrl()`.
+  - `WebViewFilePickerEvent` — `WebViewComponent source()`, `boolean multiple()`, `java.util.List<String> acceptedExtensions()` (lower-case, leading dot omitted, e.g. `["png","jpg","jpeg"]`), `java.util.List<String> acceptedMimeTypes()` (e.g. `["image/png","image/*"]`), `String pageUrl()`, `String frameUrl()`.
+- New public methods on `WebViewComponent`:
+  - `WebViewComponent setDialogHandler(WebViewDialogHandler handler)` — replaces the active handler. Passing `null` installs a "drop" handler whose methods return synchronously without showing UI (`alertOpened` returns immediately; `confirmOpened` returns `false`; `promptOpened` returns `null`; `filePickerOpened` returns empty list). Passing a non-null handler installs that handler; per-method overrides apply, un-overridden methods fall through to the interface defaults (Swing dialogs).
+  - `WebViewDialogHandler getDialogHandler()` — returns the currently installed handler. Never returns `null`; the "default" instance is returned when no caller has set one.
+- macOS heavyweight implementation:
+  - Define an Objective-C delegate class implementing the four `WKUIDelegate` selectors (alert / confirm / prompt / open-panel). Register it as the `uiDelegate` of every `WKWebView` created by the engine.
+  - Each selector marshals to the Swing EDT, invokes the active Java handler, captures the return value, and invokes the WebKit completion handler with the captured value. The marshal uses `SwingUtilities.invokeAndWait` from a non-EDT WebKit thread — never from the EDT itself (the WKWebView delegate selectors are not invoked on the EDT).
+  - The `runOpenPanelWithParameters:` selector extracts `allowsMultipleSelection`, `acceptedMIMETypes`, and `acceptedFileExtensions` (where available on the WKOpenPanelParameters version present) and populates the `WebViewFilePickerEvent` accordingly.
+  - Cleanup: the delegate is released when the engine is destroyed; no leaked reference from `WKWebView` to a freed Engine.
+- All four event POJOs include `pageUrl()` and `frameUrl()` (the top document and the immediately-initiating frame's URL, respectively) so handlers can apply per-origin policy.
+
+### Scope Out
+
+- Linux WebKitGTK interception — STORY-004-002.
+- Windows WebView2 `add_ScriptDialogOpening` interception — STORY-004-003.
+- The Linux lightweight component on macOS (which is a documented dead end per the README) — not a target platform.
+- The standalone in-process `WebView` class — this story is for embedded `WebViewComponent` only. Adding the same API to standalone `WebView` is a follow-up if a user asks for it.
+- Custom-styled dialogs (HTML-rendered overlays, themed components, etc.) — callers who want a custom look set their own `WebViewDialogHandler`.
+- `window.open(url, name, features)` popups and `beforeunload` confirmation prompts — these are different WKWebView delegate methods (`createWebViewWithConfiguration:` and the navigation delegate's `decidePolicyForNavigationAction:`) and are out of scope for this story.
+- HTTP basic / digest authentication challenges (`webView:didReceiveAuthenticationChallenge:`) — a different delegate channel, not a JS-initiated dialog.
+- Drag-and-drop file uploads — a different code path that doesn't go through `runOpenPanel`.
+- Per-call cancellation from Java mid-dialog (e.g. a way to dismiss an open `confirm` from Java) — handler returns determine the outcome; mid-flight cancellation is out of scope.
+- Telemetry / diagnostic logging of dialog events to stderr — handlers that want to log do so themselves.
+
+### Acceptance Criteria
+
+#### AC1: Default alert handler shows a Swing message dialog on macOS
+**Given** a `WebViewHeavyweightComponent` running on macOS, attached to a visible `JFrame`, with no custom `WebViewDialogHandler` set,
+**When** the loaded page calls `alert("hello world")`,
+**Then** a Swing `JOptionPane` message dialog appears modal to the host `JFrame` containing the text `"hello world"`, and `alert(...)` returns to JS only after the user dismisses the dialog.
+
+#### AC2: Default confirm handler returns true when user clicks OK on macOS
+**Given** a `WebViewHeavyweightComponent` on macOS with no custom handler set, loaded with a page that runs `const r = confirm("proceed?"); document.title = String(r);`,
+**When** the user clicks the OK button on the resulting Swing dialog,
+**Then** the page's `document.title` becomes the string `"true"`.
+
+#### AC3: Default confirm handler returns false when user clicks Cancel on macOS
+**Given** the same setup as AC2,
+**When** the user clicks the Cancel button on the resulting Swing dialog,
+**Then** the page's `document.title` becomes the string `"false"`.
+
+#### AC4: Default prompt handler returns the entered text on macOS
+**Given** a `WebViewHeavyweightComponent` on macOS with no custom handler, loaded with a page that runs `const r = prompt("name?", "default"); document.title = String(r);`,
+**When** the user types `"alice"` into the resulting Swing input dialog and clicks OK,
+**Then** the page's `document.title` becomes `"alice"`.
+
+#### AC5: Default prompt handler returns null on cancel on macOS
+**Given** the same setup as AC4,
+**When** the user clicks Cancel on the resulting Swing input dialog,
+**Then** the page's `document.title` becomes the string `"null"` (the JS `null` value, stringified).
+
+#### AC6: Default prompt handler pre-fills the default text on macOS
+**Given** the same setup as AC4,
+**When** the Swing input dialog appears,
+**Then** the input field is pre-populated with the text `"default"` so the user can edit or accept it directly.
+
+#### AC7: Default file picker honours single-file selection on macOS
+**Given** a `WebViewHeavyweightComponent` on macOS, loaded with `<input type="file" id="f">` and no custom handler,
+**When** the user clicks the file input and selects exactly one file `/tmp/a.png` in the resulting Swing `JFileChooser`,
+**Then** the page's `document.getElementById('f').files.length` is `1` and `files[0].name` is `"a.png"`.
+
+#### AC8: Default file picker honours multiple-file selection on macOS
+**Given** the same setup as AC7 but with `<input type="file" id="f" multiple>`,
+**When** the user selects two files `/tmp/a.png` and `/tmp/b.png`,
+**Then** the page's `document.getElementById('f').files.length` is `2`, and `files[0].name` is `"a.png"` and `files[1].name` is `"b.png"`.
+
+#### AC9: Default file picker honours accept attribute on macOS
+**Given** a `WebViewHeavyweightComponent` on macOS, loaded with `<input type="file" accept=".png,.jpg">`,
+**When** the user clicks the file input,
+**Then** the resulting Swing `JFileChooser` filters to files with extensions `.png` or `.jpg`; files with other extensions are not selectable through the active filter.
+
+#### AC10: Custom alert handler replaces the default
+**Given** a `WebViewHeavyweightComponent` on macOS with `setDialogHandler(new WebViewDialogHandler() { @Override public void alertOpened(WebViewAlertEvent e) { recorded = e.message(); } })` set,
+**When** the loaded page calls `alert("ping")`,
+**Then** no Swing dialog appears, the variable `recorded` holds the string `"ping"`, and `alert(...)` returns to JS within 50 ms of being called.
+
+#### AC11: Custom confirm handler returns a programmatic answer
+**Given** a `WebViewHeavyweightComponent` on macOS with a `WebViewDialogHandler` whose `confirmOpened` returns `true` unconditionally,
+**When** the page calls `const r = confirm("?"); document.title = String(r);`,
+**Then** no Swing dialog appears and `document.title` becomes `"true"`.
+
+#### AC12: Custom prompt handler returns a programmatic answer
+**Given** a `WebViewHeavyweightComponent` on macOS with a `WebViewDialogHandler` whose `promptOpened` returns `"hardcoded"`,
+**When** the page calls `const r = prompt("?", "x"); document.title = String(r);`,
+**Then** no Swing dialog appears and `document.title` becomes `"hardcoded"`.
+
+#### AC13: Custom file-picker handler returns a programmatic file list
+**Given** a `WebViewHeavyweightComponent` on macOS with a `WebViewDialogHandler` whose `filePickerOpened` returns `Arrays.asList(new File("/tmp/preselected.txt"))`,
+**When** the page contains `<input type="file" id="f">` and the user clicks it,
+**Then** no Swing `JFileChooser` appears, `document.getElementById('f').files.length` is `1`, and `files[0].name` is `"preselected.txt"`.
+
+#### AC14: setDialogHandler(null) suppresses dialogs without freezing the page
+**Given** a `WebViewHeavyweightComponent` on macOS with `setDialogHandler(null)` set,
+**When** the page calls `alert("x")`, then `const c = confirm("y")`, then `const p = prompt("z", "w")`,
+**Then** no Swing dialog appears, the page's JS thread continues without hanging, `c` is `false`, and `p` is `null`.
+
+#### AC15: WebViewFilePickerEvent surfaces multiple and accept hints
+**Given** a `WebViewHeavyweightComponent` on macOS with a custom handler that records `event.multiple()`, `event.acceptedExtensions()`, and `event.acceptedMimeTypes()`,
+**When** the page contains `<input type="file" accept="image/*,.pdf" multiple>` and the user clicks it,
+**Then** the handler is invoked once with `multiple()` `true`, `acceptedExtensions()` containing `"pdf"`, and `acceptedMimeTypes()` containing `"image/*"`.
+
+#### AC16: Handler callbacks fire on the Swing EDT
+**Given** a `WebViewHeavyweightComponent` on macOS with a custom handler that records `SwingUtilities.isEventDispatchThread()` in each of its four methods,
+**When** the page in turn triggers `alert`, `confirm`, `prompt`, and a click on `<input type=file>`,
+**Then** every recorded value is `true`.
+
+#### AC17: getDialogHandler never returns null
+**Given** a freshly constructed `WebViewHeavyweightComponent` with no handler set,
+**When** the caller invokes `getDialogHandler()`,
+**Then** the return value is non-null and refers to the framework's default handler instance (the one that shows Swing dialogs).
+
+#### AC18: pageUrl / frameUrl are populated on each event
+**Given** a `WebViewHeavyweightComponent` on macOS loaded with `https://example.com/index.html` and a custom handler that records `event.pageUrl()` and `event.frameUrl()`,
+**When** the top-level page calls `alert("x")`,
+**Then** the handler records `pageUrl()` `"https://example.com/index.html"` and `frameUrl()` `"https://example.com/index.html"` (same value because the alert came from the top-level frame).
+
+#### AC19: Dialog from a same-origin iframe surfaces the iframe URL as frameUrl
+**Given** a `WebViewHeavyweightComponent` on macOS, loaded at `https://example.com/parent.html`, which embeds a same-origin iframe at `https://example.com/child.html` that calls `alert("hi from child")`, with a custom handler that records both URLs,
+**When** the alert fires,
+**Then** the handler records `pageUrl()` `"https://example.com/parent.html"` and `frameUrl()` `"https://example.com/child.html"`.
+
+#### AC20: Handler exception does not crash WebKit
+**Given** a `WebViewHeavyweightComponent` on macOS with a custom handler whose `alertOpened` throws a `RuntimeException`,
+**When** the page calls `alert("x")`,
+**Then** the exception is surfaced via standard EDT uncaught-exception handling, the JS-side `alert(...)` returns within a bounded time (no hang), the WebView remains responsive, and the host app does not crash.
+
+### Non-Functional Expectations
+
+- The bridging from the macOS WebKit thread to the Swing EDT must not deadlock. In particular, when the WebKit UI thread is suspended waiting for an `alert`/`confirm`/`prompt` answer, the EDT must remain free to run the modal `JOptionPane` (i.e. the synchronisation primitives used to wait for the EDT must not block the EDT itself).
+- The handler-override path must be usable from a unit test in a headless environment — registering a programmatic handler that returns a fixed answer must not cause Swing to attempt to instantiate a `Window`.
+- Default Swing dialogs must be modal to the host `JFrame` (not application-modal) so that other unrelated `JFrame`s in the host app remain interactive while a single WebView's dialog is open.
+- `<input type="password">` is **not** invoked through `runOpenPanelWithParameters:` (it isn't a file input); this story imposes no new password-field behaviour. Password values continue to be the page's own concern.
+- The `WebViewFilePickerEvent.acceptedExtensions()` list must be normalised (lower-case, leading dot stripped) so that handlers don't have to special-case `.PNG` vs `.png` vs `png`.
+
+---
+
+## [STORY-004-002] Linux WebKitGTK Coverage for WebViewDialogHandler (Heavyweight + Lightweight)
+
+### Background
+
+STORY-004-001 establishes the `WebViewDialogHandler` Java contract and ships the macOS implementation. This story extends coverage to Linux — both `WebViewHeavyweightComponent` (X11-reparented WebKitGTK) and `WebViewLightweightComponent` (offscreen WebKitGTK rendered into a `BufferedImage`). The two modes share the same WebKit engine and the same signal-handler model, so they share native code.
+
+WebKitGTK exposes browser-initiated dialogs via two signals on `WebKitWebView`:
+
+- `script-dialog` (`WebKitScriptDialog *`) — fired for `alert` / `confirm` / `prompt` / `before-unload`. Connecting a handler that returns `TRUE` suppresses the default GTK dialog and lets the application drive the response via `webkit_script_dialog_confirm_set_confirmed(dialog, ...)` / `webkit_script_dialog_prompt_set_text(dialog, ...)`. The dialog's lifetime is bound by the handler returning; for async response, `webkit_script_dialog_ref(dialog)` keeps it alive until the application calls `webkit_script_dialog_close(dialog)`.
+- `run-file-chooser` (`WebKitFileChooserRequest *`) — fired for `<input type="file">` clicks. The request exposes `webkit_file_chooser_request_get_select_multiple`, `webkit_file_chooser_request_get_mime_types` / `..._get_mime_types_filter`. The application calls `webkit_file_chooser_request_select_files(request, paths)` or `webkit_file_chooser_request_cancel(request)`. Returning `TRUE` from the handler suppresses the default GTK file chooser.
+
+In heavyweight mode the default GTK dialogs *do* appear today, but our GTK window is reparented under an X11 parent that GTK doesn't know about — the same `gdk_window_move_to_rect: 'window->transient_for'` constraint already documented in `README.md` as breaking right-click menus and `<select>` dropdowns. In lightweight mode the WebView lives in a `GtkOffscreenWindow` with no `transient_for` at all, and the default dialogs cannot position themselves.
+
+This story sidesteps both Linux pain points by **intercepting both signals and routing them to the `WebViewDialogHandler` set on the Java component**. The default handler (from STORY-004-001) shows Swing dialogs anchored on the host `JFrame`, which avoids the GTK parenting problem entirely.
+
+Key points:
+- Business value: makes `alert / confirm / prompt` and `<input type="file">` actually work in lightweight mode (where they're broken today) and gives heavyweight a consistent, Swing-styled look that doesn't suffer from the orphan-dialog rendering glitches.
+- Relationship with other features: builds on the JNI bridge already used for `WebViewClickCallback`, `WebViewMouseDispatcher`, and `ConsoleDispatcher`. No new JNI infrastructure is needed — same async-callback-into-Java-from-GTK-thread pattern.
+- Why now: STORY-004-001 lands the Java contract; without this story Linux callers see `setDialogHandler(...)` doing nothing on their platform.
+
+### Business Value
+
+- Provide **working `alert / confirm / prompt`** in `WebViewLightweightComponent` on Linux, which is currently broken because the offscreen GTK window has no `transient_for`.
+- Provide **working `<input type="file">`** in `WebViewLightweightComponent` on Linux for the same reason.
+- Provide a **consistent Swing-styled experience** in heavyweight mode that avoids the documented `transient_for` rendering glitches the default GTK dialogs hit when WebKit is parented under an X11 window GTK doesn't own.
+- Fulfil the **cross-platform contract** introduced by `WebViewDialogHandler`: callers writing `setDialogHandler(...)` get identical Java semantics regardless of which native backend is underneath.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: STORY-004-001 must be complete (the `WebViewDialogHandler` interface, the four POJOs, and the `setDialogHandler` / `getDialogHandler` methods on `WebViewComponent` must already be in place). Canvases 6 and 7 (heavyweight + lightweight engines) in place.
+- **Data assumptions**: No persisted state; same per-component handler reference as on macOS.
+- **Integration points**: WebKitGTK 2.x signals `script-dialog` and `run-file-chooser` on `WebKitWebView`. Functions used: `webkit_script_dialog_get_dialog_type`, `webkit_script_dialog_get_message`, `webkit_script_dialog_prompt_get_default_text`, `webkit_script_dialog_confirm_set_confirmed`, `webkit_script_dialog_prompt_set_text`, `webkit_script_dialog_ref`, `webkit_script_dialog_close`, `webkit_file_chooser_request_get_select_multiple`, `webkit_file_chooser_request_get_mime_types_filter`, `webkit_file_chooser_request_select_files`, `webkit_file_chooser_request_cancel`. Same signals on the same `WebKitWebView` whether it's living in a foreign X11 window (heavyweight) or a `GtkOffscreenWindow` (lightweight).
+- **Business constraints**:
+  - The signal handler must return `TRUE` to claim the dialog. If `TRUE` is returned, no further default behaviour fires; if `FALSE`, the default GTK dialog appears. The handler always returns `TRUE` once this story ships — there is no path where the Java handler is invoked and the GTK default also fires.
+  - The `script-dialog` handler runs on the GTK main thread (the GTK pump thread per `README.md`). The Java handler must run on the EDT. The bridge must marshal from the GTK thread to the EDT, wait for the answer, and feed it back to WebKit. The current ConsoleDispatcher / MouseDispatcher pattern is to call back into Java from the GTK thread synchronously; this story adds a parallel callback for dialogs.
+  - `before-unload` dialogs (`WEBKIT_SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM`) reach the same `script-dialog` signal. **They are routed to the `confirmOpened` handler** because that's the closest semantic fit (a yes/no question) and the default `confirmOpened` will show a Swing OK/Cancel dialog. Future work can add a dedicated `beforeUnloadOpened` method to `WebViewDialogHandler` if needed.
+
+### Scope In
+
+- Native: connect `script-dialog` and `run-file-chooser` signals on every `WebKitWebView` created by the heavyweight and lightweight engines (single connection site per engine, both engines share it).
+- Native: dispatch the dialog kind (alert / confirm / prompt / before-unload mapped to confirm / file-picker) to Java via the existing JNI callback bridge, populating the same four event POJOs from STORY-004-001.
+- Native: receive the Java answer back (void / boolean / String / `List<File>`) and call the appropriate `webkit_script_dialog_*` / `webkit_file_chooser_request_*` function to complete the request.
+- Java: no new public API — all public types come from STORY-004-001. Internal: a small dispatcher class (e.g. `DialogDispatcher`) lives in `ca.weblite.webview` and is invoked from JNI; it marshals to the EDT, calls the active `WebViewDialogHandler`, and returns the answer.
+- Behaviour-symmetric across heavyweight and lightweight modes: the same JNI hooks, the same Java dispatcher, the same default Swing dialogs.
+
+### Scope Out
+
+- Windows WebView2 coverage — STORY-004-003.
+- macOS — already covered by STORY-004-001.
+- Adding a dedicated `beforeUnloadOpened` callback to `WebViewDialogHandler`. Before-unload is routed to `confirmOpened` in this story; a dedicated handler can be added later if a caller asks.
+- `webView:permissionRequest:` / `webkit_permission_request_*` (geolocation, notifications, camera) — not a dialog in the alert/confirm/prompt sense; out of scope.
+- Authentication dialogs (`authenticate` signal) — different signal, different shape, out of scope.
+- Drag-and-drop file uploads — different code path, out of scope.
+- HTTP/network proxy / TLS-error dialogs — different signal channel, out of scope.
+
+### Acceptance Criteria
+
+#### AC1: alert fires the dialog handler on Linux heavyweight
+**Given** a `WebViewHeavyweightComponent` on Linux, attached to a visible `JFrame`, with no custom `WebViewDialogHandler` set,
+**When** the loaded page calls `alert("hello")`,
+**Then** a Swing `JOptionPane` message dialog appears modal to the host `JFrame` showing `"hello"`, and the default GTK dialog does not appear.
+
+#### AC2: alert fires the dialog handler on Linux lightweight
+**Given** a `WebViewLightweightComponent` on Linux, attached to a visible `JFrame`, with no custom handler set,
+**When** the loaded page calls `alert("hello")`,
+**Then** a Swing `JOptionPane` message dialog appears modal to the host `JFrame` showing `"hello"`. No `gdk_window_move_to_rect: 'window->transient_for'` warning appears in stderr from this dialog.
+
+#### AC3: confirm round-trips OK on heavyweight and lightweight
+**Given** a `WebViewComponent` on Linux (run this AC once in each mode) with no custom handler, loaded with `const r = confirm("?"); document.title = String(r);`,
+**When** the user clicks OK on the Swing dialog,
+**Then** the page's `document.title` becomes `"true"`.
+
+#### AC4: confirm round-trips Cancel on heavyweight and lightweight
+**Given** the same setup as AC3,
+**When** the user clicks Cancel,
+**Then** the page's `document.title` becomes `"false"`.
+
+#### AC5: prompt round-trips the entered text on heavyweight and lightweight
+**Given** a `WebViewComponent` on Linux (each mode in turn) with no custom handler, loaded with `const r = prompt("name?", "default"); document.title = String(r);`,
+**When** the user types `"bob"` and clicks OK,
+**Then** the page's `document.title` becomes `"bob"`.
+
+#### AC6: prompt returns null on cancel
+**Given** the same setup as AC5,
+**When** the user clicks Cancel,
+**Then** the page's `document.title` becomes `"null"`.
+
+#### AC7: File picker honours multiple and accept on lightweight
+**Given** a `WebViewLightweightComponent` on Linux with `<input type="file" accept=".png" multiple>` and no custom handler,
+**When** the user clicks the input and selects two `.png` files in the resulting Swing `JFileChooser`,
+**Then** `document.querySelector('input[type=file]').files.length` is `2`.
+
+#### AC8: File picker on heavyweight
+**Given** a `WebViewHeavyweightComponent` on Linux with `<input type="file">` and no custom handler,
+**When** the user clicks the input and selects one file in the resulting Swing `JFileChooser`,
+**Then** `document.querySelector('input[type=file]').files.length` is `1` and the default GTK file dialog does not appear.
+
+#### AC9: Custom handler replaces the default on both modes
+**Given** a `WebViewComponent` on Linux (each mode in turn) with `setDialogHandler(handler)` set, where `handler.confirmOpened` returns `true` unconditionally,
+**When** the page calls `const r = confirm("?"); document.title = String(r);`,
+**Then** no Swing dialog appears and `document.title` becomes `"true"`.
+
+#### AC10: setDialogHandler(null) does not freeze the page on Linux
+**Given** a `WebViewComponent` on Linux (each mode in turn) with `setDialogHandler(null)`,
+**When** the page calls `alert("x")` then `confirm("y")` then `prompt("z", "w")`,
+**Then** no Swing dialog appears, the page's JS thread continues without hanging, and the page subsequently logs three lines through the existing console-capture channel proving execution proceeded past each call.
+
+#### AC11: Handler callbacks fire on the EDT
+**Given** a `WebViewComponent` on Linux (each mode in turn) with a custom handler that records `SwingUtilities.isEventDispatchThread()` in all four methods,
+**When** the page in turn triggers `alert`, `confirm`, `prompt`, and a file-input click,
+**Then** every recorded value is `true`.
+
+#### AC12: before-unload routes to confirmOpened
+**Given** a `WebViewComponent` on Linux (each mode in turn) with a custom handler whose `confirmOpened` returns `true` and records the event message, loaded with a page that registers `window.onbeforeunload = () => "are you sure?";`,
+**When** the page navigates away (e.g. by calling `location.href = '...'`),
+**Then** `confirmOpened` is invoked exactly once, the recorded message contains `"are you sure"` (the browser may prepend / append boilerplate per WebKit version), and navigation proceeds because the handler returned `true`.
+
+#### AC13: Default GTK dialogs are fully suppressed
+**Given** a `WebViewComponent` on Linux (each mode in turn) with the default handler,
+**When** the page calls `alert("x")`,
+**Then** no GTK-styled native dialog appears anywhere on screen — only the Swing `JOptionPane`. No `gdk_window_move_to_rect` warning is logged to stderr that originates from this story's dialog handlers.
+
+#### AC14: Heavyweight and lightweight share identical behaviour
+**Given** the same page running in `WebViewHeavyweightComponent` and `WebViewLightweightComponent` on Linux, each with the same custom handler that returns the same answers,
+**When** the page runs an identical sequence `alert("a"); const c = confirm("b"); const p = prompt("c", "d");`,
+**Then** both modes invoke the handler in the same order with identical event field values (message strings, default values, pageUrl, frameUrl), and produce the same JS-visible return values.
+
+#### AC15: WebViewFilePickerEvent surfaces accept hints on Linux
+**Given** a `WebViewComponent` on Linux (each mode in turn) with a custom handler recording `event.acceptedExtensions()` and `event.acceptedMimeTypes()`, with the page containing `<input type="file" accept="image/*,.pdf">`,
+**When** the user clicks the input,
+**Then** the handler records `acceptedExtensions()` containing `"pdf"` and `acceptedMimeTypes()` containing `"image/*"`.
+
+#### AC16: Handler returning empty list cancels the file picker without selection
+**Given** a `WebViewComponent` on Linux (each mode in turn) with a custom handler whose `filePickerOpened` returns `Collections.emptyList()`, with the page containing `<input type="file" id="f">`,
+**When** the user clicks the input,
+**Then** the `change` event fires with `document.getElementById('f').files.length` of `0`, the page does not hang, and no native GTK file dialog appears.
+
+### Non-Functional Expectations
+
+- The bridge must not block the GTK main-loop thread for longer than the dialog stays open. While the Swing dialog is up, the WebKit JS thread is paused (correct per the JS contract), but the GTK event loop must remain free to repaint other GTK widgets in the offscreen pipeline (i.e. don't park the main loop with a synchronous wait that includes paint scheduling).
+- The synchronous wait must be deadlock-free given the heavyweight model where the GTK pump runs on its own thread separate from AWT's X11 thread — invoking the EDT from the GTK pump thread and waiting must not require the GTK pump to service anything the EDT depends on.
+- Identical Java field values must be produced for the same page-side input across heavyweight and lightweight modes — there must not be silent divergence (e.g. mime-types reordered, extensions case-different) between the two engines.
+
+---
+
+## [STORY-004-003] Windows WebView2 Coverage for WebViewDialogHandler
+
+### Background
+
+STORY-004-001 establishes the `WebViewDialogHandler` Java contract on macOS. STORY-004-002 extends to Linux. This story extends coverage to Windows, where `WebViewHeavyweightComponent` uses Microsoft WebView2 (an embedded Chromium / Edge).
+
+WebView2's default behaviour today is that `alert / confirm / prompt` show built-in WebView2 dialogs (since `AreDefaultScriptDialogsEnabled` defaults to `TRUE` and the codebase does not change it), and `<input type="file">` opens the standard Windows file picker via WebView2's internal hosting. Both work out of the box.
+
+The motivation for this story is **uniform behaviour with macOS and Linux**: a caller who writes `setDialogHandler(custom)` expecting their custom handler to fire would, today, find that on Windows the default WebView2 dialog appears instead and their handler is never invoked. To fulfil the cross-platform contract from STORY-004-001, Windows must intercept the script dialogs.
+
+WebView2 exposes `ICoreWebView2::add_ScriptDialogOpening(handler, &token)` which fires for alert / confirm / prompt / before-unload (`WEBVIEW2_SCRIPT_DIALOG_KIND_*` in `windows/script/WebView2.h`). Returning a value asynchronously is supported via `ICoreWebView2ScriptDialogOpeningEventArgs::GetDeferral`. Combined with `ICoreWebView2Settings::put_AreDefaultScriptDialogsEnabled(FALSE)` this fully diverts JS dialogs to the application.
+
+WebView2 exposes **no public hook for `<input type="file">`**. The file picker is internal to WebView2 and cannot be intercepted from the host. This story therefore leaves the file picker path alone on Windows — `<input type="file">` continues to open the standard Windows file dialog. The Java `WebViewFilePickerEvent` simply does not fire on Windows in this story. This is documented as a known platform limitation.
+
+Key points:
+- Business value: makes `setDialogHandler(...)` behave the same on Windows as on macOS and Linux for the three JS dialog kinds. Tests that register a programmatic handler to answer `confirm` will work on Windows just as they do on macOS.
+- Relationship with other features: the WebView2 settings object is already obtained at engine creation (`windows/webview_embed.cc` lines around 422 and 876 — `ICoreWebView2Settings *settings = nullptr;`). This story adds a `put_AreDefaultScriptDialogsEnabled(FALSE)` call there and registers a `ScriptDialogOpening` event handler that bridges to the same Java dispatcher used by STORY-004-002.
+- Why now: closes the last gap in the cross-platform `WebViewDialogHandler` contract.
+
+### Business Value
+
+- Provide **handler-override consistency on Windows** — `setDialogHandler(custom)` actually intercepts `alert / confirm / prompt` instead of being silently overridden by WebView2's built-in dialogs.
+- Provide a **uniform Swing-styled look-and-feel** for `alert / confirm / prompt` across all three platforms when the default handler is in use, eliminating the today's discrepancy where Windows shows Chromium-styled dialogs.
+- Make **programmatic handlers** (used in tests, in CI, and in headless-ish deployments) work correctly on Windows.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: STORY-004-001 (Java API contract + macOS) must be complete. STORY-004-002 (Linux) is not a strict prerequisite — its native code is independent of Windows's — but the internal `DialogDispatcher` Java class introduced by STORY-004-002 is reused here, so STORY-004-002 landing first reduces duplicated internal scaffolding.
+- **Data assumptions**: No persisted state.
+- **Integration points**: `ICoreWebView2`, `ICoreWebView2Settings`, `ICoreWebView2ScriptDialogOpeningEventArgs`, `ICoreWebView2ScriptDialogOpeningEventHandler`, `ICoreWebView2Deferral` from the WebView2 SDK headers already vendored under `windows/script/`.
+- **Business constraints**:
+  - `<input type="file">` is **not interceptable** in WebView2. This story does not attempt to bridge it; on Windows, `WebViewFilePickerEvent` does not fire and the OS-native file picker continues to appear as today. This is documented in `README.md` as a Windows-specific limitation. Callers who need custom file-picker behaviour can still use `<input type="file" webkitdirectory />` and similar HTML primitives — same constraint applies. **AC4 verifies the unchanged default behaviour; no AC requires a custom file handler to fire on Windows.**
+  - `before-unload` dialogs reach the same `ScriptDialogOpening` event (kind = `WEBVIEW2_SCRIPT_DIALOG_KIND_BEFOREUNLOAD` in some SDK versions, or simply confirm in others). They route to `confirmOpened` for parity with STORY-004-002.
+  - The `ScriptDialogOpening` callback runs on the WebView2 worker thread (per the existing `README.md` description: "Each embedded WebView runs on its own worker thread that pumps a private message queue"). The bridge must marshal to the EDT and call back across worker→EDT boundaries without blocking the worker queue beyond the dialog's modal lifetime.
+  - Calling `put_AreDefaultScriptDialogsEnabled(FALSE)` happens once, at engine creation, immediately after the `ICoreWebView2Settings` is obtained.
+
+### Scope In
+
+- Native: in the Windows engine creation path (`windows/webview_embed.cc`, around the existing `ICoreWebView2Settings *settings = nullptr;` site), call `settings->put_AreDefaultScriptDialogsEnabled(FALSE)` after acquiring the settings interface.
+- Native: register a `ICoreWebView2ScriptDialogOpeningEventHandler` via `ICoreWebView2::add_ScriptDialogOpening`. The handler:
+  1. Reads `Uri`, `Kind`, `Message`, `DefaultText` from the event args.
+  2. Calls `GetDeferral` and stashes the deferral pointer.
+  3. Routes to the existing `DialogDispatcher` (introduced by STORY-004-002 or by this story if 004-002 has not landed) which marshals to the EDT, invokes `WebViewDialogHandler.alertOpened` / `confirmOpened` / `promptOpened`, and returns the answer.
+  4. On answer: calls `put_ResultText` (for prompt) or `Accept` (for confirm); for `alert` calls `Accept`. For "cancel" outcomes (confirm returns `false`, prompt returns `null`) it does **not** call `Accept` — leaving the deferral with no `Accept` causes WebView2 to cancel the dialog, which matches the JS contract (`confirm` returns `false`, `prompt` returns `null`). Then calls `Complete` on the deferral.
+- Native: `before-unload` dialogs route to `confirmOpened`, same as Linux (STORY-004-002).
+- Java: no public API changes. The internal `DialogDispatcher` from STORY-004-002 is reused. If STORY-004-002 has not yet landed, this story introduces `DialogDispatcher` in the same shape.
+- README documentation: add a note in the platform-support section explaining that on Windows, `WebViewFilePickerEvent` does not fire (WebView2 limitation) and `<input type="file">` uses the OS-native file picker as before.
+
+### Scope Out
+
+- macOS — STORY-004-001.
+- Linux — STORY-004-002.
+- Bridging `<input type="file">` on Windows — WebView2 does not expose a hook for this. Out of scope for this story, and the limitation is documented in README. A future workaround would require injecting a JS shim that intercepts the file-input click and routes through a custom binding; that is a different design and a separate story.
+- `NewWindowRequested`, `PermissionRequested`, `BasicAuthenticationRequested`, `WebResourceRequested` — different event channels, all out of scope.
+- Migrating to a newer WebView2 SDK version. The vendored SDK headers under `windows/script/` are sufficient.
+
+### Acceptance Criteria
+
+#### AC1: Default alert handler shows a Swing message dialog on Windows
+**Given** a `WebViewHeavyweightComponent` running on Windows 11 with the WebView2 Runtime installed, attached to a visible `JFrame`, with no custom `WebViewDialogHandler`,
+**When** the loaded page calls `alert("hello world")`,
+**Then** a Swing `JOptionPane` message dialog appears modal to the host `JFrame` showing `"hello world"`, and the WebView2 built-in alert dialog does not appear.
+
+#### AC2: Default confirm round-trips OK and Cancel
+**Given** a `WebViewHeavyweightComponent` on Windows with no custom handler, loaded with `const r = confirm("?"); document.title = String(r);`,
+**When** the user clicks OK on the resulting Swing dialog and then reloads and clicks Cancel,
+**Then** `document.title` is `"true"` in the first case and `"false"` in the second.
+
+#### AC3: Default prompt round-trips entered text and cancel
+**Given** a `WebViewHeavyweightComponent` on Windows with no custom handler, loaded with `const r = prompt("name?", "default"); document.title = String(r);`,
+**When** the user types `"carol"` and clicks OK in one run, and clicks Cancel in another,
+**Then** `document.title` is `"carol"` in the first case and `"null"` in the second; in both, the WebView2 built-in prompt does not appear.
+
+#### AC4: <input type=file> continues to open the OS-native picker on Windows
+**Given** a `WebViewHeavyweightComponent` on Windows with `<input type="file">` and no custom handler,
+**When** the user clicks the file input,
+**Then** the standard Windows file dialog (Common Item Dialog) appears as today, the user can select a file, and the page receives the selection. **`WebViewFilePickerEvent` does not fire on Windows in this story.**
+
+#### AC5: Custom alertOpened replaces the default on Windows
+**Given** a `WebViewHeavyweightComponent` on Windows with `setDialogHandler(new WebViewDialogHandler(){ @Override public void alertOpened(WebViewAlertEvent e){ recorded = e.message(); } })`,
+**When** the loaded page calls `alert("ping")`,
+**Then** no Swing dialog and no WebView2 dialog appear, and `recorded` equals `"ping"`.
+
+#### AC6: Custom confirmOpened returns a programmatic answer
+**Given** a `WebViewHeavyweightComponent` on Windows with a handler whose `confirmOpened` returns `true` unconditionally,
+**When** the page calls `const r = confirm("?"); document.title = String(r);`,
+**Then** no dialog appears and `document.title` becomes `"true"`.
+
+#### AC7: Custom promptOpened returns a programmatic answer
+**Given** a `WebViewHeavyweightComponent` on Windows with a handler whose `promptOpened` returns `"hardcoded"`,
+**When** the page calls `const r = prompt("?", "x"); document.title = String(r);`,
+**Then** no dialog appears and `document.title` becomes `"hardcoded"`.
+
+#### AC8: setDialogHandler(null) suppresses dialogs without freezing the page
+**Given** a `WebViewHeavyweightComponent` on Windows with `setDialogHandler(null)`,
+**When** the page calls `alert("x")` then `confirm("y")` then `prompt("z", "w")`,
+**Then** no dialog appears, the page's JS thread continues without hanging, and the three calls return synchronously with the documented null-handler semantics (void / false / null).
+
+#### AC9: before-unload routes to confirmOpened on Windows
+**Given** a `WebViewHeavyweightComponent` on Windows with a handler whose `confirmOpened` returns `true` and records the event,
+**When** a page running `window.onbeforeunload = () => "really?"` is navigated away from,
+**Then** `confirmOpened` is invoked exactly once, navigation proceeds, and the WebView2 built-in before-unload dialog does not appear.
+
+#### AC10: Handler callback fires on the EDT
+**Given** a `WebViewHeavyweightComponent` on Windows with a handler recording `SwingUtilities.isEventDispatchThread()` inside `alertOpened`, `confirmOpened`, and `promptOpened`,
+**When** the page in turn triggers each of the three dialog kinds,
+**Then** every recorded value is `true`.
+
+#### AC11: pageUrl and frameUrl are populated on Windows
+**Given** a `WebViewHeavyweightComponent` on Windows loaded with `https://example.com/index.html` and a handler recording `event.pageUrl()` and `event.frameUrl()`,
+**When** the page calls `alert("x")`,
+**Then** `pageUrl()` is `"https://example.com/index.html"` and `frameUrl()` is `"https://example.com/index.html"`.
+
+#### AC12: Built-in WebView2 dialogs do not appear with default handler
+**Given** a `WebViewHeavyweightComponent` on Windows with the default `WebViewDialogHandler` (no custom handler set),
+**When** the page calls `alert("first")` then `confirm("second")` then `prompt("third", "x")`,
+**Then** at no point does the WebView2 built-in dialog flash on screen before the Swing dialog appears (i.e. `AreDefaultScriptDialogsEnabled` is `FALSE` from engine creation, not toggled mid-flight).
+
+#### AC13: Handler exception does not crash WebView2
+**Given** a `WebViewHeavyweightComponent` on Windows with a handler whose `alertOpened` throws a `RuntimeException`,
+**When** the page calls `alert("x")`,
+**Then** the exception is surfaced via EDT uncaught-exception handling, the JS-side `alert(...)` returns within a bounded time (the deferral is completed even on exception), the WebView2 stays responsive, and the host app does not crash.
+
+### Non-Functional Expectations
+
+- The `ICoreWebView2Deferral` must always be completed, even when the Java handler throws. Failure to complete the deferral leaves the WebView2 JS engine hung.
+- The marshal from the WebView2 worker thread to the EDT and back must not require WebView2's worker queue to service messages from the EDT (the worker thread is paused waiting for the answer); there must be no inverted-dependency between the WebView2 message pump and the EDT.
+- The Windows-only limitation that `WebViewFilePickerEvent` does not fire must be documented in `README.md` (Platform support table or a dedicated note), so callers don't write code that silently no-ops on Windows.
+
+---
+
+## Quality Checks
+
+**STORY-004-001 (Java API contract + macOS coverage)**:
+- ✅ All required sections present (Background, Business Value, Dependencies and Assumptions, Scope In, Scope Out, Acceptance Criteria, Non-Functional Expectations).
+- ✅ ACs use Given-When-Then with concrete inputs (`alert("hello world")`, `prompt("name?", "default")`, `<input type="file" accept=".png,.jpg" multiple>`) and observable outcomes (`document.title` equals specific string, `files.length` equals specific integer).
+- ✅ Business-language ACs — public API names (`setDialogHandler`, `WebViewDialogHandler`, `confirmOpened`, `WebViewFilePickerEvent`) appear because they are the user-visible contract. No JNI signatures, no ObjC selector names inside AC bodies (selectors mentioned only in Dependencies / Scope-In context).
+- ✅ Covers happy path (default Swing dialogs for all four kinds), validation / business rules (cancel returns null/false, accept-filter applied, multiple flag honoured), error conditions (handler exception, setDialogHandler(null) suppression), and EDT / pre-display / iframe-URL invariants.
+- ✅ At most three core functional points (Java API, macOS native delegate, default Swing dialog implementation).
+- ✅ 3-5 days of work (ObjC UIDelegate class, JNI bridge for synchronous return, four event POJOs, default Swing dialog impl, EDT marshaling).
+
+**STORY-004-002 (Linux coverage)**:
+- ✅ All required sections present.
+- ✅ ACs run "in each mode in turn" where the behaviour is identical, explicitly checking both `WebViewHeavyweightComponent` and `WebViewLightweightComponent`.
+- ✅ Business-language ACs, no GTK signal names inside AC bodies (signal names appear only in Background / Dependencies / Scope-In).
+- ✅ Covers happy path (alert / confirm / prompt / file picker, both modes), validation (accept-filter, multiple, cancel-returns-empty), error/edge (`setDialogHandler(null)` semantics), and parity (AC14: heavyweight vs lightweight produce identical Java field values).
+- ✅ At most two core functional points (GTK signal handlers for script-dialog and run-file-chooser).
+- ✅ 2-4 days of work (two GTK signal connections, JNI bridging reuses STORY-004-001 pattern, no new Java API).
+
+**STORY-004-003 (Windows coverage)**:
+- ✅ All required sections present.
+- ✅ ACs use concrete inputs / outputs; AC4 explicitly carves out the WebView2 file-picker limitation so the reader is not surprised.
+- ✅ Business-language ACs; COM interface names appear only in Dependencies / Scope-In, never inside AC bodies.
+- ✅ Covers happy path (alert / confirm / prompt default), edge (before-unload routes to confirm, AC9), business rules (no built-in WebView2 dialog flash, AC12), and error conditions (handler exception completes the deferral, AC13).
+- ✅ Two core functional points (settings flag + `add_ScriptDialogOpening` handler).
+- ✅ 2-3 days of work.
+
+## Final INVEST Re-validation
+
+| Property | STORY-004-001 | STORY-004-002 | STORY-004-003 |
+|---|---|---|---|
+| Independent | ✅ (no story-level dependency; designs the API) | ✅ (depends only on the API from 004-001, native code is wholly independent) | ✅ (depends only on the API from 004-001, native code is wholly independent of Linux's) |
+| Complete | ✅ (full Java contract + working macOS) | ✅ (full Linux coverage, both modes) | ✅ (full Windows coverage for the three interceptable kinds + documented limitation) |
+| Valuable | ✅ (fixes the silently-broken macOS platform; ships the contract) | ✅ (fixes broken Linux lightweight; fixes orphan-dialog glitch on heavyweight) | ✅ (makes setDialogHandler actually work on Windows) |
+| Estimable | ✅ (one ObjC delegate + JNI sync-bridge + four POJOs + Swing default impl) | ✅ (two GTK signal handlers reusing existing JNI pattern) | ✅ (one settings put + one event-handler registration + deferral plumbing) |
+| Right-sized | ✅ (3-5 days) | ✅ (2-4 days) | ✅ (2-3 days) |
+| Testable | ✅ (default dialogs and handler override both observable from Swing harness; programmatic handler runs in headless unit test) | ✅ (parity AC14 + both-mode coverage AC1-AC11) | ✅ (built-in dialog suppression observable via AC12; file-picker carve-out tested via AC4) |
+
+All three stories pass INVEST.

--- a/run-linux-dialog-demo.sh
+++ b/run-linux-dialog-demo.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# One-shot script: build the Linux native lib, build WebView.jar, compile
+# and run the browser-initiated UI dialogs demo (WebViewDialogDemo).
+#
+# Exercises window.alert / window.confirm / window.prompt and
+# <input type="file"> across three handler modes (Default Swing dialogs,
+# Custom programmatic answers, Drop / null = suppress).  See
+# demos/WebViewDialogDemo/README.md for the AC-mapped manual test
+# checklist.
+#
+# Usage:    ./run-linux-dialog-demo.sh             # lightweight (default)
+#           ./run-linux-dialog-demo.sh heavyweight # force heavyweight mode
+#           ./run-linux-dialog-demo.sh lightweight # force lightweight mode
+#           WEBVIEW_MODE=heavyweight ./run-linux-dialog-demo.sh
+#
+# STORY-004-002 requires AC verification in BOTH modes; run the script
+# twice (once per mode) to cover the full acceptance matrix.
+#
+# Override JDK:  JAVA_HOME=/path/to/jdk ./run-linux-dialog-demo.sh
+#
+# Required packages:
+#   - g++, pkg-config
+#   - libgtk-3-dev
+#   - libwebkit2gtk-4.1-dev (Ubuntu 24.04+) or libwebkit2gtk-4.0-dev (older)
+#   - libx11-dev
+#   - libxt-dev   <-- pulled in because JDK 8's jawt_md.h includes X11/Intrinsic.h
+set -e
+set -o pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 0. Mode selection
+# ---------------------------------------------------------------------------
+MODE="${1:-${WEBVIEW_MODE:-lightweight}}"
+case "$MODE" in
+    heavyweight|lightweight) ;;
+    *)
+        echo "Unknown mode: $MODE" >&2
+        echo "Usage: $0 [heavyweight|lightweight]" >&2
+        exit 1
+        ;;
+esac
+echo "Mode: $MODE"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if command -v javac >/dev/null 2>&1; then
+        JAVAC_PATH="$(readlink -f "$(command -v javac)" 2>/dev/null || command -v javac)"
+        JAVA_HOME="$(dirname "$(dirname "$JAVAC_PATH")")"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g. via mise / asdf:" >&2
+    echo "  mise install   # picks up .tool-versions" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Pick a WebKit pkg-config name
+# ---------------------------------------------------------------------------
+if pkg-config --exists webkit2gtk-4.1; then
+    WEBKIT_PKG=webkit2gtk-4.1
+elif pkg-config --exists webkit2gtk-4.0; then
+    WEBKIT_PKG=webkit2gtk-4.0
+else
+    echo "Neither webkit2gtk-4.1 nor webkit2gtk-4.0 was found via pkg-config." >&2
+    echo "Install one of the following with your package manager:" >&2
+    echo "  Debian/Ubuntu 24.04+:  sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev libx11-dev libxt-dev" >&2
+    echo "  Debian/Ubuntu older:   sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev libx11-dev libxt-dev" >&2
+    echo "  Fedora:                sudo dnf install gtk3-devel webkit2gtk4.1-devel libX11-devel libXt-devel" >&2
+    exit 1
+fi
+if ! pkg-config --exists gtk+-3.0; then
+    echo "gtk+-3.0 (libgtk-3-dev) is required." >&2
+    exit 1
+fi
+echo "Using WebKit package: $WEBKIT_PKG"
+
+if ! printf '#include <X11/Intrinsic.h>\nint main(){return 0;}\n' | \
+        g++ -E -x c++ - >/dev/null 2>&1; then
+    echo "" >&2
+    echo "ERROR: <X11/Intrinsic.h> not found." >&2
+    echo "" >&2
+    echo "JDK 8 on Linux pulls X11 Intrinsics in via jawt_md.h.  Install:" >&2
+    echo "  Debian/Ubuntu:  sudo apt install libxt-dev" >&2
+    echo "  Fedora:         sudo dnf install libXt-devel" >&2
+    echo "  Arch:           sudo pacman -S libxt" >&2
+    echo "" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Build libwebview.so for the current arch
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    x86_64|amd64)   NATIVE_DIR=linux_64 ;;
+    aarch64|arm64)  NATIVE_DIR=linux_arm64 ;;
+    armv7l|armv7)   NATIVE_DIR=linux_arm ;;
+    i?86)           NATIVE_DIR=linux_32 ;;
+    *)              NATIVE_DIR=linux_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR (arch: $(uname -m))"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+SO="$REPO_DIR/src/$NATIVE_DIR/libwebview.so"
+
+NEED_SO=0
+if [ ! -f "$SO" ]; then
+    NEED_SO=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
+    done
+fi
+
+if [ "$NEED_SO" = "1" ]; then
+    echo "Building libwebview.so ..."
+    g++ -fPIC -std=c++11 -Wall \
+        -DWEBVIEW_GTK=1 \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
+        -I./src_c \
+        $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp \
+        $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+        -lX11 -ldl \
+        -shared -o "$SO"
+    echo "Built $SO"
+else
+    echo "libwebview.so up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 5. Build WebView.jar -- classes + linux_*/libwebview.so at jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$SO" "$STAGE/$NATIVE_DIR/libwebview.so"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 6. Compile and run the dialog demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewDialogDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-dialog-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewDialogDemo.java"
+
+echo "Launching WebViewDialogDemo (mode=$MODE) ..."
+# Force the X11 GDK backend; embedding via XReparentWindow needs a real X11
+# GdkDisplay on both sides.
+export GDK_BACKEND=x11
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+export WEBKIT_FORCE_SANDBOX=0
+
+exec "$JAVA" \
+    "-Dca.weblite.webview.mode=$MODE" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewDialogDemo

--- a/run-mac-dialog-demo.sh
+++ b/run-mac-dialog-demo.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# One-shot script: build the macOS native lib, build WebView.jar, compile
+# and run the browser-initiated UI dialogs demo (WebViewDialogDemo).
+#
+# Exercises window.alert / window.confirm / window.prompt and
+# <input type="file"> across three handler modes (Default Swing dialogs,
+# Custom programmatic answers, Drop / null = suppress).  See
+# demos/WebViewDialogDemo/README.md for the AC-mapped manual test
+# checklist.
+#
+# Usage:    ./run-mac-dialog-demo.sh
+# Override: JAVA_HOME=/path/to/jdk ./run-mac-dialog-demo.sh
+#
+set -e
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if [ -x /usr/libexec/java_home ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g.:" >&2
+    echo "  brew install --cask temurin" >&2
+    echo "  export JAVA_HOME=\"\$(/usr/libexec/java_home)\"" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Build libwebview.dylib if missing or source is newer
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    arm64|aarch64) NATIVE_DIR=osx_arm64 ;;
+    x86_64)        NATIVE_DIR=osx_64 ;;
+    *)             NATIVE_DIR=osx_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+DYLIB="$REPO_DIR/src/$NATIVE_DIR/libwebview.dylib"
+NEED_DYLIB=0
+if [ ! -f "$DYLIB" ]; then
+    NEED_DYLIB=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$DYLIB" ]; then NEED_DYLIB=1; break; fi
+    done
+fi
+
+if [ "$NEED_DYLIB" = "1" ]; then
+    echo "Building libwebview.dylib (arch: $(uname -m)) ..."
+    c++ \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/darwin" \
+        -dynamiclib \
+        src_c/webview_embed.cpp \
+        -o "$DYLIB" \
+        -DWEBVIEW_COCOA=1 \
+        -std=c++11 \
+        -framework WebKit -framework Cocoa -framework QuartzCore \
+        -Wl,-undefined,dynamic_lookup
+    echo "Built $DYLIB"
+else
+    echo "libwebview.dylib up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" \
+    -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 4. Build WebView.jar -- classes + osx_*/libwebview.dylib at the jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$DYLIB" "$STAGE/$NATIVE_DIR/libwebview.dylib"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 5. Compile and run the dialog demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewDialogDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-dialog-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" \
+    -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewDialogDemo.java"
+
+echo "Launching WebViewDialogDemo ..."
+exec "$JAVA" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewDialogDemo

--- a/run-windows-dialog-demo.bat
+++ b/run-windows-dialog-demo.bat
@@ -1,0 +1,218 @@
+@echo off
+REM ============================================================================
+REM run-windows-dialog-demo.bat
+REM
+REM One-shot build & launch of WebViewDialogDemo on Windows.  Builds the
+REM WebView2-backed native DLL, packages WebView.jar, compiles the demo, and
+REM runs it.  No Ant required.
+REM
+REM Exercises window.alert / window.confirm / window.prompt and
+REM <input type="file"> across three handler modes (Default Swing dialogs,
+REM Custom programmatic answers, Drop / null = suppress).  See
+REM demos\WebViewDialogDemo\README.md for the AC-mapped manual test checklist.
+REM
+REM On Windows, <input type="file"> always uses the OS-native Common Item
+REM Dialog -- WebView2 exposes no public hook for it (documented limitation),
+REM so the Custom handler's filePickerOpened does not fire on Windows.
+REM
+REM Requires:
+REM   - JAVA_HOME set to a JDK 8+ install.
+REM   - Visual Studio 2019 or newer with "Desktop development with C++".
+REM   - The WebView2 runtime (ships with Windows 11; install Evergreen on
+REM     older Windows: https://aka.ms/webview2 ).
+REM ============================================================================
+setlocal enabledelayedexpansion
+
+set "REPO_DIR=%~dp0"
+if "%REPO_DIR:~-1%"=="\" set "REPO_DIR=%REPO_DIR:~0,-1%"
+echo Repo: %REPO_DIR%
+
+REM ---------------------------------------------------------------------------
+REM 1. Resolve JAVA_HOME
+REM ---------------------------------------------------------------------------
+if "%JAVA_HOME%"=="" (
+    echo.
+    echo JAVA_HOME is not set.  Set it to your JDK install and re-run, e.g.:
+    echo.
+    echo     set "JAVA_HOME=C:\Program Files\Amazon Corretto\jdk1.8.0_xxx"
+    echo     run-windows-dialog-demo.bat
+    echo.
+    exit /b 1
+)
+if not exist "%JAVA_HOME%\bin\javac.exe" (
+    echo ERROR: javac.exe not found in "%JAVA_HOME%\bin".
+    echo Check that JAVA_HOME points at the JDK root, not the JRE.
+    exit /b 1
+)
+echo Using JAVA_HOME=%JAVA_HOME%
+
+REM ---------------------------------------------------------------------------
+REM 2. Locate Visual Studio via vswhere
+REM ---------------------------------------------------------------------------
+set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" set "vswhere=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" (
+    echo ERROR: vswhere.exe not found.
+    echo Install Visual Studio 2019 or newer with the
+    echo "Desktop development with C++" workload.
+    exit /b 1
+)
+set "vc_dir="
+for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+    set "vc_dir=%%i"
+)
+if "%vc_dir%"=="" (
+    echo ERROR: Could not locate a Visual Studio installation with VC tools x86/x64.
+    exit /b 1
+)
+echo Visual Studio: %vc_dir%
+
+REM ---------------------------------------------------------------------------
+REM 3. Activate the MSVC x64 environment
+REM ---------------------------------------------------------------------------
+call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
+if errorlevel 1 (
+    echo ERROR: vsdevcmd.bat failed.
+    exit /b 1
+)
+
+set "SDK_OK="
+for %%I in ("%INCLUDE:;=";"%") do (
+    if exist "%%~I\windows.h" set "SDK_OK=1"
+)
+
+if defined SDK_OK goto :sdk_check_done
+set "KITS_ROOT=C:\Program Files (x86)\Windows Kits\10"
+set "SDK_VER="
+if not exist "%KITS_ROOT%\Include" goto :sdk_check_done
+for /f "delims=" %%V in ('dir /b /ad /on "%KITS_ROOT%\Include" 2^>nul') do (
+    if exist "%KITS_ROOT%\Include\%%V\um\windows.h" set "SDK_VER=%%V"
+)
+if "%SDK_VER%"=="" goto :sdk_check_done
+echo NOTE: vsdevcmd did not register a Windows SDK, but one is present
+echo       on disk.  Manually adding Windows SDK %SDK_VER% at %KITS_ROOT%.
+set "INCLUDE=%INCLUDE%;%KITS_ROOT%\Include\%SDK_VER%\ucrt;%KITS_ROOT%\Include\%SDK_VER%\um;%KITS_ROOT%\Include\%SDK_VER%\shared;%KITS_ROOT%\Include\%SDK_VER%\winrt;%KITS_ROOT%\Include\%SDK_VER%\cppwinrt"
+set "LIB=%LIB%;%KITS_ROOT%\Lib\%SDK_VER%\ucrt\x64;%KITS_ROOT%\Lib\%SDK_VER%\um\x64"
+set "SDK_OK=1"
+:sdk_check_done
+
+if defined SDK_OK goto :build_dll
+echo.
+echo ERROR: Windows SDK headers not found on the cl.exe INCLUDE path.
+echo        vsdevcmd activated successfully but no SDK provides windows.h.
+echo.
+echo Fix: open the Visual Studio Installer, click Modify on your VS install,
+echo and on the "Individual components" tab tick a "Windows 11 SDK" or
+echo "Windows 10 SDK" entry, then re-run this script.
+echo.
+exit /b 1
+:build_dll
+
+REM ---------------------------------------------------------------------------
+REM 4. Build webview.dll (x64)
+REM ---------------------------------------------------------------------------
+set "NATIVE_DIR=windows_64"
+set "DLL_OUT=%REPO_DIR%\src\%NATIVE_DIR%"
+if not exist "%DLL_OUT%" mkdir "%DLL_OUT%"
+set "BUILD_DIR=%REPO_DIR%\build"
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
+set "WEBVIEW2_VERSION=1.0.2592.51"
+set "WEBVIEW2_DIR=%REPO_DIR%\windows\script\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%"
+set "WEBVIEW2_NUPKG=%WEBVIEW2_DIR%\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg"
+set "WEBVIEW2_URL=https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/%WEBVIEW2_VERSION%"
+
+set "PWSH=%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe"
+if not exist "%PWSH%" set "PWSH=powershell.exe"
+
+if exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" goto :webview2_ready
+if not exist "%WEBVIEW2_DIR%" mkdir "%WEBVIEW2_DIR%"
+if exist "%WEBVIEW2_NUPKG%" goto :webview2_extract
+echo Downloading Microsoft.Web.WebView2 %WEBVIEW2_VERSION% from NuGet ...
+"%PWSH%" -NoProfile -Command "$ProgressPreference='SilentlyContinue'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%WEBVIEW2_URL%' -OutFile '%WEBVIEW2_NUPKG%' -UseBasicParsing"
+if not exist "%WEBVIEW2_NUPKG%" (
+    echo ERROR: failed to download WebView2 SDK from %WEBVIEW2_URL%.
+    exit /b 1
+)
+:webview2_extract
+echo Extracting Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg ...
+"%PWSH%" -NoProfile -Command "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('%WEBVIEW2_NUPKG%', '%WEBVIEW2_DIR%')"
+if not exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" (
+    echo ERROR: failed to extract WebView2 SDK.
+    exit /b 1
+)
+:webview2_ready
+
+echo Building webview.dll (x64) ...
+cl /nologo ^
+    /D "WEBVIEW_API=__declspec(dllexport)" ^
+    /D "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" ^
+    /I "%JAVA_HOME%\include" ^
+    /I "%JAVA_HOME%\include\win32" ^
+    /I "%REPO_DIR%\windows" ^
+    /I "%WEBVIEW2_DIR%\build\native\include" ^
+    /std:c++17 /EHsc ^
+    /Fo"%BUILD_DIR%\\" ^
+    "%REPO_DIR%\windows\webview.cc" ^
+    "%REPO_DIR%\windows\webview_embed.cc" ^
+    /link /DLL ^
+    "%WEBVIEW2_DIR%\build\native\x64\WebView2LoaderStatic.lib" ^
+    "%JAVA_HOME%\lib\jawt.lib" ^
+    advapi32.lib ole32.lib oleaut32.lib shlwapi.lib shell32.lib user32.lib version.lib winhttp.lib ^
+    /OUT:"%BUILD_DIR%\webview.dll"
+if errorlevel 1 (
+    echo ERROR: cl.exe build failed.
+    exit /b 1
+)
+copy /Y "%BUILD_DIR%\webview.dll" "%DLL_OUT%\webview.dll" >nul
+echo Built %DLL_OUT%\webview.dll
+
+REM ---------------------------------------------------------------------------
+REM 5. Compile WebView Java sources
+REM ---------------------------------------------------------------------------
+set "WV_CLASSES=%BUILD_DIR%\classes-webview"
+if exist "%WV_CLASSES%" rmdir /s /q "%WV_CLASSES%"
+mkdir "%WV_CLASSES%"
+echo Compiling WebView Java sources ...
+dir /s /b "%REPO_DIR%\src\*.java" > "%BUILD_DIR%\wv-sources.txt"
+"%JAVA_HOME%\bin\javac.exe" -d "%WV_CLASSES%" -classpath "%REPO_DIR%\lib\*" @"%BUILD_DIR%\wv-sources.txt"
+if errorlevel 1 (
+    echo ERROR: javac failed.
+    exit /b 1
+)
+
+REM ---------------------------------------------------------------------------
+REM 6. Build WebView.jar
+REM ---------------------------------------------------------------------------
+set "WV_JAR=%REPO_DIR%\dist\WebView.jar"
+if not exist "%REPO_DIR%\dist" mkdir "%REPO_DIR%\dist"
+set "STAGE=%BUILD_DIR%\stage-webview"
+if exist "%STAGE%" rmdir /s /q "%STAGE%"
+mkdir "%STAGE%\%NATIVE_DIR%"
+"%SystemRoot%\System32\xcopy.exe" /e /q /y "%WV_CLASSES%\*" "%STAGE%\" >nul
+if errorlevel 1 (
+    echo ERROR: xcopy of compiled classes into the jar staging dir failed.
+    exit /b 1
+)
+copy /Y "%DLL_OUT%\webview.dll" "%STAGE%\%NATIVE_DIR%\webview.dll" >nul
+pushd "%STAGE%"
+"%JAVA_HOME%\bin\jar.exe" cf "%WV_JAR%" .
+popd
+echo Built %WV_JAR%
+
+REM ---------------------------------------------------------------------------
+REM 7. Compile and launch the dialog demo
+REM ---------------------------------------------------------------------------
+set "DEMO_DIR=%REPO_DIR%\demos\WebViewDialogDemo"
+set "DEMO_CLASSES=%BUILD_DIR%\classes-dialog-demo"
+if not exist "%DEMO_CLASSES%" mkdir "%DEMO_CLASSES%"
+echo Compiling demo ...
+"%JAVA_HOME%\bin\javac.exe" -d "%DEMO_CLASSES%" -classpath "%WV_JAR%" "%DEMO_DIR%\src\ca\weblite\webview\demos\WebViewDialogDemo.java"
+if errorlevel 1 (
+    echo ERROR: javac failed on demo.
+    exit /b 1
+)
+
+echo Launching WebViewDialogDemo ...
+"%JAVA_HOME%\bin\java.exe" -cp "%DEMO_CLASSES%;%WV_JAR%" ca.weblite.webview.demos.WebViewDialogDemo
+
+endlocal

--- a/spdd/analysis/GGQPA-XXX-202605181830-[Analysis]-browser-initiated-ui-dialogs.md
+++ b/spdd/analysis/GGQPA-XXX-202605181830-[Analysis]-browser-initiated-ui-dialogs.md
@@ -1,0 +1,359 @@
+# SPDD Analysis: Browser-Initiated UI Dialogs (alert / confirm / prompt / file picker)
+
+## Original Business Requirement
+
+(Excerpt — full text preserved verbatim in `requirements/[User-story-4]browser-initiated-ui-dialogs.md`.)
+
+Three sister stories sharing one Java contract:
+
+- **STORY-004-001** — `WebViewDialogHandler` API + macOS WKWebView coverage. Designs the cross-platform Java contract (`WebViewDialogHandler` interface with four `default` methods showing Swing dialogs; four immutable event POJOs: `WebViewAlertEvent`, `WebViewConfirmEvent`, `WebViewPromptEvent`, `WebViewFilePickerEvent`; `setDialogHandler` / `getDialogHandler` on `WebViewComponent`) and ships the macOS implementation via a `WKUIDelegate`. Currently macOS is silently broken: no `uiDelegate` is set on the `WKWebView`, so `alert` / `confirm` / `prompt` / `<input type=file>` all silently no-op. 20 ACs + 5 non-functional expectations.
+
+- **STORY-004-002** — Linux WebKitGTK coverage (heavyweight + lightweight). Connects `script-dialog` and `run-file-chooser` signal handlers on `WebKitWebView`, suppresses the GTK default (returns `TRUE`), and bridges to the same `WebViewDialogHandler`. Same JNI / dispatcher pattern in both modes. Fixes the documented `transient_for` problem in lightweight (offscreen `GtkOffscreenWindow` has no transient parent → orphan dialogs cannot position) and replaces the heavyweight default which suffers the same `gdk_window_move_to_rect` glitch on a foreign-toolkit X11 parent. 16 ACs + 3 non-functional expectations.
+
+- **STORY-004-003** — Windows WebView2 coverage. Adds `put_AreDefaultScriptDialogsEnabled(FALSE)` at engine creation and registers `add_ScriptDialogOpening` to bridge alert/confirm/prompt to the same Java handler. WebView2 exposes **no public hook** for `<input type=file>` so the OS-native file dialog continues to appear on Windows; `WebViewFilePickerEvent` does not fire on Windows in this story — documented as a known platform limitation. 13 ACs + 3 non-functional expectations.
+
+Cross-cutting invariants the contract requires:
+
+- **EDT-only callbacks.** Every `*Opened` method runs on the Swing EDT.
+- **Synchronous JS-contract semantics.** `alert` / `confirm` / `prompt` are synchronous in JS; the native completion handler / deferral must not be invoked until the Java handler returns. `<input type=file>` is async — completion fires on dismissal, page receives selection via the `change` event.
+- **Default behaviour = Swing dialogs.** No-handler / handler-using-defaults shows `JOptionPane` (alert/confirm/prompt) and `JFileChooser` (file picker), modal to the host `JFrame` resolved via `SwingUtilities.getWindowAncestor(component)`.
+- **Override = one handler per component.** `setDialogHandler(custom)` replaces. `setDialogHandler(null)` installs a "drop" handler that returns void / `false` / `null` / empty list without showing UI — required for headless tests.
+- **No new reserved JS binding** (dialog requests are native callbacks, not page-injected JS). The existing `__webview_` prefix convention is unused for this work.
+- **Story dependency graph.** STORY-004-001 designs the API and is the prerequisite for the other two; STORY-004-002 and STORY-004-003 can ship in parallel after it.
+
+## Domain Concept Identification
+
+### Existing Concepts (from codebase)
+
+- **`WebViewComponent`** (`src/ca/weblite/webview/swing/WebViewComponent.java`) — abstract base for both Swing variants. Already exposes `consoleDispatcher`, `mouseDispatcher` (both `protected final`, initialised at construction so they survive peer create/destroy), and the constant `RESERVED_BINDING_PREFIX = "__webview_"`. **The new `setDialogHandler` / `getDialogHandler` API attaches here as concrete `final` methods (no abstract overload needed)** — same shape as the existing `addWebViewMouseListener` / `setDefaultContextMenuEnabled` / `addConsoleListener` family at lines 282-406. The component is the natural owner of the per-instance handler reference; both subclasses see the same dispatcher.
+
+- **`WebViewHeavyweightComponent`** (`src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`) — wraps an `EmbeddedWebView`; peer created lazily in `createPeer()` (line 409). The `createPeer()` site at lines 410-501 is **the canonical install site** for new bridges: console (425-432), DOM mouse events (438-459), native focus (473-483), native click (491-501). The new dialog bridge attaches at the same site, immediately after the existing setFocusCallback / setClickCallback registrations.
+
+- **`WebViewLightweightComponent`** (`src/ca/weblite/webview/swing/WebViewLightweightComponent.java`) — wraps an `OffscreenWebView`; peer created lazily in `addNotify()` (around line 209). Mirrors the heavyweight install site for the console + mouse bridges. The same dialog-callback installation pattern lands here for STORY-004-002's lightweight path.
+
+- **`EmbeddedWebView`** (referenced from heavyweight component) — JNI wrapper over the heavyweight native peer. Currently exposes `setFocusCallback(WebViewFocusCallback)` (used in `createPeer` at line 473) and `setClickCallback(WebViewClickCallback)` (line 491). **These are the two existing precedents for fire-and-forget Java callbacks the native code invokes.** The new dialog callback needs a similar setter (`setDialogCallback(WebViewDialogCallback)`) but with a critical difference: it must return values synchronously (alert: void; confirm: boolean; prompt: String-or-null; file picker: String[]). Neither existing callback returns anything.
+
+- **`OffscreenWebView`** — JNI wrapper over the offscreen peer. Already exposes `addOnBeforeLoad`, `addJavascriptCallback`, `eval`, `dispatch`. **Does not currently have a focus or click callback setter** — those are heavyweight-only because the lightweight engine sees mouse / focus events through AWT, not from the native side. The new dialog callback must be added to both engines because the native browser-engine callbacks for dialogs originate inside WebKit/WebView2 regardless of the embedding model.
+
+- **`WebViewNative`** (`src/ca/weblite/webview/WebViewNative.java`) — the JNI surface. Current callback-setter entry points: `webview_embed_set_focus_callback(long w, WebViewFocusCallback cb)` (line 228), `webview_embed_set_click_callback(long w, WebViewClickCallback cb)` (line 243). **The new dialog dispatcher introduces two new native entry points**: `webview_embed_set_dialog_callback(long w, WebViewDialogCallback cb)` for heavyweight and `webview_offscreen_set_dialog_callback(long peer, WebViewDialogCallback cb)` for offscreen.
+
+- **`WebViewFocusCallback`** / **`WebViewClickCallback`** (`src/ca/weblite/webview/WebViewFocusCallback.java`, `WebViewClickCallback.java`) — single-method functional interfaces. **Both explicitly document "callback invoked from a native thread (AppKit main thread on macOS / GTK main on Linux / WebView2 worker on Windows); implementations MUST marshal to the EDT themselves before touching any Swing state."** This story's `WebViewDialogCallback` follows the same JNI contract but the implementation lives inside the new `DialogDispatcher` rather than each Swing subclass, so individual users never see the native-thread invocation — they see only the EDT-marshalled `WebViewDialogHandler` callback.
+
+- **`ConsoleDispatcher`** (`src/ca/weblite/webview/ConsoleDispatcher.java`) — canonical fan-out hub: `CopyOnWriteArrayList<Listener>` registry, `dispatch(rawJson)` decoding entry point, `deliverOnEdt(msg)` EDT-marshal helper, per-listener `try/catch` isolation forwarding to `Thread.getDefaultUncaughtExceptionHandler()` (lines 235-241). **The new `DialogDispatcher` mirrors this class structurally** for the listener registry + EDT marshaling pattern, but diverges in two critical ways: (a) it uses `invokeAndWait`, not `invokeLater`, because the native side waits for the answer, and (b) it holds a single handler reference (`setHandler`), not a listener list, because dialog requests need a single resolver not fan-out.
+
+- **`WebViewMouseDispatcher`** (`src/ca/weblite/webview/WebViewMouseDispatcher.java`) — second canonical fan-out hub. Adds the `FlagSink` pattern for pushing JS-side state changes (the `__webview_dom_event_suppress` flag) to the live peer. **The dialog work does not need a FlagSink** — there is no JS-side state to mirror; the suppression is enforced at the native delegate / signal level, not in JavaScript.
+
+- **`EvalDispatcher`** (`src/ca/weblite/webview/EvalDispatcher.java`) — third dispatcher precedent. Introduces the `marshalToEdt` constructor flag (line 137) distinguishing standalone-`WebView` (no Swing in the picture) from `WebViewComponent` (EDT marshaling required). **For dialog handling we only care about the embedded surface** — STORY-004-001 explicitly scopes out the standalone `WebView` class (line 134 of the requirements) — so the dispatcher hard-codes EDT marshaling and skips the `marshalToEdt` flag.
+
+- **JS-binding bridge** — every engine routes binding calls through a `{name, seq, args}` JSON envelope. **Not relevant to this story** — dialog requests come from native browser-engine callbacks (`WKUIDelegate` methods / `WebKitWebView` signals / `ICoreWebView2_add_ScriptDialogOpening`), not from page-injected JS. The reserved `__webview_*` prefix and `addJavascriptCallback` are untouched.
+
+- **Native engine creation paths** —
+  - macOS: `cocoa_create_engine` in `src_c/webview_embed.cpp` (line 1951). The `WKWebView` is alloc'd at line 1989 against a `WKWebViewConfiguration` (line 1987). **The `uiDelegate` is never assigned** — confirmed by grep. The new ObjC `WKUIDelegate` class is registered alongside the existing `WKScriptMessageHandler` registration (line 2083) by adding `msg<void,id>(e->webview, sel("setUIDelegate:"), ui_delegate);` after the delegate instance is constructed. The class can be installed via the same once-per-JVM cached-Class pattern `get_webview_embed_delegate_cls()` uses for the script-message delegate (line 1684).
+  - Linux: `gtk_create_engine` (heavyweight, around line 529) and `gtk_create_offscreen_engine` (lightweight, around line 1023) — both create the `WebKitWebView` via `webkit_web_view_new()`. Existing `g_signal_connect` calls hook `load-changed`, `load-failed`, GTK gesture-pressed, and the GdkFrameClock paint signals. **No `script-dialog` or `run-file-chooser` signal handlers exist** — this story adds two `g_signal_connect` calls per engine. Returning `TRUE` from each handler suppresses the default GTK behaviour (story Constraint).
+  - Windows: `windows/webview_embed.cc` — settings acquired around line 422 (`ICoreWebView2Settings *settings`), where this story adds `settings->put_AreDefaultScriptDialogsEnabled(FALSE)`. Event handler registration follows the existing `FocusHandler` precedent (lines 449-454) — a small C++ class implementing `ICoreWebView2ScriptDialogOpeningEventHandler`, instantiated and registered via `webview->add_ScriptDialogOpening`.
+
+- **`SwingUtilities.getWindowAncestor`** — the existing pattern used implicitly anywhere a modal anchor is needed. The default `WebViewDialogHandler` uses this to find the host `JFrame`; the four `JOptionPane` / `JFileChooser` calls take it as the first argument.
+
+- **JUnit 4** (`pom.xml:43-49`) — the only test dependency. Existing test files (`EvalDispatcherTest.java`, `JavaScriptEvalExceptionTest.java`) follow a unit-test style without spinning up a real engine — they exercise the dispatcher Java surface directly. The new `DialogDispatcher` test will follow the same shape.
+
+### New Concepts Required
+
+- **`ca.weblite.webview.WebViewDialogHandler`** — public interface with four `default` methods, all EDT-invoked: `alertOpened(WebViewAlertEvent)` returning void; `confirmOpened(WebViewConfirmEvent)` returning `boolean`; `promptOpened(WebViewPromptEvent)` returning `String` (or `null` for cancel); `filePickerOpened(WebViewFilePickerEvent)` returning `java.util.List<java.io.File>`. The default implementations call `JOptionPane.showMessageDialog`, `showConfirmDialog`, `showInputDialog`, and a configured `JFileChooser` respectively — all anchored on `SwingUtilities.getWindowAncestor(event.source())`.
+
+- **`ca.weblite.webview.WebViewAlertEvent`** — immutable POJO: `source` (`WebViewComponent`), `message` (`String`), `pageUrl` (`String`), `frameUrl` (`String`). Constructed by `DialogDispatcher` from the native payload.
+
+- **`ca.weblite.webview.WebViewConfirmEvent`** — same fields as `WebViewAlertEvent`. (Could be unified into a single base class but the requirements list them as four distinct types for caller clarity; keep them separate per the requirements.)
+
+- **`ca.weblite.webview.WebViewPromptEvent`** — `source`, `message`, `defaultValue`, `pageUrl`, `frameUrl`.
+
+- **`ca.weblite.webview.WebViewFilePickerEvent`** — `source`, `multiple` (boolean), `acceptedExtensions` (`List<String>` — lower-case, leading dot omitted), `acceptedMimeTypes` (`List<String>`), `pageUrl`, `frameUrl`.
+
+- **`ca.weblite.webview.DialogDispatcher`** — per-component fan-out hub holding the single `WebViewDialogHandler` reference plus the four dispatch entry points called from JNI. Public-because-cross-package (matches `ConsoleDispatcher` / `WebViewMouseDispatcher`). Owns the `WebViewComponent source` reference for event-construction (matches `WebViewMouseDispatcher` constructor).
+  - `setHandler(WebViewDialogHandler handler)` — replacing setter; `null` installs a `DROP` handler whose methods return void / false / null / empty without UI.
+  - `getHandler()` — never returns null; returns the framework default when no caller has set one.
+  - Native-facing dispatch entry points (one per dialog kind) returning the answer synchronously:
+    - `void dispatchAlert(String message, String pageUrl, String frameUrl)`
+    - `boolean dispatchConfirm(String message, String pageUrl, String frameUrl)`
+    - `String dispatchPrompt(String message, String defaultValue, String pageUrl, String frameUrl)`
+    - `String[] dispatchFilePicker(boolean multiple, String[] mimeTypes, String[] extensions, String pageUrl, String frameUrl)`
+  - Each `dispatch*` method uses `SwingUtilities.invokeAndWait` to hop to the EDT, invokes the handler, and returns the captured value. Handler exceptions are caught, forwarded to the default uncaught-exception handler, and the dispatch returns a safe fallback (void / false / null / empty) so the native completion handler / deferral is never left dangling.
+
+- **`ca.weblite.webview.WebViewDialogCallback`** — internal-ish single-method functional interface called from JNI. Likely simplest as one method per dialog kind on a single interface, all of which return the answer synchronously. Matches the `WebViewFocusCallback` / `WebViewClickCallback` pattern but with return values. The Java implementation in `WebViewComponent`'s `createPeer` / `addNotify` site is a one-liner delegating to the per-component `DialogDispatcher`.
+
+- **`ca.weblite.webview.WebViewDialogHandler.DEFAULT`** — shared stateless default instance whose four methods invoke the interface defaults (which in turn show Swing dialogs). Returned by `getDialogHandler()` when no caller has installed a custom handler.
+
+- **New JNI native methods on `WebViewNative`** —
+  - `native static void webview_embed_set_dialog_callback(long w, WebViewDialogCallback cb)` — for the heavyweight engines (macOS, Linux heavyweight, Windows).
+  - `native static void webview_offscreen_set_dialog_callback(long peer, WebViewDialogCallback cb)` — for the Linux lightweight offscreen engine.
+
+- **Native delegate / signal-handler / event-handler classes** —
+  - macOS: an ObjC class implementing the four `WKUIDelegate` selectors (`runJavaScriptAlertPanelWithMessage:`, `runJavaScriptConfirmPanelWithMessage:`, `runJavaScriptTextInputPanelWithPrompt:`, `runOpenPanelWithParameters:`). Lives in `src_c/webview_embed.cpp` alongside `get_webview_embed_delegate_cls()` (the existing `WKScriptMessageHandler` class).
+  - Linux: two static C functions registered via `g_signal_connect(WEBKIT_WEB_VIEW(e->web), "script-dialog", ...)` and `g_signal_connect(WEBKIT_WEB_VIEW(e->web), "run-file-chooser", ...)`. Both in `src_c/webview_embed.cpp`, hooked from inside both `gtk_create_engine` and `gtk_create_offscreen_engine`.
+  - Windows: a C++ class `ScriptDialogHandler : public ICoreWebView2ScriptDialogOpeningEventHandler` in `windows/webview_embed.cc`, registered via `webview->add_ScriptDialogOpening` next to the existing `add_WebMessageReceived` site.
+
+- **Reserved binding name `__webview_dialog`** — **not introduced.** Dialogs do not flow through a JS binding; the engines emit native callbacks. The existing `RESERVED_BINDING_PREFIX` discipline is untouched by this story.
+
+### Conceptual Relationships
+
+- `WebViewComponent` owns a `DialogDispatcher` for its entire lifetime — same lifecycle as `consoleDispatcher` and `mouseDispatcher`. The `protected final DialogDispatcher dialogDispatcher = new DialogDispatcher(this)` field is initialised at construction so a caller can call `setDialogHandler` before the component is displayed.
+
+- The dispatcher owns the single `WebViewDialogHandler` reference. Setting `null` installs an internal `DROP` handler that suppresses dialogs without UI; setting a non-null handler replaces. There is **no listener-list semantic** (deliberate divergence from `ConsoleDispatcher` / `WebViewMouseDispatcher`) because a dialog request needs exactly one answer.
+
+- Pre-display handler registration is buffered trivially: the handler reference lives in the Java-side dispatcher; the JNI callback isn't wired until peer-attach. If a dialog somehow fires before the peer attaches (impossible in practice — no page loaded yet means no `alert` call), the native side has no callback to invoke and the engine's own default fires. There is no "pre-attach dialog event queue" because dialogs are synchronous and there's no JS in flight before the page loads.
+
+- The native callback (`WebViewDialogCallback`) is invoked synchronously from the native UI thread — AppKit main on macOS, GTK pump on Linux, WebView2 worker on Windows. The Java implementation in the Swing subclass's peer-attach site is a one-line `dialogDispatcher.dispatch*(...)` call. The dispatcher does the EDT hop via `SwingUtilities.invokeAndWait` and returns the answer. The native side then feeds the answer back to the platform's deferral / completion handler.
+
+- The default `WebViewDialogHandler.DEFAULT` is **stateless** — it just calls `JOptionPane.showMessageDialog(SwingUtilities.getWindowAncestor(event.source()), event.message())` and friends. No per-instance state; safe to share across components and across threads (though it only runs on the EDT regardless).
+
+- The dispatcher is **independent of `ConsoleDispatcher` and `WebViewMouseDispatcher`** — they share class structure but not state, and operate on entirely separate transport channels (the others on JS bindings, this one on native engine callbacks).
+
+- The `WebViewContextMenu` helper (STORY-002-001) is **orthogonal** — it consumes the mouse-event channel; this story consumes a different channel. They coexist without interaction.
+
+- `openDevTools()` and `evalAsync()` are **orthogonal** — neither interacts with dialog dispatch.
+
+### Key Business Rules
+
+- **Single handler per component.** `setDialogHandler(handler)` replaces the active handler verbatim. There is no add/remove listener model. Stories AC10-AC14 (STORY-004-001), AC9 / AC10 (STORY-004-002), AC5-AC8 (STORY-004-003) all derive from this rule.
+
+- **`null` handler = drop semantics.** `setDialogHandler(null)` does not throw and does not restore a "default" — it installs a handler that suppresses all dialog UI and returns the JS-spec cancel values synchronously (void / false / null / empty list). Required for headless tests. Stories STORY-004-001 AC14, STORY-004-002 AC10, STORY-004-003 AC8.
+
+- **`getDialogHandler()` never returns null.** Returns `WebViewDialogHandler.DEFAULT` when no caller has installed one. Story STORY-004-001 AC17.
+
+- **EDT-only handler callbacks.** Every method on the handler runs on the Swing EDT, marshaled from whatever native thread fired the dialog. Stories AC16 (004-001), AC11 (004-002), AC10 (004-003).
+
+- **Modal-to-host-JFrame.** Default Swing dialogs anchor on `SwingUtilities.getWindowAncestor(component)`. If the component is not yet in a window, fall back to anchoring on the component itself (matches `JOptionPane`'s existing fallback). Story STORY-004-001 Constraint + AC1.
+
+- **`before-unload` routes to `confirmOpened`.** Linux's `WEBKIT_SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM` and Windows's `WEBVIEW2_SCRIPT_DIALOG_KIND_BEFOREUNLOAD` both map to `confirmOpened`. No dedicated `beforeUnloadOpened` method is introduced. Stories STORY-004-002 AC12, STORY-004-003 AC9.
+
+- **Default GTK / WebView2 / WKWebView dialogs are fully suppressed once the bridge is installed.** No path exists where the Java handler is invoked AND the native default also shows. Stories STORY-004-002 AC1 / AC2 / AC13 + STORY-004-003 AC1 / AC12.
+
+- **Default `WebViewFilePickerEvent.acceptedExtensions` normalisation.** Lower-case, leading dot stripped, deduplicated. Stories STORY-004-001 AC15, STORY-004-002 AC15.
+
+- **Windows file picker is OS-native, `WebViewFilePickerEvent` does not fire.** Documented limitation; AC4 of STORY-004-003 verifies that the OS dialog still appears for `<input type=file>`.
+
+- **Handler exceptions never leave the dispatcher.** Caught, forwarded to `Thread.getDefaultUncaughtExceptionHandler()` (same pattern as `ConsoleDispatcher` line 235-241), and a safe fallback is returned so the native completion handler / deferral always completes. Stories STORY-004-001 AC20, STORY-004-003 AC13.
+
+## Strategic Approach
+
+### Solution Direction
+
+**Introduce a fourth dispatcher (`DialogDispatcher`) following the existing per-component-fan-out-hub pattern, but specialised for synchronous single-resolver semantics. Hook it to a new JNI callback (`WebViewDialogCallback`) installed per peer-attach. Implement the platform-specific callback sites natively in each engine: a `WKUIDelegate` on macOS, two `g_signal_connect` handlers on Linux (both modes), and a `ICoreWebView2ScriptDialogOpeningEventHandler` plus `put_AreDefaultScriptDialogsEnabled(FALSE)` on Windows.**
+
+Cross-cutting Java side (STORY-004-001):
+
+- Add immutable event POJOs (`WebViewAlertEvent`, `WebViewConfirmEvent`, `WebViewPromptEvent`, `WebViewFilePickerEvent`) to `ca.weblite.webview`.
+- Add `WebViewDialogHandler` interface to `ca.weblite.webview` with four `default` methods showing Swing dialogs. Each default uses `SwingUtilities.getWindowAncestor(event.source())` to anchor on the host JFrame.
+- Add `WebViewDialogCallback` interface to `ca.weblite.webview` (internal-ish single-method functional interface; one method per dialog kind, each returning the answer synchronously). Documented as "callback invoked from a native thread; implementations must marshal to EDT" — same wording as `WebViewFocusCallback`.
+- Add `DialogDispatcher` to `ca.weblite.webview`. Holds the single `WebViewDialogHandler` reference (volatile; defaulting to `WebViewDialogHandler.DEFAULT`). Exposes `setHandler`, `getHandler`, and four `dispatch*` methods called from the JNI callback. Each `dispatch*` does the `SwingUtilities.invokeAndWait` EDT hop, captures the handler return value, and returns it. Internal helpers `runOnEdtAndCapture(...)` factor out the boilerplate.
+- Add `setDialogHandler` / `getDialogHandler` to `WebViewComponent` as concrete `final` methods delegating to the per-instance `DialogDispatcher`. Add a `protected final DialogDispatcher dialogDispatcher = new DialogDispatcher(this)` field initialised at construction.
+- Add `webview_embed_set_dialog_callback(long, WebViewDialogCallback)` and `webview_offscreen_set_dialog_callback(long, WebViewDialogCallback)` to `WebViewNative` plus their `EmbeddedWebView` / `OffscreenWebView` wrapper methods.
+
+macOS native side (STORY-004-001):
+
+- Add a `WKUIDelegate` ObjC class to `src_c/webview_embed.cpp` following the `get_webview_embed_delegate_cls()` cached-Class pattern at line 1684. Class implements four selectors:
+  - `webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:` — calls `dialogDispatcher.dispatchAlert` via JNI; invokes the completion handler (no args) on AppKit main thread after Java returns.
+  - `webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:` — calls `dispatchConfirm`; invokes completion handler with `BOOL`.
+  - `webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:` — calls `dispatchPrompt`; invokes completion handler with `NSString*` or `nil`.
+  - `webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:` — extracts `allowsMultipleSelection`, `_acceptedMIMETypes`, `_acceptedFileExtensions` (KVC; these are private accessors but documented stable), calls `dispatchFilePicker`; invokes completion handler with `NSArray<NSURL*>*` or `nil`.
+- Assign the delegate to `e->webview` via `msg<void,id>(e->webview, sel("setUIDelegate:"), ui_delegate)` immediately after `WKWebView` alloc/init (line 1989-1992).
+- The delegate stashes the `Engine*` via `objc_setAssociatedObject` so it can find the right Java dispatcher (mirrors the existing pattern at line 2088 for the script-message delegate).
+- Add `cocoa_set_dialog_callback(Engine*, JNIEnv*, jobject)` mirroring `cocoa_set_focus_callback` (line 1923) and `cocoa_set_click_callback` (line 1940).
+- **Critical**: `WKUIDelegate` selectors are invoked on the AppKit main thread, NOT the EDT. Calling `SwingUtilities.invokeAndWait` from the AppKit main thread blocks AppKit; while blocked, AppKit doesn't service its own runloop. The EDT in turn does NOT depend on AppKit servicing its runloop for `JOptionPane.showMessageDialog` to complete (Swing dialogs are pure-Java modal pumps on the EDT — they don't dispatch to AppKit). So invokeAndWait does not deadlock — but the AppKit runloop is paused while the Swing dialog is up, which is exactly the desired behaviour: the WebKit JS thread is also paused, and the page does not get to repaint or run any timers while waiting for the answer. This is correct per the JS contract.
+
+Linux native side (STORY-004-002):
+
+- Add two static C functions to `src_c/webview_embed.cpp`:
+  - `on_script_dialog(WebKitWebView*, WebKitScriptDialog*, gpointer user_data)` — reads dialog type via `webkit_script_dialog_get_dialog_type`, extracts message / default text, calls the appropriate Java `dispatchAlert` / `dispatchConfirm` / `dispatchPrompt` / `dispatchConfirm` (for before-unload, which is also `WEBKIT_SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM`). For alert: no need to set anything, just return TRUE. For confirm / before-unload: `webkit_script_dialog_confirm_set_confirmed(dialog, java_result)`. For prompt: `webkit_script_dialog_prompt_set_text(dialog, java_text)` or leave unset for null/cancel. Returns `TRUE` to suppress GTK default.
+  - `on_run_file_chooser(WebKitWebView*, WebKitFileChooserRequest*, gpointer user_data)` — reads `webkit_file_chooser_request_get_select_multiple`, `webkit_file_chooser_request_get_mime_types_filter`, calls `dispatchFilePicker`. If non-empty result, calls `webkit_file_chooser_request_select_files(request, paths)`; if empty (cancel), calls `webkit_file_chooser_request_cancel(request)`. Returns `TRUE`.
+- Both `g_signal_connect`'d in `gtk_create_engine` (heavyweight, around line 583) AND `gtk_create_offscreen_engine` (lightweight, around line 1045) — same two function pointers, separate registration sites. The `gpointer user_data` carries the `Engine*` pointer so the handler can find its Java callback.
+- Add `gtk_set_dialog_callback(Engine*, JNIEnv*, jobject)` mirroring the macOS one.
+- **Critical**: the signal handler runs on the GTK main thread (the GTK pump thread per the README). EDT marshaling via `SwingUtilities.invokeAndWait` from a non-EDT thread is straightforward. The GTK pump and EDT are independent threads with no mutual blocking dependency — same shape as `WebViewFocusCallback` invocation, which already works.
+
+Windows native side (STORY-004-003):
+
+- In `windows/webview_embed.cc`, at the `ICoreWebView2Settings` site (line 422-428):
+  - Add `settings->put_AreDefaultScriptDialogsEnabled(FALSE);` after the existing settings calls.
+- After `add_WebMessageReceived` registration (line 440), add:
+  - `auto *sh = new ScriptDialogHandler(e); webview->add_ScriptDialogOpening(sh, &e->script_dialog_token); sh->Release();`
+  - Where `ScriptDialogHandler` implements `ICoreWebView2ScriptDialogOpeningEventHandler::Invoke` by: reading `Uri`, `Kind`, `Message`, `DefaultText` from the args; calling `GetDeferral`; spawning a Java dispatch on a worker thread (so the WebView2 worker thread isn't blocked while waiting for EDT — see Risk section); on completion, invoke `Accept` / `put_ResultText` as appropriate; call `Complete` on the deferral. Returns `S_OK`.
+- Store the dialog token in the `Engine` struct alongside the existing `message_token`, `got_focus_token`, `lost_focus_token`.
+- Add `win_set_dialog_callback(Engine*, JNIEnv*, jobject)` for the Java-side hook.
+- **File picker is NOT intercepted** — WebView2 has no public hook. README is updated to document the limitation.
+
+### Key Design Decisions
+
+- **Single handler vs. listener-list.** Trade-off: a listener list (`addDialogListener` / `removeDialogListener`) matches `WebViewMouseListener` and `ConsoleListener`; a single handler is asymmetric with the rest of the codebase. **Recommendation: single handler, accepting the asymmetry.** A dialog request needs ONE answer; multiple listeners would have to merge answers somehow (first wins? last wins? boolean AND/OR?) and every option is surprising. The story explicitly chose this in the requirements (line 80 of the doc) and the API is cleaner. The user's tests treat the dispatch as "answer this question," not "broadcast this event."
+
+- **`SwingUtilities.invokeAndWait` vs. async with `CompletableFuture`-style completion.** Trade-off: `invokeAndWait` is simple and matches the synchronous JS contract directly; `CompletableFuture` round-tripping is more flexible (could be cancelled, could be tested without an EDT) but requires the native code to call back into Java again with the answer. **Recommendation: `invokeAndWait` from the native UI thread.** The native UI thread is *expected* to block while the dialog is open (that's the whole point of a modal dialog), and the JS thread is suspended either way. `invokeAndWait` keeps the dispatcher's API surface tiny. The standalone `WebView` is out of scope for this story (requirements line 134) so we don't need the standalone-no-EDT branch that `EvalDispatcher` has.
+
+- **`invokeAndWait` from inside a `WKUIDelegate` selector — deadlock risk?** The AppKit main thread invokes the delegate; we then `invokeAndWait` to the EDT. The EDT runs `JOptionPane.showMessageDialog(host, ...)` which spins a secondary modal pump on the EDT (Swing's modal-dialog implementation is pure Java — the EDT internally pumps a nested event queue while the dialog is up). The EDT never re-enters AppKit synchronously while pumping; Swing repaints go through Java2D which on macOS does call AppKit asynchronously, but those calls don't block. **Recommendation: `invokeAndWait` is safe.** The AppKit main thread is paused while waiting, which means AppKit doesn't repaint the WKWebView until Java returns — that's the desired behaviour (the page is frozen during the modal dialog). Verified by analogy with `WebViewFocusCallback`: that also fires from AppKit and the receiving Java code already runs on a non-EDT thread, then `invokeLater`s to EDT. The new path adds the wait, which is the only difference, and the EDT does not depend on AppKit.
+
+- **`invokeAndWait` from Linux GTK pump thread — deadlock risk?** The GTK pump runs on its own thread separate from AWT's X11 thread (per README: "A dedicated GTK pump thread drives the WebKitGTK main loop independently of AWT's X11 event loop"). The EDT runs on AWT's main thread. The two are decoupled. EDT shows `JOptionPane`, which under X11 uses AWT's X11 surface — AWT's X11 surface uses AWT's X11 thread, not GTK's pump. **Recommendation: safe.** Lightweight mode is even more decoupled — the offscreen `GtkOffscreenWindow` doesn't talk to X11 at all from the GTK pump's perspective.
+
+- **`invokeAndWait` from Windows WebView2 worker thread — deadlock risk?** Each WebView2 engine has its own worker thread (per README). The EDT is AWT's thread. WebView2's `Accept` / `put_ResultText` / `Complete` calls must be made on the WebView2 worker thread — calling them from the EDT is incorrect. **Recommendation: in the Windows handler, do NOT use `invokeAndWait` synchronously**; instead use `GetDeferral` + spawn the EDT marshal on a separate Java thread that calls `invokeAndWait` to the EDT, captures the result, then dispatches a Runnable back onto the WebView2 worker thread via `webview_embed_dispatch` to complete the deferral. This is the same shape `WebView2` examples use for any deferral that needs UI confirmation. The Java `DialogDispatcher.dispatchAlertAsyncWindows(...)` returns nothing; the native handler holds a `Microsoft::WRL::ComPtr<ICoreWebView2Deferral>` for the duration. (Alternative: block the WebView2 worker thread and rely on no other WebView2 ops running on it during the dialog — risky because the worker also services repaint and JS execution, which we want frozen during the modal *anyway*. Probably **safe**, and simpler than the deferral dance.) **Decision: prefer the synchronous-block approach** unless STORY-004-003 implementation reveals a deadlock; the deferral pattern is the fallback.
+
+- **POJO design: one event class per dialog kind vs. one unified `WebViewDialogEvent`.** Trade-off: four classes keep accessors honest (no `getDefaultValue()` on an `AlertEvent`); one unified class with a `type` discriminator is more compact but invites accessor-on-wrong-event-kind bugs. **Recommendation: four classes per the requirements.** Matches what STORY-002-001 chose with `WebViewMouseEvent` (single class) versus splitting per event kind — the story explicitly asked for four POJOs.
+
+- **Event source: pass `WebViewComponent` reference vs. opaque token.** Trade-off: passing the component reference is convenient (handler can call `SwingUtilities.getWindowAncestor(event.source())`) but couples the event POJO to the Swing API; an opaque token would let the same event type ship in a hypothetical future standalone-`WebView` path. **Recommendation: pass `WebViewComponent` reference.** The story explicitly scopes out the standalone `WebView` path, and the convenience is the whole reason the default handler can show modal dialogs without callers wiring the anchor.
+
+- **`acceptedMimeTypes` / `acceptedExtensions` normalisation.** Trade-off: ship the raw `accept` attribute strings to Java (more flexibility) vs. normalise in the native layer (consistent across platforms). **Recommendation: normalise in the dispatcher (Java side).** The native layer reports what each platform makes available (`acceptedMIMETypes` + `acceptedFileExtensions` on WKOpenPanelParameters; `webkit_file_chooser_request_get_mime_types`/`..._mime_types_filter` on Linux; not available on Windows). The Java dispatcher canonicalises: lowercase, strip leading dot, dedupe, split on `,`. Story STORY-004-001 NF-expectation explicitly requires this normalisation.
+
+- **STORY-004-002 wiring: separate functions per mode vs. shared.** Trade-off: heavyweight (`gtk_create_engine`) and lightweight (`gtk_create_offscreen_engine`) both create a `WebKitWebView`; the `script-dialog` / `run-file-chooser` signals are identical. Sharing is straightforward (two static C functions, two `g_signal_connect` sites). **Recommendation: shared functions, separate registration sites.** Mirrors the existing `gtk_create_engine` / `gtk_create_offscreen_engine` split for the rest of the engine setup.
+
+- **STORY-004-003: full-functionality or partial?** The WebView2 file picker can't be intercepted, but the three script dialogs can. Trade-off: ship STORY-004-003 with the documented limitation (today's plan) vs. defer the entire Windows story until the file picker can also be intercepted somehow. **Recommendation: ship with documented limitation.** Three of four dialog kinds covered on Windows is materially more value than zero, and the file picker continues to work via WebView2's OS-native dialog — it just doesn't fire `filePickerOpened` on Windows. README documents the limitation. AC4 of STORY-004-003 explicitly verifies the unchanged file-picker behaviour.
+
+### Alternatives Considered
+
+- **JavaScript-shim approach** (intercept `window.alert` etc. via an `addOnBeforeLoad` shim, route through a reserved `__webview_dialog` binding) — **rejected.** Three reasons: (a) it can't intercept `<input type=file>` clicks because that's not a JS API the shim can override; (b) `before-unload` is a special browser event, not driven by `window.confirm()`, so the shim wouldn't see it; (c) every platform already provides a clean native-side hook (`WKUIDelegate`, `script-dialog` signal, `add_ScriptDialogOpening`) so using the lower-level path costs us nothing and gives us complete coverage. The shim approach would also be vulnerable to page code re-assigning `window.alert` after our shim runs.
+
+- **Single async `WebViewDialogHandler` interface returning `CompletableFuture<...>` from each method** — **rejected.** Synchronous `JOptionPane.show*` calls are the natural Swing idiom; forcing handlers to return futures pushes complexity onto every caller and gains nothing because the underlying contract is synchronous JS-side. STORY-004-001 explicitly defines synchronous handler signatures (interface declared `default void alertOpened(event)` etc. in the requirements).
+
+- **Per-engine `WKUIDelegate` instance vs. shared singleton.** Could reuse a single ObjC delegate object across all engines by reading `objc_getAssociatedObject(self, "eng")`. **Decision: per-engine.** Matches the existing per-engine pattern used by the script-message delegate (line 2085: `delegate = msg(delegate_cls, sel("new"))` is called once per engine). Adds negligible cost.
+
+- **For Windows: synchronously block worker thread vs. deferral pattern.** Discussed above under Design Decisions.
+
+- **Routing `before-unload` to a dedicated `beforeUnloadOpened` callback** — **rejected for this iteration.** The semantic difference (user has typed something, can lose data on navigation) deserves its own method, but the requirements explicitly defer this. Adding one default method is cheap and could happen as a follow-up; doing it now would expand the API surface for two platforms (Linux + Windows) that the user can already handle via `confirmOpened`. Followup work referenced in STORY-004-002 Scope-Out.
+
+## Risk & Gap Analysis
+
+### Requirement Ambiguities
+
+- **`SwingUtilities.invokeAndWait` from EDT.** What happens if a caller invokes `WebViewComponent` operations from a handler that itself was invoked from `invokeAndWait`? The WKUIDelegate selectors are *not* on the EDT, so the dispatcher calls `invokeAndWait` to hop ONTO the EDT. Inside the handler the EDT IS the current thread. If the handler then calls `wv.dispatch(r)`, no problem — that hops to the native thread. But if the handler calls `wv.evalAsync(js)` and chains a `.thenAccept` continuation on the EDT, and then synchronously waits for it via `.get()`, **the handler deadlocks itself** (EDT waiting for an EDT task). **Resolution**: document in the handler interface Javadoc: "Methods run on the EDT; do not block on `evalAsync(...).get()` or any other EDT-scheduled task from inside the handler." STORY-004-001 should add this to the interface Javadoc and a corresponding NF expectation.
+
+- **Default `WebViewFilePickerEvent.acceptedMimeTypes` empty vs. null vs. wildcard.** When the page's `<input type="file">` has no `accept` attribute, the WebKit / WebView2 API surfaces an empty list or null for accepted MIME types. The requirements say `acceptedMimeTypes` returns a `List<String>` but don't specify the empty-list contract precisely. **Resolution**: the list is never null; it's empty when no `accept` attribute is set. Document this on the POJO Javadoc. AC15 of STORY-004-001 doesn't check the empty case but the default `JFileChooser` impl needs to handle it.
+
+- **What does `frameUrl` report when the dialog originates from a worker or a `srcdoc` iframe?** Workers can't call `alert` (no DOM), but `srcdoc` iframes can. WKWebView reports `initiatedByFrame.request.URL` which is `about:srcdoc` for srcdoc iframes; WebKitGTK reports the same; WebView2's `Uri` property gives the iframe URL. **Resolution**: `frameUrl` carries whatever the platform reports — `about:srcdoc` for srcdoc, the iframe URL for normal iframes, equals `pageUrl` for top-level. Document on the POJO Javadoc.
+
+- **Multi-select file picker file order.** AC8 of STORY-004-001 says `files[0].name = "a.png"` and `files[1].name = "b.png"` — implies an ordering. Native order depends on `JFileChooser.getSelectedFiles()` (which returns whatever order the user selected them in, OS-dependent). **Resolution**: pass the order verbatim from `JFileChooser.getSelectedFiles()` to the platform completion handler; the platforms preserve order. AC8 should be read as "the two selected files appear in the page's `files` collection" (order matching JFileChooser order); not a strict alphabetical guarantee. Tighten the AC wording, or accept "in selection order" as the implicit contract.
+
+- **`getDialogHandler()` returning `DEFAULT` when caller installed a custom handler.** AC17 of STORY-004-001 says `getDialogHandler()` returns "the framework's default handler instance" when no caller has set one. But what if a caller has called `setDialogHandler(custom)` and then `setDialogHandler(null)`? Returns the DROP handler? The DEFAULT? **Resolution**: `setDialogHandler(null)` installs the DROP handler, NOT a reset to DEFAULT. `getDialogHandler()` then returns the DROP handler. To reset to DEFAULT, callers explicitly pass `WebViewDialogHandler.DEFAULT`. Document on the setter.
+
+- **AC4 of STORY-004-003** says the standard Windows file dialog "appears as today" — but does the test verify the WebView2's built-in file picker (which is what `<input type=file>` actually opens, not the Common Item Dialog directly)? **Resolution**: WebView2 opens the OS-native `IFileOpenDialog` (Common Item Dialog) under the hood; the test simply confirms that a system file dialog appears and a selection round-trips into the page's `files` collection. AC wording is acceptable; treat "Common Item Dialog" as descriptive, not prescriptive.
+
+### Edge Cases
+
+- **Page calls `alert` from `unload` or `pagehide`.** WKWebView refuses to show alerts from `pagehide` (engine-enforced). The delegate may still be called for legitimate `beforeunload` confirmations. **Behaviour**: as long as the delegate is invoked, the dispatcher fires; if the engine drops the request before reaching the delegate, the page sees the JS-spec default (alert returns undefined, confirm returns false). No code change needed.
+
+- **Page calls multiple `alert`s in rapid succession.** Each `alert` blocks the JS thread until the previous returns. The native delegate is called once per alert; the dispatcher serially handles each. **Behaviour**: queue-of-one — the second `alert` doesn't fire its delegate until the first completes. No code change needed; just verify in AC.
+
+- **Multiple `WebViewComponent`s in the same JFrame, both showing alerts simultaneously.** Each component has its own `DialogDispatcher`. Each Swing dialog anchors on the same host JFrame and is `Dialog.ModalityType.DOCUMENT_MODAL` to that frame. JOptionPane's modal pump on the EDT processes one at a time. **Behaviour**: the second `JOptionPane.show*` call queues until the first dismisses. The native JS thread of the second component remains blocked. No deadlock — the EDT eventually pumps both. NF expectation should call this out.
+
+- **Handler returns null from `promptOpened`** — that's the cancel semantic, but what if the handler is implemented buggy-ly and throws NullPointerException? The dispatcher's try/catch catches it; returns null fallback. AC20 of STORY-004-001 covers this.
+
+- **Native callback fires after `WebViewComponent.dispose()` has been called.** Java side has released the global ref; native side calls back into a stale JNI handle. **Behaviour**: native code must check for null-callback before invoking. The existing `cocoa_set_focus_callback` / `cocoa_set_click_callback` patterns already null-check (`if (!e->focus_callback) return`); the new `cocoa_set_dialog_callback` must do the same. On disposal, the native completion handler is still invoked with a safe fallback (alert: no-op; confirm: NO; prompt: nil; open-panel: nil) so the engine doesn't hang.
+
+- **Handler shows a Swing dialog that triggers an internal `WebViewComponent` operation.** E.g. the user clicks a button in `confirmOpened`'s rendered dialog that calls `wv.setUrl(...)`. The handler is on the EDT; `setUrl` is allowed from the EDT (it dispatches to the native UI thread). **Behaviour**: works. But note: the native UI thread is currently blocked in the `WKUIDelegate` selector waiting for our return. So the new `setUrl` enqueues a navigation request that won't be serviced until the delegate returns. Caller may observe a delay. Document as a "don't do this" note in the Javadoc, but not a hard error.
+
+- **Page calls `prompt(null, undefined)`** — the JS spec coerces both args to strings; `prompt(null)` shows a dialog with message "null". The native delegate sees this verbatim. **Behaviour**: the dispatcher carries the coerced strings; the Swing dialog displays them as text. No special handling.
+
+- **Handler returns a non-existent file path from `filePickerOpened`.** The native side passes the file path to the platform completion handler (`NSArray<NSURL*>*` on macOS, `webkit_file_chooser_request_select_files` on Linux); the engines accept the path and the page's `files` collection contains a `File` object with that name. Whether the file is actually readable is a separate concern (the page's subsequent `FileReader` may fail). **Behaviour**: caller's responsibility. Document on the handler Javadoc.
+
+- **Page is destroyed mid-dialog.** The handler's modal `JOptionPane` is still showing on the EDT, but `WebViewComponent.dispose()` was called from another thread. The native completion handler is gone; calling back into it would crash. **Behaviour**: the dispatcher's `dispatch*` methods must check `disposed` flag before invoking the handler AND before returning. If disposed mid-flight, dismiss the Swing dialog programmatically (call `dialog.dispose()` on the EDT), return the safe fallback, and the native side must check `disposed` before invoking the completion handler. This is a small extra plumbing concern. Map to a NF expectation: "Disposal during an open dialog dismisses the dialog and does not crash."
+
+- **Page calls `alert` from a `MessageChannel`-posted message handler.** The handler can run synchronously inside the engine's microtask queue. The native delegate is still invoked; the dispatcher behaves identically. No special handling.
+
+### Technical Risks
+
+- **macOS `WKOpenPanelParameters._acceptedMIMETypes` / `_acceptedFileExtensions` are private API.** These accessors are not documented public; using them via KVC (`[parameters valueForKey:@"_acceptedMIMETypes"]`) works on macOS 10.12+ but could break in a future macOS release. **Mitigation**: wrap the KVC read in `@try`/`@catch`; fall back to empty list if missing. Document the limitation. Alternative: probe `parameters.respondsToSelector(@selector(...))` for a public alternative if any future macOS exposes one.
+
+- **JNI synchronous round-trip with `SwingUtilities.invokeAndWait` from non-EDT.** Established pattern in Swing apps for decades — not novel. Risk is low.
+
+- **Windows WebView2 worker thread blocking.** Synchronously blocking the worker thread inside the `ScriptDialogOpening` event is unusual; the WebView2 SDK examples use `GetDeferral` for any wait. **Mitigation**: implement the deferral pattern from the start. The native handler stashes the deferral, dispatches the Java call onto a worker thread (or directly invokes `dispatchAlertWindowsAsync` which does `invokeAndWait` to EDT), and on completion the answer is written back to the deferral via `webview_embed_dispatch` to hop back onto the WebView2 worker. Slightly more code than blocking-synchronous; safer.
+
+- **Linux `webkit_script_dialog_*` API version differences.** WebKitGTK 2.x has stable signal names but the dialog's accessor functions may differ between 2.0 and 2.1 (the codebase supports both — README mentions `libwebkit2gtk-4.0-dev` and `libwebkit2gtk-4.1-dev`). **Mitigation**: use only the long-stable accessors (`webkit_script_dialog_get_dialog_type`, `..._get_message`, `..._prompt_get_default_text`, `..._confirm_set_confirmed`, `..._prompt_set_text`). All these have been in WebKitGTK since 2.0. No `webkit_script_dialog_ref` / `webkit_script_dialog_close` needed because the synchronous return model is sufficient — the dialog object stays alive while the signal handler runs.
+
+- **`<input type=file>` on Linux returning a single-element list when `multiple` is true.** WebKitGTK's `webkit_file_chooser_request_select_files` always takes a list; multiplicity is up to the page. No issue.
+
+- **Default `JFileChooser` modality.** `JFileChooser` shown via `showOpenDialog(component)` is automatically modal to the component's window. Same as `JOptionPane`. No special handling.
+
+- **Coordinate / DPI scaling.** Not relevant for this story — Swing dialogs use platform-native rendering and don't need viewport coordinate translation. The mouse-event story had to handle this; dialogs don't.
+
+- **`SwingUtilities.invokeAndWait` throwing `InterruptedException` / `InvocationTargetException`.** The dispatcher must catch both; on `InterruptedException`, restore the interrupt flag and return safe fallback; on `InvocationTargetException`, surface the wrapped exception via `Thread.getDefaultUncaughtExceptionHandler()` and return safe fallback. NF expectation: handler exceptions never leave the dispatcher.
+
+- **The `WebViewDialogCallback` Java interface design (one method per dialog kind vs. one variadic method).** One method per kind keeps types tidy but means the JNI signature is split across four `CallVoidMethod` / `CallBooleanMethod` / `CallObjectMethod` / `CallObjectMethod` invocations from C. **Mitigation**: define the interface with four explicit methods; the native side caches the `jmethodID` for each at setup time. Adds ~50 lines of native code vs. a variadic single method, but is straightforward and the existing native code already caches method IDs (used by `fire_click_callback` line 166).
+
+### Acceptance Criteria Coverage
+
+**STORY-004-001 (Java API contract + macOS coverage) — 20 ACs:**
+
+| AC# | Description | Addressable? | Gaps/Notes |
+|-----|-------------|--------------|------------|
+| 1 | Default alert handler shows Swing dialog | Yes | Standard Swing `JOptionPane.showMessageDialog(host, ...)`; modal-to-frame. |
+| 2 | Default confirm OK returns true | Yes | `JOptionPane.OK_OPTION` mapping. |
+| 3 | Default confirm Cancel returns false | Yes | Same path; `CANCEL_OPTION` returns false. |
+| 4 | Default prompt entered text | Yes | `JOptionPane.showInputDialog`. |
+| 5 | Default prompt null on cancel | Yes | `showInputDialog` returns null on cancel. |
+| 6 | Default prompt default value pre-filled | Yes | Third arg of `showInputDialog`. |
+| 7 | Default file picker single-file | Yes | `JFileChooser` without multi-selection. |
+| 8 | Default file picker multi-file | Yes | `setMultiSelectionEnabled(true)` + `getSelectedFiles()`. |
+| 9 | Default file picker accept filter | Yes | `FileNameExtensionFilter` from `acceptedExtensions`. |
+| 10 | Custom alertOpened replaces default | Yes | Handler is single-resolver; replacement is direct. |
+| 11 | Custom confirmOpened programmatic | Yes | Handler returns boolean. |
+| 12 | Custom promptOpened programmatic | Yes | Handler returns String. |
+| 13 | Custom filePickerOpened programmatic | Yes | Handler returns `List<File>`. |
+| 14 | setDialogHandler(null) suppresses | Yes | DROP handler returns safe defaults; no UI. |
+| 15 | WebViewFilePickerEvent multiple + accept hints | Yes | POJO accessors. |
+| 16 | Handler callbacks on EDT | Yes | Dispatcher uses `invokeAndWait`. |
+| 17 | getDialogHandler never returns null | Yes | DEFAULT is the no-op initial state. |
+| 18 | pageUrl / frameUrl populated | Yes | Native delegate extracts `initiatedByFrame.request.URL`. |
+| 19 | Iframe URL surfaces as frameUrl | Yes | Same path; iframe's `initiatedByFrame.request.URL` differs from top-level. |
+| 20 | Handler exception does not crash WebKit | Yes | Dispatcher catches and forwards to uncaught-exception handler. |
+
+All 20 addressable; no gaps.
+
+**STORY-004-002 (Linux coverage) — 16 ACs:**
+
+| AC# | Description | Addressable? | Gaps/Notes |
+|-----|-------------|--------------|------------|
+| 1 | alert fires on heavyweight | Yes | Signal handler installed in `gtk_create_engine`. |
+| 2 | alert fires on lightweight | Yes | Signal handler installed in `gtk_create_offscreen_engine`. |
+| 3 | confirm OK both modes | Yes | Same path. |
+| 4 | confirm Cancel both modes | Yes | Same path. |
+| 5 | prompt entered text both modes | Yes | Same path. |
+| 6 | prompt null on cancel | Yes | `webkit_script_dialog_prompt_set_text` not called for cancel; engine spec returns null. |
+| 7 | File picker multi + accept on lightweight | Yes | `run-file-chooser` signal handler. |
+| 8 | File picker on heavyweight | Yes | Same handler, separate registration. |
+| 9 | Custom handler replaces default | Yes | Same dispatcher path as macOS. |
+| 10 | setDialogHandler(null) does not freeze | Yes | DROP handler returns safe defaults. AC asserts "logs three lines through console-capture channel" — verifiable via existing console plumbing. |
+| 11 | Handler callbacks on EDT | Yes | Dispatcher uses `invokeAndWait`. |
+| 12 | before-unload routes to confirmOpened | Yes | `script-dialog` signal covers BEFORE_UNLOAD_CONFIRM; dispatcher maps it to `dispatchConfirm`. |
+| 13 | Default GTK dialogs suppressed | Yes | Handlers return TRUE. |
+| 14 | Heavyweight + lightweight identical behaviour | Yes | Same dispatcher, same JNI surface, same event POJOs. |
+| 15 | WebViewFilePickerEvent accept hints | Yes | `webkit_file_chooser_request_get_mime_types_filter` extraction. |
+| 16 | Empty list cancels file picker | Yes | `webkit_file_chooser_request_cancel` for empty result. |
+
+All 16 addressable; AC10's "no `gdk_window_move_to_rect` warning" check requires careful stderr inspection during testing — flag as a "verify in dev environment" note, not a code-level concern.
+
+**STORY-004-003 (Windows coverage) — 13 ACs:**
+
+| AC# | Description | Addressable? | Gaps/Notes |
+|-----|-------------|--------------|------------|
+| 1 | Default alert handler shows Swing dialog | Yes | `add_ScriptDialogOpening` + EDT marshal. |
+| 2 | Default confirm OK / Cancel | Yes | `Accept` for OK, leave un-accepted for Cancel (engine cancels). |
+| 3 | Default prompt entered text / cancel | Yes | `put_ResultText` then `Accept`. |
+| 4 | <input type=file> opens OS-native | Yes | We do nothing for file picker; default behaviour persists. |
+| 5 | Custom alertOpened replaces default | Yes | Same dispatcher path. |
+| 6 | Custom confirmOpened programmatic | Yes | Same. |
+| 7 | Custom promptOpened programmatic | Yes | Same. |
+| 8 | setDialogHandler(null) suppresses | Yes | DROP handler returns safe defaults; deferral completed without `Accept`. |
+| 9 | before-unload routes to confirmOpened | Yes | `Kind == BEFOREUNLOAD` mapped to `dispatchConfirm`. |
+| 10 | Handler callback on EDT | Yes | Dispatcher uses `invokeAndWait` from worker thread. |
+| 11 | pageUrl / frameUrl populated | Yes | `ICoreWebView2ScriptDialogOpeningEventArgs::get_Uri`. |
+| 12 | Built-in WebView2 dialogs do not appear | Yes | `put_AreDefaultScriptDialogsEnabled(FALSE)` at engine creation. |
+| 13 | Handler exception completes deferral | Yes | Dispatcher's try/catch; native handler always calls `Complete` on the deferral. |
+
+All 13 addressable. **Gap on AC11**: `Uri` corresponds to the top-level page URL; WebView2 does not expose a separate frame URL on the dialog event args. **Resolution**: on Windows, `frameUrl()` equals `pageUrl()` for now (top-level only). Document on the POJO Javadoc / README. AC11 only verifies the top-level case so the resolution is consistent with the AC wording.
+
+### Open Questions
+
+1. **The `WebViewDialogCallback` Java interface shape**: one method per dialog kind, vs. a single method dispatching on a discriminator? Both work; the former is more type-safe but adds 4 JNI signatures to cache. **Recommendation: one method per kind**, matching the four `dispatch*` methods on `DialogDispatcher`. To be confirmed during canvas authoring.
+
+2. **`WebViewDialogHandler` interface placement**: in `ca.weblite.webview` (next to `ConsoleListener`, `WebViewMouseListener`) vs. `ca.weblite.webview.swing` (closer to where it's used and depends on Swing). **Recommendation: `ca.weblite.webview`**, matching the other handler/listener interfaces. The fact that its `default` methods use `JOptionPane` makes the package depend on Swing, but the existing dispatchers already do (`SwingUtilities.invokeLater`).
+
+3. **Standalone `WebView` integration**: the requirements scope it out (line 134), but the standalone `WebView` also embeds a native engine that's subject to the same `alert` / `confirm` / `prompt` issue on macOS. **Decision: out of scope per requirements.** A follow-up story can mirror the API onto standalone `WebView` if asked.
+
+4. **README documentation updates**: STORY-004-003 explicitly requires a README note about the Windows file-picker limitation. STORY-004-001 and STORY-004-002 should also describe the new API in the existing "Talking to JavaScript" / "Quick start" sections. **Decision: include README updates in each story's canvas Operations.** This is consistent with previous canvases (STORY-002-001 updated README via Operation 10).
+
+5. **Demo program**: STORY-002-001 shipped `WebViewContextMenuDemo`. Should this story ship a `WebViewDialogDemo`? **Recommendation: yes** — a single small demo that exercises all four dialog kinds in both default-handler and custom-handler modes. Cheap to write, exercise-of-the-feature value. Each platform-specific story Operations should add or extend the demo as appropriate.
+
+6. **Test strategy**: existing tests are unit-tests-without-real-engine (`EvalDispatcherTest`, `JavaScriptEvalExceptionTest`). The dispatcher can be unit-tested by simulating the four native `dispatch*` calls and verifying handler invocation + EDT-thread assertion. The native delegate / signal-handler / event-handler code is integration-tested via the demo and ACs run on actual hardware. **Decision: unit-test `DialogDispatcher` extensively; AC-test the rest on real engines.**

--- a/spdd/prompt/11-20260518-1930-[Feat]-Browser-Initiated-Ui-Dialogs-And-Macos-Coverage.md
+++ b/spdd/prompt/11-20260518-1930-[Feat]-Browser-Initiated-Ui-Dialogs-And-Macos-Coverage.md
@@ -1,0 +1,2010 @@
+---
+generated_at: 2026-05-18T19:30:00-07:00
+---
+
+# REASONS Canvas: Browser-Initiated UI Dialogs (Java API + macOS WKWebView Coverage)
+
+## R · Requirements
+
+- Establish the cross-platform Java contract for browser-initiated UI
+  dialogs originating inside the embedded page (`window.alert`,
+  `window.confirm`, `window.prompt`, `<input type="file">` clicks), and
+  ship a working macOS WKWebView implementation of that contract.
+  Today macOS is silently broken: `cocoa_create_engine` in
+  `src_c/webview_embed.cpp:1951` creates a `WKWebView` (line 1989) with
+  no `uiDelegate` assigned, so the engine drops alert / confirm /
+  prompt requests and `<input type="file">` clicks open no picker.
+- Expose a single public functional-style interface
+  `ca.weblite.webview.WebViewDialogHandler` with four `default`
+  methods, all EDT-invoked:
+  - `void alertOpened(WebViewAlertEvent)` — default shows
+    `JOptionPane.showMessageDialog`.
+  - `boolean confirmOpened(WebViewConfirmEvent)` — default shows
+    `JOptionPane.showConfirmDialog(OK_CANCEL_OPTION)` and returns
+    `true` for OK.
+  - `String promptOpened(WebViewPromptEvent)` — default shows
+    `JOptionPane.showInputDialog` and returns the entered text
+    (or `null` on cancel).
+  - `List<File> filePickerOpened(WebViewFilePickerEvent)` — default
+    shows a modal `JFileChooser` honouring `multiple()` and
+    `acceptedExtensions()`.
+  All four defaults anchor on `SwingUtilities.getWindowAncestor(event.source())`.
+- Expose four immutable event POJOs in `ca.weblite.webview`
+  (`WebViewAlertEvent`, `WebViewConfirmEvent`, `WebViewPromptEvent`,
+  `WebViewFilePickerEvent`) carrying the event data: source component,
+  message / default value / multiple+accept hints as appropriate, and
+  `pageUrl` + `frameUrl` for per-origin policy decisions.
+- Expose `setDialogHandler(WebViewDialogHandler)` /
+  `getDialogHandler()` on `WebViewComponent` as concrete `final`
+  methods (no abstract overload needed). Passing `null` to the setter
+  installs an internal `DROP` handler whose methods return void /
+  `false` / `null` / empty list synchronously without UI — required
+  for headless tests. `getDialogHandler()` MUST NEVER return `null`;
+  it returns `WebViewDialogHandler.DEFAULT` (the Swing-dialog default
+  instance) when no caller has set one.
+- Wire the contract to the macOS heavyweight engine by attaching a
+  `WKUIDelegate` ObjC class to the `WKWebView`. The delegate
+  implements the four `WKUIDelegate` selectors
+  (`runJavaScriptAlertPanelWithMessage:`,
+  `runJavaScriptConfirmPanelWithMessage:`,
+  `runJavaScriptTextInputPanelWithPrompt:`,
+  `runOpenPanelWithParameters:`) and bridges each to the
+  corresponding `DialogDispatcher.dispatch*` method via a new JNI
+  callback (`WebViewDialogCallback`). After Java returns, the
+  delegate invokes the platform's completion handler with the
+  captured value, releasing the WebKit JS thread.
+- All handler callbacks MUST run on the Swing Event Dispatch Thread.
+  The dispatcher uses `SwingUtilities.invokeAndWait` (NOT
+  `invokeLater` — the native side is suspended waiting for the
+  answer; matches `alert` / `confirm` / `prompt`'s synchronous JS
+  contract). Behaviour matches the existing
+  [[swing-webview-context-menu-and-dom-mouse-events]] EDT contract
+  but with synchronous return semantics.
+- The implementation MUST NOT introduce a JSON-parsing dependency
+  (the project has none — `pom.xml:43-50` declares only JUnit-test
+  dependency). Dialog events are not page-injected JS; no JS shim is
+  installed and no reserved `__webview_*` binding name is added.
+  Communication flows: native engine → JNI callback → Java
+  dispatcher → EDT-marshalled handler → return value → JNI return →
+  native completion handler.
+- The implementation MUST add two new JNI entry points on
+  `WebViewNative`:
+  - `webview_embed_set_dialog_callback(long, WebViewDialogCallback)`
+    — for the heavyweight engine (macOS today; Linux heavyweight
+    and Windows in subsequent canvases).
+  - `webview_offscreen_set_dialog_callback(long, WebViewDialogCallback)`
+    — for the offscreen engine (Linux lightweight in a subsequent
+    canvas; stub no-op on macOS / Windows where the offscreen path
+    is itself a stub).
+  Both entry points follow the existing
+  `webview_embed_set_focus_callback` /
+  `webview_embed_set_click_callback` precedent
+  (`WebViewNative.java:228, 243`).
+- The implementation MUST add `setDialogCallback(WebViewDialogCallback)`
+  to both `EmbeddedWebView` (heavyweight wrapper) and
+  `OffscreenWebView` (offscreen wrapper), mirroring the existing
+  `setFocusCallback` / `setClickCallback` on `EmbeddedWebView`
+  (`EmbeddedWebView.java:311, 330`). Anchoring the callback in the
+  wrapper's `heap` `IdentityHashMap` is required so the JVM does
+  not collect the lambda while the native side holds a global ref.
+- The Linux and Windows native callback sites are explicitly OUT OF
+  SCOPE for this canvas — they land in STORY-004-002 and
+  STORY-004-003. However the Java API and JNI surface introduced
+  here MUST be designed so those two stories can wire their native
+  callbacks without re-shaping the Java side. The Linux offscreen
+  setter must exist (as a stub on macOS / Windows native binaries)
+  so STORY-004-002 can implement it without touching Java again.
+- Definition of Done:
+  - All 20 STORY-004-001 ACs pass on macOS with the new code.
+  - A `WebViewDialogDemo` Swing app under `demos/` exercises all
+    four dialog kinds in both default-handler and custom-handler
+    modes (per analysis open question 5).
+  - README under "Demos" lists the new demo, and the existing
+    "Talking to JavaScript" / mode-selection prose grows a small
+    "Browser-initiated dialogs" subsection documenting the
+    `setDialogHandler` API and the macOS-only coverage caveat for
+    this iteration (Linux / Windows arrive in 004-002 / 004-003).
+  - Unit tests for `DialogDispatcher` validate handler invocation,
+    EDT marshaling, `setHandler(null)` drop semantics,
+    `getHandler() != null` invariant, exception isolation,
+    `WebViewFilePickerEvent.acceptedExtensions` normalisation, and
+    the fallback values produced when the dispatcher is disposed
+    mid-flight. Native delegate code is integration-tested via the
+    demo (consistent with the no-automated-GUI-tests policy from
+    [[swing-webview-context-menu-and-dom-mouse-events]]).
+- Out of scope (explicit non-goals):
+  - Linux WebKitGTK `script-dialog` / `run-file-chooser` signal
+    handlers (STORY-004-002).
+  - Windows WebView2 `add_ScriptDialogOpening` /
+    `put_AreDefaultScriptDialogsEnabled(FALSE)` (STORY-004-003).
+  - The standalone in-process `WebView` class — this canvas only
+    touches the embedded `WebViewComponent` surface. Adding the
+    same API to standalone `WebView` is a future story.
+  - A dedicated `beforeUnloadOpened` handler method. `before-unload`
+    confirmations route through `confirmOpened` on Linux and
+    Windows when those land; on macOS WKWebView there is no
+    separate `WKUIDelegate` selector for before-unload (it goes
+    through `runJavaScriptConfirmPanelWithMessage:` like any other
+    confirm), so the routing is trivial.
+  - `window.open(url, name, features)` popup handling
+    (`WKUIDelegate`'s `createWebViewWithConfiguration:` selector)
+    — a different channel, out of scope.
+  - HTTP basic / digest authentication challenges
+    (`webView:didReceiveAuthenticationChallenge:` on the
+    navigation delegate) — a different channel, out of scope.
+  - Drag-and-drop file uploads (different code path; not
+    `runOpenPanel`).
+  - Per-call cancellation from Java mid-dialog (no
+    "dismiss-this-confirm-from-Java" API; the handler return is
+    the only outcome).
+  - HiDPI / DPI coordinate translation — dialogs use platform-native
+    Swing rendering and don't carry viewport coordinates.
+
+## E · Entities
+
+- **WebViewDialogHandler** (new public interface,
+  `src/ca/weblite/webview/WebViewDialogHandler.java`). Functional
+  interface-flavoured — four `default` methods, no required abstract
+  method. The "DEFAULT" public constant points at an instance that
+  uses every `default` method as-is, so callers who want stock Swing
+  dialogs do nothing and callers who want overrides supply their own
+  implementation with overridden methods.
+  - `default void alertOpened(WebViewAlertEvent event)`
+  - `default boolean confirmOpened(WebViewConfirmEvent event)`
+  - `default String promptOpened(WebViewPromptEvent event)`
+  - `default List<File> filePickerOpened(WebViewFilePickerEvent event)`
+  - `static WebViewDialogHandler DEFAULT = new WebViewDialogHandler() {};`
+    — anonymous interface instance with all defaults intact, used
+    by the dispatcher when no caller has installed one.
+
+- **WebViewAlertEvent** (new public class,
+  `src/ca/weblite/webview/WebViewAlertEvent.java`). Immutable value
+  type. Invariants:
+  - All five fields are stored in `final` ivars assigned by the
+    package-private constructor.
+  - `source` is never null (NPE thrown by constructor).
+  - `message`, `pageUrl`, `frameUrl` are never null but may be empty
+    (empty when the engine reports no value).
+
+- **WebViewConfirmEvent** (new public class,
+  `src/ca/weblite/webview/WebViewConfirmEvent.java`). Same shape as
+  `WebViewAlertEvent` — `source`, `message`, `pageUrl`, `frameUrl`.
+
+- **WebViewPromptEvent** (new public class,
+  `src/ca/weblite/webview/WebViewPromptEvent.java`). Fields:
+  `source`, `message`, `defaultValue`, `pageUrl`, `frameUrl`. The
+  `defaultValue` is never null but may be empty.
+
+- **WebViewFilePickerEvent** (new public class,
+  `src/ca/weblite/webview/WebViewFilePickerEvent.java`). Fields:
+  `source`, `multiple` (boolean), `acceptedExtensions`
+  (unmodifiable `List<String>`, lower-case, leading dot stripped,
+  deduplicated), `acceptedMimeTypes` (unmodifiable `List<String>`,
+  lower-case, deduplicated), `pageUrl`, `frameUrl`. Lists never null;
+  empty when the page's `<input>` has no `accept` attribute.
+
+- **WebViewDialogCallback** (new public interface,
+  `src/ca/weblite/webview/WebViewDialogCallback.java`).
+  Internal-ish functional interface — public only because the native
+  layer's JNI bridge calls into it; consuming Swing code routes
+  through `setDialogHandler` and never sees this type. Four methods
+  matching the four dispatch entry points; each returns the answer
+  synchronously. The class-level Javadoc states explicitly:
+  "Invoked from a native thread (AppKit main on macOS, GTK main on
+  Linux, WebView2 worker on Windows). Implementations route through
+  `DialogDispatcher`, which marshals to the EDT."
+  - `void onAlert(String message, String pageUrl, String frameUrl)`
+  - `boolean onConfirm(String message, String pageUrl, String frameUrl)`
+  - `String onPrompt(String message, String defaultValue, String pageUrl, String frameUrl)`
+  - `String[] onFilePicker(boolean multiple, String[] mimeTypes, String[] extensions, String pageUrl, String frameUrl)`
+
+- **DialogDispatcher** (new public class,
+  `src/ca/weblite/webview/DialogDispatcher.java`). Per-component
+  fan-out hub for native dialog requests. Owns the single
+  `WebViewDialogHandler` reference. Public-because-cross-package
+  (matches the existing `ConsoleDispatcher` /
+  `WebViewMouseDispatcher` rationale).
+  Invariants:
+  - Constructed once per `WebViewComponent` instance, lives for the
+    component's lifetime.
+  - `getHandler()` never returns null.
+  - `setHandler(null)` installs the `DROP` internal handler that
+    suppresses dialogs without UI.
+  - Every `dispatch*` method runs the active handler on the EDT.
+  - Disposed dispatcher returns safe fallbacks (void / false / null /
+    empty array) without invoking any handler.
+
+- **WebViewComponent** (modified;
+  `src/ca/weblite/webview/swing/WebViewComponent.java`). Gains:
+  - `protected final DialogDispatcher dialogDispatcher = new DialogDispatcher(this);`
+    instance field, initialised at construction (same pattern as
+    `consoleDispatcher` / `mouseDispatcher`).
+  - `public final WebViewComponent setDialogHandler(WebViewDialogHandler handler)`.
+  - `public final WebViewDialogHandler getDialogHandler()`.
+
+- **EmbeddedWebView** (modified;
+  `src/ca/weblite/webview/EmbeddedWebView.java`). Gains:
+  - `public EmbeddedWebView setDialogCallback(WebViewDialogCallback cb)`
+    — mirrors `setFocusCallback` (line 311) and `setClickCallback`
+    (line 330). Anchors `cb` in `heap` so the JVM does not collect
+    it while the native side holds a global ref. Calls the new
+    JNI entry point `WebViewNative.webview_embed_set_dialog_callback`.
+
+- **OffscreenWebView** (modified). Gains:
+  - `public OffscreenWebView setDialogCallback(WebViewDialogCallback cb)`
+    — mirrors the heavyweight wrapper. Calls
+    `WebViewNative.webview_offscreen_set_dialog_callback`.
+
+- **WebViewNative** (modified;
+  `src/ca/weblite/webview/WebViewNative.java`). Gains two native
+  method declarations:
+  - `native static void webview_embed_set_dialog_callback(long w, WebViewDialogCallback cb)`
+  - `native static void webview_offscreen_set_dialog_callback(long peer, WebViewDialogCallback cb)`
+
+- **`ca_weblite_webview_WebViewNative.h`** (regenerated;
+  `src/ca/weblite/webview/ca_weblite_webview_WebViewNative.h` AND
+  the duplicate at `src_c/ca_weblite_webview_WebViewNative.h` AND
+  `windows/ca_weblite_webview_WebViewNative.h`). Re-derived from
+  the modified `WebViewNative` class. The two new JNI function
+  prototypes appear.
+
+- **`src_c/webview_embed.cpp`** (modified, macOS-only changes in
+  this canvas). Gains:
+  - `Engine::dialog_callback` `jobject` field (global ref to the
+    Java `WebViewDialogCallback`), placed alongside the existing
+    `focus_callback` / `click_callback` fields.
+  - `Engine::ui_delegate` `id` field holding the per-engine ObjC
+    `WKUIDelegate` instance (released on engine destroy).
+  - `get_webview_embed_ui_delegate_cls()` — once-per-JVM cached
+    `Class` builder for the `WKUIDelegate` ObjC class, mirroring
+    the existing `get_webview_embed_delegate_cls()` at line 1684
+    (used for `WKScriptMessageHandler`).
+  - Four selector implementations on the new delegate class:
+    `webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:`,
+    `webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:`,
+    `webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:`,
+    `webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:`.
+  - `cocoa_set_dialog_callback(Engine*, JNIEnv*, jobject)` —
+    setter mirroring `cocoa_set_focus_callback` (line 1923) and
+    `cocoa_set_click_callback` (line 1940).
+  - Inside `cocoa_create_engine` (line 1951), after the `WKWebView`
+    is allocated and configured (lines 1989-1992) and the
+    script-message delegate is attached (line 2083), assign the
+    UIDelegate: `msg<void,id>(e->webview, sel("setUIDelegate:"), e->ui_delegate);`.
+  - JNI bridge function bodies for the two new `WebViewNative_…`
+    native methods, routing through `cocoa_set_dialog_callback`
+    (heavyweight on macOS) and a no-op stub for the offscreen
+    setter (offscreen is not implemented on macOS).
+
+- **`WebViewHeavyweightComponent`** (modified;
+  `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`).
+  Inside `createPeer()`, AFTER the existing
+  `embedded.setFocusCallback(...)` /
+  `embedded.setClickCallback(...)` registrations
+  (`WebViewHeavyweightComponent.java:473-501`), insert the dialog
+  callback registration that bridges to `dialogDispatcher`.
+
+- **`WebViewLightweightComponent`** (modified;
+  `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`).
+  Inside `addNotify()`, AFTER the existing console / mouse bridge
+  installs and inside the `engine != null` branch (matching the
+  existing late-install pattern), insert the corresponding
+  `engine.setDialogCallback(...)` registration. Behaves identically
+  to the heavyweight install but goes through the offscreen wrapper.
+
+- **`WebViewDialogDemo`** (new Swing demo,
+  `demos/WebViewDialogDemo/src/ca/weblite/webview/demos/WebViewDialogDemo.java`).
+  Layout mirrors `demos/WebViewConsoleDemo/`. Loads an inline page
+  (`addOnBeforeLoad` + `setUrl("about:blank")` or `data:` URL)
+  with buttons for each dialog kind. Includes a JComboBox switch
+  between three handler modes:
+  - **Default** (`setDialogHandler(WebViewDialogHandler.DEFAULT)` or
+    no setter call) — Swing dialogs.
+  - **Custom** (override every method to print the event to stdout
+    and return a fixed value: alert no-op, confirm true, prompt
+    `"hardcoded"`, file picker `[/tmp/preselected.txt]`) — exercises
+    AC10-AC13.
+  - **Drop** (`setDialogHandler(null)`) — exercises AC14.
+
+- **README.md** (modified). Two prose changes:
+  1. Under the "Demos" / additional-demos paragraph, list
+     `WebViewDialogDemo` with a one-line description.
+  2. New subsection titled "Browser-initiated dialogs" (sibling of
+     "Talking to JavaScript") documenting the `setDialogHandler`
+     API, the four `default` methods, the `null`-handler drop
+     semantics, and an explicit note that this iteration ships
+     macOS coverage only — Linux and Windows continue to use the
+     platform default dialogs until 004-002 / 004-003 land.
+
+- **`DialogDispatcherTest`** (new JUnit 4 test,
+  `test/ca/weblite/webview/DialogDispatcherTest.java`). Mirrors
+  `EvalDispatcherTest` style. No real engine — tests drive the
+  dispatcher's four `dispatch*` methods directly and assert on
+  handler invocation, EDT marshaling, exception isolation, drop
+  semantics, default normalisation of file-picker hints, and the
+  dispose path.
+
+```mermaid
+classDiagram
+direction TB
+
+class WebViewDialogHandler {
+    <<interface>>
+    +alertOpened(WebViewAlertEvent) void
+    +confirmOpened(WebViewConfirmEvent) boolean
+    +promptOpened(WebViewPromptEvent) String
+    +filePickerOpened(WebViewFilePickerEvent) List~File~
+    +DEFAULT WebViewDialogHandler$
+}
+
+class WebViewAlertEvent {
+    +source() WebViewComponent
+    +message() String
+    +pageUrl() String
+    +frameUrl() String
+}
+
+class WebViewConfirmEvent {
+    +source() WebViewComponent
+    +message() String
+    +pageUrl() String
+    +frameUrl() String
+}
+
+class WebViewPromptEvent {
+    +source() WebViewComponent
+    +message() String
+    +defaultValue() String
+    +pageUrl() String
+    +frameUrl() String
+}
+
+class WebViewFilePickerEvent {
+    +source() WebViewComponent
+    +multiple() boolean
+    +acceptedExtensions() List~String~
+    +acceptedMimeTypes() List~String~
+    +pageUrl() String
+    +frameUrl() String
+}
+
+class DialogDispatcher {
+    -source WebViewComponent
+    -handler WebViewDialogHandler
+    -disposed boolean
+    +setHandler(WebViewDialogHandler) void
+    +getHandler() WebViewDialogHandler
+    +dispatchAlert(String, String, String) void
+    +dispatchConfirm(String, String, String) boolean
+    +dispatchPrompt(String, String, String, String) String
+    +dispatchFilePicker(boolean, String[], String[], String, String) String[]
+    +disposeAll() void
+}
+
+class WebViewDialogCallback {
+    <<interface>>
+    +onAlert(String, String, String) void
+    +onConfirm(String, String, String) boolean
+    +onPrompt(String, String, String, String) String
+    +onFilePicker(boolean, String[], String[], String, String) String[]
+}
+
+class WebViewComponent {
+    #dialogDispatcher DialogDispatcher
+    +setDialogHandler(WebViewDialogHandler) WebViewComponent
+    +getDialogHandler() WebViewDialogHandler
+}
+
+class EmbeddedWebView {
+    +setDialogCallback(WebViewDialogCallback) EmbeddedWebView
+}
+
+class OffscreenWebView {
+    +setDialogCallback(WebViewDialogCallback) OffscreenWebView
+}
+
+WebViewComponent "1" *-- "1" DialogDispatcher : owns
+DialogDispatcher "1" --> "1" WebViewDialogHandler : invokes
+DialogDispatcher ..> WebViewAlertEvent : constructs
+DialogDispatcher ..> WebViewConfirmEvent : constructs
+DialogDispatcher ..> WebViewPromptEvent : constructs
+DialogDispatcher ..> WebViewFilePickerEvent : constructs
+EmbeddedWebView ..> WebViewDialogCallback : invokes via JNI
+OffscreenWebView ..> WebViewDialogCallback : invokes via JNI
+WebViewDialogCallback ..> DialogDispatcher : delegates to
+```
+
+## A · Approach
+
+1. **Layering and threading model:**
+   - The dispatcher is the sole gatekeeper between the native UI
+     thread and the Java handler. Native delegates / signal handlers
+     / event handlers invoke `WebViewDialogCallback.on*` from
+     whatever native UI thread they run on (AppKit main on macOS in
+     this canvas; GTK pump and WebView2 worker in subsequent
+     canvases). The callback implementation in
+     `WebViewHeavyweightComponent` / `WebViewLightweightComponent`
+     is a one-line delegation to `dialogDispatcher.dispatch*(...)`.
+   - `DialogDispatcher.dispatch*` does a synchronous EDT hop via
+     `SwingUtilities.invokeAndWait`. If already on the EDT (impossible
+     in practice — the native UI thread is never the EDT — but cheap
+     to short-circuit), invoke the handler directly. The dispatch
+     captures the handler return value, releases the EDT lock, and
+     returns to the native side. The native side then invokes the
+     platform's completion handler (WKWebView completion handler /
+     WebKitGTK `_set_text` / `_set_confirmed` / WebView2 deferral)
+     with the captured value.
+   - The native UI thread blocks for the duration of the modal Swing
+     dialog. This is the intended JS-contract behaviour: the page's
+     JS thread is also blocked, and no engine repaints land during
+     the modal. The README already documents this "page is frozen
+     during the modal" expectation for any embedded WebView
+     framework.
+
+2. **Why `invokeAndWait` and not `invokeLater` + CompletableFuture:**
+   - The JS contract for `alert` / `confirm` / `prompt` is
+     synchronous; the native side has to know the answer before
+     returning to JS. `invokeAndWait` produces a tiny dispatcher
+     surface (one method per kind, no future tracking, no per-call
+     identifier, no map cleanup) at the cost of holding the native
+     UI thread. That cost is intentional — the dialog IS the modal
+     pump.
+   - `invokeLater` + a `CompletableFuture` returned to native code
+     would require a second JNI call to feed the answer back. That
+     pattern is reserved for `<input type="file">` on Windows in a
+     future story IF the deferral analysis there reveals a deadlock
+     in the synchronous-block approach (analysis Risk section).
+     macOS, Linux, and the typical Windows case do not need it.
+   - For `<input type="file">` (asynchronous in JS), the native
+     `runOpenPanel` completion handler doesn't fire until the
+     picker dismisses; we can still implement this synchronously
+     in Java (the EDT blocks on `JFileChooser.showOpenDialog`) and
+     return the chosen paths once the user clicks OK / Cancel.
+     Functionally indistinguishable from the page's perspective
+     because the page only sees the `change` event when the
+     completion handler runs.
+
+3. **Why `SwingUtilities.invokeAndWait` is safe from AppKit main:**
+   - The AppKit main thread invokes the `WKUIDelegate` selector.
+     The selector calls into Java via JNI; Java calls
+     `invokeAndWait` to hop to AWT's EDT. The EDT runs
+     `JOptionPane.showMessageDialog(host, ...)` which spins a
+     **secondary modal pump on the EDT itself** (Swing's modal
+     implementation is pure Java; it nests an event-queue pump on
+     the EDT while the dialog is up). The EDT does not re-enter
+     AppKit synchronously while pumping. Java2D's macOS paint path
+     posts to AppKit asynchronously, but the EDT does not block on
+     those posts.
+   - The AppKit main thread sits parked in `invokeAndWait` until
+     the EDT-side dialog closes. AppKit is therefore not running
+     its own runloop — which is correct: the WKWebView and any
+     other AppKit content are visually frozen until the dialog
+     closes. This matches the JS contract.
+   - The `WebViewFocusCallback` and `WebViewClickCallback` already
+     run on the AppKit main thread and the Java side already
+     processes them on a non-EDT path that ultimately
+     `invokeLater`s to the EDT — without deadlock. Switching the
+     last step from `invokeLater` to `invokeAndWait` blocks the
+     AppKit thread on the EDT result; the EDT does not depend on
+     the AppKit thread for the Swing-modal-pump itself.
+
+4. **WKUIDelegate selector implementation strategy (per kind):**
+
+   - **`alert`:**
+     1. Read `message` (NSString) from the selector arg, convert to
+        UTF-8 jstring.
+     2. Read `pageUrl` from
+        `webView.URL.absoluteString` (top-level) and `frameUrl` from
+        `frame.request.URL.absoluteString` (or fall back to
+        `webView.URL.absoluteString` when nil).
+     3. Look up the Engine's `dialog_callback` `jobject` (global
+        ref, set via `cocoa_set_dialog_callback`).
+     4. Acquire the JNIEnv via `AttachCurrentThread` if needed
+        (AppKit main thread may or may not already be a JVM
+        attached thread — defensive `AttachCurrentThread` is
+        cheap if already attached).
+     5. Call the cached `onAlert(String, String, String)` jmethodID
+        via `CallVoidMethod`.
+     6. Detach (`DetachCurrentThread`) only if we attached here.
+     7. Invoke the `WKWebView` completion handler:
+        `((void(^)())completionHandler)();`
+
+   - **`confirm`:**
+     1-4. Same as alert.
+     5. Call `onConfirm(...)`, returning `jboolean`.
+     6. Detach.
+     7. Invoke the completion handler with the captured boolean:
+        `((void(^)(BOOL))completionHandler)(result == JNI_TRUE);`
+
+   - **`prompt`:**
+     1. Same as alert + `defaultValue` arg.
+     2-4. Same as alert.
+     5. Call `onPrompt(...)`, capturing the returned `jstring` (or
+        null for cancel).
+     6. If non-null: convert to NSString. If null: pass `nil` to
+        the completion handler (WKWebView interprets `nil` as
+        cancel; returns `null` to JS).
+     7. Invoke the completion handler with the NSString-or-nil:
+        `((void(^)(NSString*))completionHandler)(nsResult);`
+     8. Detach.
+
+   - **`open panel`:**
+     1. Read `parameters.allowsMultipleSelection` (public API,
+        `BOOL`).
+     2. Read accepted MIME types via
+        `[parameters valueForKey:@"_acceptedMIMETypes"]` (private
+        API; KVC wrap in `@try`/`@catch`; fall back to empty
+        NSArray). Convert to `jobjectArray` of UTF-8 jstrings.
+     3. Read accepted file extensions via
+        `[parameters valueForKey:@"_acceptedFileExtensions"]`,
+        same KVC-with-fallback dance. Convert similarly.
+     4. Read pageUrl / frameUrl as above.
+     5. Call `onFilePicker(boolean, String[], String[], String, String)`,
+        returning `jobjectArray` of UTF-8 jstrings (file paths).
+     6. Build an `NSArray<NSURL*>*` from the returned paths via
+        `[NSURL fileURLWithPath:...]`. Empty / null array → `nil`.
+     7. Invoke the completion handler with the NSArray-or-nil:
+        `((void(^)(NSArray<NSURL*>*))completionHandler)(urls);`
+     8. Detach.
+
+5. **Why use KVC for `_acceptedMIMETypes` / `_acceptedFileExtensions`:**
+   - These are documented in WebKit source and have been stable
+     since macOS 10.12, but they are not part of the public WKWebKit
+     API. Public WKOpenPanelParameters only exposes
+     `allowsMultipleSelection` and `allowsDirectories`. Apps
+     wanting accept-attribute hints have used the KVC path for
+     years (e.g. Electron, CEF on macOS).
+   - The wrapper `@try`/`@catch` ensures we degrade gracefully if a
+     future macOS removes the underscore-prefixed accessors:
+     `acceptedExtensions` / `acceptedMimeTypes` become empty lists
+     and the default `JFileChooser` simply shows all files. The
+     page's own client-side `accept` validation continues to work.
+
+6. **EDT marshal and exception isolation:**
+   - The dispatcher's `dispatch*` methods all run through the same
+     internal `runOnEdtAndCapture(Supplier<T>)` helper that:
+     1. If `disposed`, return the supplier-provided fallback
+        without invoking anything.
+     2. If `SwingUtilities.isEventDispatchThread()`, invoke the
+        supplier inline.
+     3. Otherwise, wrap the supplier in a `Callable<T>`-style
+        `Runnable` that stores its result in a final `Object[]`
+        cell and call `SwingUtilities.invokeAndWait(...)`.
+     4. Catch `InterruptedException` (restore interrupt flag,
+        return fallback), `InvocationTargetException` (forward
+        the wrapped exception to
+        `Thread.getDefaultUncaughtExceptionHandler()`, return
+        fallback), and `RuntimeException` (forward, return
+        fallback). No exception propagates back to the JNI
+        caller.
+   - The four `dispatch*` methods construct their event POJO from
+     the JNI-marshalled primitives, call `runOnEdtAndCapture`
+     supplying the relevant handler invocation, and return the
+     captured (or fallback) value.
+
+7. **`setDialogHandler(null)` drop semantics:**
+   - The dispatcher holds a non-null `volatile WebViewDialogHandler
+     handler` field, initialised to `WebViewDialogHandler.DEFAULT`.
+   - `setHandler(null)` does NOT null the field — it stores an
+     internal `DROP` singleton that overrides every method to
+     return the JS-spec cancel value synchronously without UI.
+     `getHandler()` returns whatever is stored; it never returns
+     `null`.
+   - DROP is NOT identity-equal to DEFAULT (so callers can detect
+     the drop state if they care), but is package-private — there
+     is no `WebViewDialogHandler.DROP` public constant. Callers
+     reset to the default by calling
+     `setDialogHandler(WebViewDialogHandler.DEFAULT)` explicitly.
+   - DROP returns: `alertOpened` → no-op; `confirmOpened` → false;
+     `promptOpened` → null; `filePickerOpened` → empty list.
+
+8. **Native-thread JNI mechanics:**
+   - The macOS WKUIDelegate selector runs on AppKit main, which may
+     or may not be a JVM-attached thread depending on whether
+     anyone has run prior JNI work on it. The existing
+     `fire_focus_callback` and `fire_click_callback` patterns in
+     `webview_embed.cpp` use a shared helper that defensively
+     `AttachCurrentThreadAsDaemon`s if needed and detaches at the
+     end. Reuse that helper (or a sibling) for the dialog selectors.
+   - The Engine's `dialog_callback` jobject is a global ref created
+     in `cocoa_set_dialog_callback` (via `env->NewGlobalRef(cb)`)
+     and deleted in `cocoa_set_dialog_callback` when replaced (and
+     in the engine destructor). Same lifecycle pattern as
+     `focus_callback` / `click_callback`.
+   - The four `jmethodID`s for `onAlert` / `onConfirm` / `onPrompt`
+     / `onFilePicker` are cached once at first invocation (lazy
+     init) inside the engine, OR resolved per-call from the
+     callback's class via `GetObjectClass` + `GetMethodID`. The
+     existing `fire_click_callback` resolves per-call
+     (`webview_embed.cpp:166`); the new code mirrors that for
+     simplicity. The per-call resolution cost is small compared to
+     the modal dialog's wall-clock duration.
+
+9. **File-picker accept-attribute normalisation:**
+   - The native side reports whatever the platform makes available.
+     On macOS via KVC: `_acceptedMIMETypes` is an `NSArray<NSString*>`
+     of MIME-type strings as the page wrote them (e.g. `"image/png"`,
+     `"image/*"`); `_acceptedFileExtensions` is an `NSArray<NSString*>`
+     of extension strings (may include or omit leading dots).
+   - The JNI bridge converts both arrays to `jobjectArray` verbatim.
+   - The Java `DialogDispatcher.dispatchFilePicker` is responsible
+     for normalisation BEFORE constructing the
+     `WebViewFilePickerEvent`:
+     1. Lowercase all entries.
+     2. For extensions: strip a single leading dot.
+     3. Deduplicate (preserving first-seen order via
+        `LinkedHashSet`).
+     4. Wrap each in
+        `Collections.unmodifiableList(new ArrayList<>(...))`.
+   - This guarantees handler implementations see the same shape
+     across all platforms and matches the STORY-004-001
+     NF-expectation directly.
+
+10. **Default `JFileChooser` filtering logic:**
+    - Default `filePickerOpened` constructs a `JFileChooser`,
+      sets `multiSelectionEnabled` from `event.multiple()`, and
+      builds a filter:
+      - If `acceptedExtensions` non-empty: add a
+        `FileNameExtensionFilter("Accepted files", ext1, ext2, ...)`
+        as the default filter and disable "All Files" via
+        `setAcceptAllFileFilterUsed(false)` when the page has
+        constrained extensions.
+      - If only `acceptedMimeTypes` non-empty (no extensions):
+        leave the chooser unfiltered (all files visible) since
+        Swing's stock `JFileChooser` does not natively filter by
+        MIME type. Handlers wanting MIME-based filtering can
+        provide a custom handler.
+      - If both lists empty: no filter, default
+        "Open File" experience.
+    - On `JFileChooser.APPROVE_OPTION`: return
+      `Arrays.asList(chooser.getSelectedFiles())` (or
+      `Collections.singletonList(chooser.getSelectedFile())`
+      when single-file). On `CANCEL_OPTION` / closed: return
+      `Collections.emptyList()`.
+
+11. **Handler-on-EDT contract for callers:**
+    - Handlers MUST NOT block the EDT on an EDT-scheduled task —
+      e.g. `wv.evalAsync(js).get()` from inside a handler will
+      deadlock because the dispatcher's `invokeAndWait` already
+      occupies the EDT and `evalAsync` continuations land on
+      that same EDT. Document in `WebViewDialogHandler` Javadoc
+      and `setDialogHandler` Javadoc.
+    - Handlers MAY freely call `wv.setUrl`, `wv.eval`,
+      `wv.dispatch(r)`, etc. — those dispatch to the native UI
+      thread and return immediately. Note that the native UI
+      thread is currently blocked in the WKUIDelegate selector,
+      so the navigation / eval queues until the handler returns
+      and the delegate's completion handler releases the JS
+      thread.
+
+12. **Demo strategy:**
+    - The demo loads an inline page (constructed via
+      `addOnBeforeLoad` and `setUrl("about:blank")`, NOT a
+      `data:` URL, because `data:` URLs constrain
+      `webView.URL.absoluteString` to the literal data URI
+      and the demo wants a "page URL" assertion path).
+    - Page contains four buttons: "Alert", "Confirm", "Prompt",
+      "Pick File" — each wires `onclick` to call the
+      corresponding JS function. Page logs every call's return
+      value to `console.log` so the existing console-capture
+      channel surfaces it to the demo log pane.
+    - Demo includes a JComboBox to switch among three handler
+      modes (DEFAULT, custom, drop) and exercises AC-relevant
+      behaviour by clicking each button under each mode.
+
+## S · Structure
+
+### Inheritance Relationships
+1. `WebViewDialogHandler` is a public functional-style interface
+   with four `default` methods and a `DEFAULT` static constant.
+   Callers either accept the defaults entirely or implement /
+   override one or more methods. No required abstract method.
+2. `WebViewAlertEvent`, `WebViewConfirmEvent`, `WebViewPromptEvent`,
+   `WebViewFilePickerEvent` are public final classes (no
+   inheritance, no `Cloneable`, no `Serializable` per house
+   style — matches the existing `ConsoleMessage` /
+   `WebViewMouseEvent` POJOs).
+3. `WebViewDialogCallback` is a public interface with four
+   methods. NOT `@FunctionalInterface` (more than one method).
+4. `DialogDispatcher` is a `public final` class — no subclassing
+   expected (matches `ConsoleDispatcher` and `EvalDispatcher`).
+5. `WebViewComponent` (existing abstract class) gains a
+   `DialogDispatcher` instance field and two `final` methods. No
+   change to the abstract surface; both subclasses inherit the
+   new methods directly.
+6. `EmbeddedWebView` and `OffscreenWebView` (existing concrete
+   classes) each gain one `setDialogCallback` method matching
+   their existing `setFocusCallback` / `setClickCallback`
+   patterns.
+
+### Dependencies
+1. `WebViewDialogHandler` (default methods) → `javax.swing.JOptionPane`,
+   `javax.swing.JFileChooser`,
+   `javax.swing.SwingUtilities.getWindowAncestor`,
+   `javax.swing.filechooser.FileNameExtensionFilter`,
+   `java.io.File`, `java.util.List`, `java.util.Collections`.
+2. `DialogDispatcher` → `javax.swing.SwingUtilities`
+   (`invokeAndWait`, `isEventDispatchThread`),
+   `java.lang.reflect.InvocationTargetException`, the four event
+   POJO constructors, `WebViewDialogHandler`,
+   `java.io.File`, `java.util.Arrays`, `java.util.LinkedHashSet`.
+3. `WebViewComponent` → `DialogDispatcher`, `WebViewDialogHandler`.
+4. `WebViewHeavyweightComponent.createPeer()` → `EmbeddedWebView`,
+   `DialogDispatcher`, `WebViewDialogCallback`. Wires a
+   `WebViewDialogCallback` adapter (anonymous inner class) that
+   delegates each method to `dialogDispatcher.dispatch*`.
+5. `WebViewLightweightComponent.addNotify()` → `OffscreenWebView`,
+   `DialogDispatcher`, `WebViewDialogCallback`. Same shape as the
+   heavyweight wiring.
+6. `EmbeddedWebView.setDialogCallback` → `WebViewNative.webview_embed_set_dialog_callback`.
+7. `OffscreenWebView.setDialogCallback` → `WebViewNative.webview_offscreen_set_dialog_callback`.
+8. `Java_…_webview_1embed_1set_1dialog_1callback` (in `webview_embed.cpp`)
+   → `cocoa_set_dialog_callback` (macOS path).
+9. macOS UIDelegate selectors → `Engine::dialog_callback` jobject →
+   JNI `CallVoidMethod` / `CallBooleanMethod` /
+   `CallObjectMethod` → Java `WebViewDialogCallback.on*` →
+   `DialogDispatcher.dispatch*` → EDT → `WebViewDialogHandler.*Opened`.
+
+### Layered Architecture
+1. **Native engine layer** (`src_c/webview_embed.cpp`): Cocoa
+   `WKUIDelegate` ObjC class, four selector implementations, the
+   `cocoa_set_dialog_callback` setter, and the JNI bridge
+   functions for the two new `WebViewNative_…` natives. Engine
+   struct holds the new `dialog_callback` / `ui_delegate`
+   fields.
+2. **JNI surface** (`ca.weblite.webview.WebViewNative`): two new
+   `native static` method declarations.
+3. **Engine wrapper layer** (`EmbeddedWebView`, `OffscreenWebView`):
+   `setDialogCallback` setters that anchor the callback in
+   `heap` and call the corresponding JNI method.
+4. **Dispatcher layer** (`ca.weblite.webview.DialogDispatcher`):
+   per-component fan-out hub holding the active handler,
+   marshaling to the EDT, isolating handler exceptions.
+5. **Component API layer**
+   (`ca.weblite.webview.swing.WebViewComponent`):
+   `setDialogHandler` / `getDialogHandler` public methods, owns
+   the per-instance dispatcher.
+6. **Public contract layer**
+   (`ca.weblite.webview.WebViewDialogHandler` + four event POJOs +
+   `WebViewDialogCallback`): the user-facing interface and the
+   internal-ish JNI callback interface.
+7. **Wiring layer** (`WebViewHeavyweightComponent.createPeer()`,
+   `WebViewLightweightComponent.addNotify()`): bridges the
+   per-component dispatcher to the per-engine native callback at
+   peer-attach time.
+8. **Demo layer** (`demos/WebViewDialogDemo/`): runnable Swing
+   app exercising the four dialog kinds in three handler modes.
+
+## O · Operations
+
+### 1. Create Value Object — WebViewAlertEvent
+File: `src/ca/weblite/webview/WebViewAlertEvent.java`
+
+1. Responsibility: immutable carrier of one `window.alert` request's
+   data, surfaced to the Java handler.
+2. Package-private constructor:
+   - `WebViewAlertEvent(WebViewComponent source, String message,
+        String pageUrl, String frameUrl)`
+   - Logic: null-check `source` (NPE with name `"source"`);
+     coerce null `message` / `pageUrl` / `frameUrl` to empty string
+     (the engine may legitimately report no value — empty is the
+     "no value" sentinel for these fields, per the analysis
+     resolution); store all four fields in `final` ivars.
+3. Public accessors (no-`get` style, matching
+   `WebViewMouseEvent` precedent):
+   - `source(): WebViewComponent`
+   - `message(): String`
+   - `pageUrl(): String`
+   - `frameUrl(): String`
+4. `toString()` returns
+   `"WebViewAlertEvent[message=<...>, pageUrl=<...>]"` for debug
+   logging. Truncate `message` to 80 chars + `"..."` if longer.
+5. No `equals` / `hashCode` overrides.
+
+### 2. Create Value Object — WebViewConfirmEvent
+File: `src/ca/weblite/webview/WebViewConfirmEvent.java`
+
+1. Responsibility: immutable carrier of one `window.confirm`
+   request's data.
+2. Package-private constructor and accessors: identical shape to
+   `WebViewAlertEvent` (Operation 1) — `source`, `message`,
+   `pageUrl`, `frameUrl`. Same null-handling, same accessors,
+   same `toString` style.
+3. The two classes are intentionally NOT collapsed into a shared
+   base class — per requirements (line 65 of the analysis) the
+   four POJOs are distinct types for caller clarity and to keep
+   handler method signatures honest.
+
+### 3. Create Value Object — WebViewPromptEvent
+File: `src/ca/weblite/webview/WebViewPromptEvent.java`
+
+1. Responsibility: immutable carrier of one `window.prompt`
+   request's data, including the default value the page supplied.
+2. Package-private constructor:
+   - `WebViewPromptEvent(WebViewComponent source, String message,
+        String defaultValue, String pageUrl, String frameUrl)`
+   - Logic: null-check `source`; coerce all other null Strings to
+     empty (`defaultValue` empty when the page passed no second
+     argument or passed `null` — JS coerces to the string
+     `"null"`, but if WKWebView reports `nil` we treat that as
+     empty).
+3. Public accessors: `source()`, `message()`, `defaultValue()`,
+   `pageUrl()`, `frameUrl()`.
+4. `toString()` — same pattern as Operation 1.
+
+### 4. Create Value Object — WebViewFilePickerEvent
+File: `src/ca/weblite/webview/WebViewFilePickerEvent.java`
+
+1. Responsibility: immutable carrier of one `<input type=file>`
+   click's parameters.
+2. Package-private constructor:
+   - `WebViewFilePickerEvent(WebViewComponent source, boolean multiple,
+        List<String> acceptedExtensions, List<String> acceptedMimeTypes,
+        String pageUrl, String frameUrl)`
+   - Logic: null-check `source`; coerce null `pageUrl` /
+     `frameUrl` to empty; null `acceptedExtensions` /
+     `acceptedMimeTypes` become empty unmodifiable lists; non-null
+     lists are defensively wrapped via
+     `Collections.unmodifiableList(new ArrayList<>(input))` so
+     mutation of the source list after construction does not
+     affect the stored field.
+   - Constructor does NOT re-normalise the lists — normalisation
+     is the caller's responsibility (the `DialogDispatcher`
+     normalises before calling the constructor per Operation 7).
+3. Public accessors: `source()`, `multiple()`,
+   `acceptedExtensions()`, `acceptedMimeTypes()`, `pageUrl()`,
+   `frameUrl()`. The two list accessors return the stored
+   already-unmodifiable views directly.
+4. `toString()` — single-line summary including extension count,
+   MIME-type count, `multiple` flag.
+
+### 5. Create Handler Interface — WebViewDialogHandler
+File: `src/ca/weblite/webview/WebViewDialogHandler.java`
+
+1. Public `interface`, NOT `@FunctionalInterface` (it has four
+   `default` methods and no required abstract method; multiple
+   methods make it non-functional).
+2. Imports needed: `javax.swing.JOptionPane`,
+   `javax.swing.JFileChooser`, `javax.swing.SwingUtilities`,
+   `javax.swing.filechooser.FileNameExtensionFilter`,
+   `java.awt.Window`, `java.io.File`, `java.util.Collections`,
+   `java.util.List`, `java.util.Arrays`.
+3. Four `default` methods:
+   - `default void alertOpened(WebViewAlertEvent event)`:
+     - Logic: `Window host = SwingUtilities.getWindowAncestor(event.source());`
+       then
+       `JOptionPane.showMessageDialog(host, event.message(), "JavaScript Alert", JOptionPane.PLAIN_MESSAGE);`.
+     - The `host` may be null if the component is not in a window
+       — `JOptionPane` handles this by parenting on a hidden
+       shared frame, which is the standard Swing behaviour and
+       matches the requirements' fallback contract.
+   - `default boolean confirmOpened(WebViewConfirmEvent event)`:
+     - Logic: `Window host = SwingUtilities.getWindowAncestor(event.source());`
+       then
+       `int r = JOptionPane.showConfirmDialog(host, event.message(), "JavaScript Confirm", JOptionPane.OK_CANCEL_OPTION);`
+       and `return r == JOptionPane.OK_OPTION;`.
+   - `default String promptOpened(WebViewPromptEvent event)`:
+     - Logic: `Window host = SwingUtilities.getWindowAncestor(event.source());`
+       then
+       `Object r = JOptionPane.showInputDialog(host, event.message(), "JavaScript Prompt", JOptionPane.QUESTION_MESSAGE, null, null, event.defaultValue());`
+       and `return r == null ? null : r.toString();`.
+     - Uses the seven-arg `showInputDialog` so the default value
+       can be pre-populated (the simpler three-arg form doesn't
+       accept initial value); the `null, null` positional args
+       are the icon and the selection-values array — both unused.
+   - `default List<File> filePickerOpened(WebViewFilePickerEvent event)`:
+     - Logic:
+       1. Resolve `Window host`.
+       2. Construct `JFileChooser chooser = new JFileChooser();`.
+       3. `chooser.setMultiSelectionEnabled(event.multiple());`
+       4. If `!event.acceptedExtensions().isEmpty()`:
+          - `String[] exts = event.acceptedExtensions().toArray(new String[0]);`
+          - `chooser.setFileFilter(new FileNameExtensionFilter("Accepted files", exts));`
+          - `chooser.setAcceptAllFileFilterUsed(false);`
+       5. Otherwise leave the chooser unfiltered.
+       6. `int r = chooser.showOpenDialog(host);`
+       7. If `r != JFileChooser.APPROVE_OPTION`, return
+          `Collections.emptyList()`.
+       8. Otherwise: if `event.multiple()`, return
+          `Arrays.asList(chooser.getSelectedFiles())`;
+          else return
+          `Collections.singletonList(chooser.getSelectedFile())`.
+4. Public static constant:
+   - `WebViewDialogHandler DEFAULT = new WebViewDialogHandler() {};`
+   - Anonymous instance with all defaults intact. Stateless; safe
+     to share across components and threads.
+5. Class-level Javadoc:
+   - Documents that all methods run on the Swing EDT.
+   - Documents the synchronous JS-contract semantics: every
+     handler invocation blocks the WebKit JS thread until the
+     handler returns; `alert` / `confirm` / `prompt` rely on this
+     blocking behaviour to provide their synchronous return
+     values.
+   - Documents the `setDialogHandler(null)` drop-handler shortcut
+     (callers wanting to suppress all dialogs without writing
+     stub override methods).
+   - Documents the EDT-deadlock warning: handlers MUST NOT block
+     on `wv.evalAsync(js).get()` or any other EDT-scheduled task
+     from inside a handler — the EDT is busy running the
+     handler.
+   - Documents that handlers MAY freely call
+     `wv.setUrl` / `wv.eval` / `wv.dispatch(r)`; these enqueue
+     work onto the native UI thread but do not block.
+   - Documents that handler exceptions are caught by the
+     dispatcher and forwarded to
+     `Thread.getDefaultUncaughtExceptionHandler()`; they do not
+     propagate to the native engine.
+   - Documents the macOS coverage status (this canvas), with a
+     forward reference to STORY-004-002 / STORY-004-003 for
+     Linux / Windows.
+
+### 6. Create JNI Callback Interface — WebViewDialogCallback
+File: `src/ca/weblite/webview/WebViewDialogCallback.java`
+
+1. Public `interface`. NOT `@FunctionalInterface` — four methods.
+2. Four methods, each returning the answer synchronously:
+   - `void onAlert(String message, String pageUrl, String frameUrl)`
+   - `boolean onConfirm(String message, String pageUrl, String frameUrl)`
+   - `String onPrompt(String message, String defaultValue, String pageUrl, String frameUrl)` — may return null
+   - `String[] onFilePicker(boolean multiple, String[] mimeTypes, String[] extensions, String pageUrl, String frameUrl)` — never returns null; empty array for "cancel"
+3. Class-level Javadoc:
+   - States explicitly: "Invoked from a native thread (AppKit
+     main on macOS, GTK main on Linux, WebView2 worker on
+     Windows). Implementations MUST marshal to the EDT before
+     touching Swing state. The library-provided implementation
+     in `WebViewHeavyweightComponent` /
+     `WebViewLightweightComponent` routes through
+     `DialogDispatcher`, which performs the EDT hop via
+     `SwingUtilities.invokeAndWait`."
+   - States that this interface is part of the JNI surface and
+     is NOT intended to be implemented by application code —
+     application code customises behaviour via
+     `WebViewComponent.setDialogHandler(WebViewDialogHandler)`.
+4. Method-level Javadoc:
+   - For `onPrompt`: returning `null` signals cancel (matches
+     JS `prompt()`'s `null` return value).
+   - For `onFilePicker`: returning an empty array signals cancel
+     (matches JS `<input type=file>`'s no-files-selected state).
+
+### 7. Create Dispatcher — DialogDispatcher
+File: `src/ca/weblite/webview/DialogDispatcher.java`
+
+1. Responsibility: per-component fan-out hub for native dialog
+   requests. Holds the single active `WebViewDialogHandler`,
+   marshals dispatch onto the EDT via
+   `SwingUtilities.invokeAndWait`, isolates handler exceptions,
+   normalises `WebViewFilePickerEvent.acceptedExtensions` /
+   `acceptedMimeTypes` before constructing the event POJO,
+   honours the `disposed` flag to return safe fallbacks during
+   teardown.
+2. Class is `public final` — matches the existing
+   `ConsoleDispatcher` / `EvalDispatcher` precedent.
+3. Fields:
+   - `private final WebViewComponent source;` — non-null;
+     supplied at construction.
+   - `private volatile WebViewDialogHandler handler = WebViewDialogHandler.DEFAULT;`
+     — never null; written via `setHandler`.
+   - `private volatile boolean disposed = false;` — set true by
+     `disposeAll()`.
+   - `private static final WebViewDialogHandler DROP = new WebViewDialogHandler() { @Override public void alertOpened(WebViewAlertEvent e){} @Override public boolean confirmOpened(WebViewConfirmEvent e){ return false; } @Override public String promptOpened(WebViewPromptEvent e){ return null; } @Override public List<File> filePickerOpened(WebViewFilePickerEvent e){ return java.util.Collections.emptyList(); } };`
+     — package-private singleton, installed when caller passes
+     `null` to `setHandler`. Stateless; safe to share.
+4. Constructor:
+   - `public DialogDispatcher(WebViewComponent source)`:
+     - Logic: null-check `source` (NPE with name `"source"`);
+       store.
+5. Public methods:
+   - `public void setHandler(WebViewDialogHandler h)`:
+     - Logic: if `h == null`, store `DROP`; else store `h`.
+     - Atomic write to a volatile field.
+   - `public WebViewDialogHandler getHandler()`:
+     - Logic: return the stored handler (never null).
+   - `public void dispatchAlert(String message, String pageUrl, String frameUrl)`:
+     - Logic: if `disposed`, return; otherwise build a
+       `WebViewAlertEvent` and call
+       `runOnEdtAndCaptureVoid(() -> handler.alertOpened(event))`.
+   - `public boolean dispatchConfirm(String message, String pageUrl, String frameUrl)`:
+     - Logic: if `disposed`, return false; otherwise build a
+       `WebViewConfirmEvent` and return
+       `runOnEdtAndCapture(() -> handler.confirmOpened(event), Boolean.FALSE).booleanValue()`.
+   - `public String dispatchPrompt(String message, String defaultValue, String pageUrl, String frameUrl)`:
+     - Logic: if `disposed`, return null; otherwise build a
+       `WebViewPromptEvent` and return
+       `runOnEdtAndCapture(() -> handler.promptOpened(event), (String) null)`.
+   - `public String[] dispatchFilePicker(boolean multiple, String[] mimeTypes, String[] extensions, String pageUrl, String frameUrl)`:
+     - Logic: if `disposed`, return `new String[0]`;
+       normalise the two arrays into unmodifiable lists per
+       Approach §9, construct a `WebViewFilePickerEvent`, call
+       `List<File> files = runOnEdtAndCapture(() -> handler.filePickerOpened(event), java.util.Collections.emptyList());`,
+       then convert to `String[]` of absolute paths (skipping
+       nulls in the file list), and return.
+   - `public void disposeAll()`:
+     - Logic: set `disposed = true`. The dispatcher does NOT need
+       to drain pending futures — `dispatch*` methods are
+       short-lived synchronous calls; in-flight handlers running
+       on the EDT will complete naturally and their return values
+       reach the native completion handler as usual. (Contrast
+       with `EvalDispatcher.disposeAllPending` which has long-
+       lived futures to fail.)
+6. Private helpers:
+   - `private void runOnEdtAndCaptureVoid(Runnable r)`:
+     - Logic: if `SwingUtilities.isEventDispatchThread()`,
+       invoke `r.run()` directly inside a try/catch that
+       forwards exceptions to
+       `Thread.getDefaultUncaughtExceptionHandler()`.
+     - Otherwise, build a
+       `Runnable wrapped = () -> { try { r.run(); } catch (Throwable t) { forwardUncaught(t); } }`
+       and call
+       `SwingUtilities.invokeAndWait(wrapped)`.
+     - Catch `InterruptedException` from invokeAndWait (restore
+       interrupt flag, return), `InvocationTargetException`
+       (forward `getCause()` to uncaught handler), other
+       `RuntimeException` (forward, return).
+   - `private <T> T runOnEdtAndCapture(java.util.function.Supplier<T> supplier, T fallback)`:
+     - Logic: same EDT-or-not branching as the void variant. The
+       captured result is stored in a final single-element
+       `Object[1]` cell. Returns `fallback` on any exception
+       (after forwarding to uncaught handler). On successful
+       EDT execution, returns the captured value (which may be
+       null — the supplier's return value is propagated even
+       when null).
+   - `private static void forwardUncaught(Throwable t)`:
+     - Logic: identical to
+       `ConsoleDispatcher.deliver`'s per-listener catch
+       (`ConsoleDispatcher.java:235-241`). Calls
+       `Thread.getDefaultUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), t);`
+       wrapped in a try/catch that printStackTraces if the
+       handler itself throws.
+7. Normalisation helper (private static):
+   - `private static List<String> normaliseExtensions(String[] input)`:
+     - Logic: if null or empty, return
+       `Collections.emptyList()`.
+     - Build a `LinkedHashSet<String>` (preserves insertion
+       order).
+     - For each entry: lowercase via `String.toLowerCase(java.util.Locale.ROOT)`,
+       strip a single leading `.` if present, skip empty
+       strings, add to set.
+     - Wrap in
+       `Collections.unmodifiableList(new ArrayList<>(set))`.
+   - `private static List<String> normaliseMimeTypes(String[] input)`:
+     - Logic: identical except for the leading-dot strip step —
+       MIME types don't have leading dots.
+8. Constraints / Invariants:
+   - `setHandler` and `getHandler` are safe to call from any
+     thread; the field is volatile.
+   - `dispatch*` methods are called from native threads (and
+     possibly EDT in unit tests). Both paths must produce a
+     valid return value within bounded time even when the
+     handler throws.
+   - `disposed = true` is observed by every subsequent
+     `dispatch*` call without locking thanks to the volatile
+     field.
+
+### 8. Extend WebViewComponent Base
+File: `src/ca/weblite/webview/swing/WebViewComponent.java`
+
+1. Add import: `import ca.weblite.webview.DialogDispatcher;` and
+   `import ca.weblite.webview.WebViewDialogHandler;`.
+2. Add field at class level (next to the existing
+   `mouseDispatcher` declaration,
+   `WebViewComponent.java:67`):
+   - `protected final DialogDispatcher dialogDispatcher = new DialogDispatcher(this);`
+   - The `this` escape during construction is acceptable for the
+     same reason as `mouseDispatcher` — the dispatcher does not
+     call back into the component during construction.
+3. Add two `public final` methods on the base class (not
+   abstract — they don't depend on subclass state):
+   - `public final WebViewComponent setDialogHandler(WebViewDialogHandler handler)`:
+     - Logic: `dialogDispatcher.setHandler(handler); return this;`
+   - `public final WebViewDialogHandler getDialogHandler()`:
+     - Logic: `return dialogDispatcher.getHandler();`
+4. Method-level Javadoc:
+   - `setDialogHandler`: documents the replacement semantic, the
+     `null = drop` shortcut, and the
+     `WebViewDialogHandler.DEFAULT` constant for explicit
+     reset-to-default. Cross-references the
+     `WebViewDialogHandler` Javadoc for the EDT and JS-contract
+     constraints. Notes that this iteration ships macOS coverage
+     only; Linux / Windows continue to use platform-default
+     dialogs.
+   - `getDialogHandler`: documents the never-null invariant and
+     the DEFAULT-when-unset behaviour.
+5. Constraints / Invariants:
+   - Both new methods MUST be safe to call before the component
+     is displayed. The dispatcher holds the handler reference
+     independently of peer-attach state; the native callback is
+     wired at peer-attach time and reads the handler reference
+     fresh on each dispatch.
+   - Calling the two methods after `dispose()` is benign:
+     `setDialogHandler` mutates the dispatcher state; subsequent
+     dispatches return safe fallbacks because `disposed = true`.
+   - `getDialogHandler() != null` is an invariant — never returns
+     null even after dispose, even when the caller passed null
+     (DROP is non-null).
+
+### 9. Extend EmbeddedWebView with setDialogCallback
+File: `src/ca/weblite/webview/EmbeddedWebView.java`
+
+1. Add import: `import ca.weblite.webview.WebViewDialogCallback;`
+   (in the existing import block).
+2. Add method, placed AFTER `setClickCallback`
+   (`EmbeddedWebView.java:330-337`):
+   ```
+   public EmbeddedWebView setDialogCallback(WebViewDialogCallback cb) {
+       checkAlive();
+       if (cb != null) {
+           heap.add(cb);
+       }
+       WebViewNative.webview_embed_set_dialog_callback(peer, cb);
+       return this;
+   }
+   ```
+3. Javadoc:
+   - States: "Register (or clear, by passing null) a callback
+     invoked for each JS-initiated UI dialog (alert / confirm /
+     prompt) and `<input type=file>` click inside the embedded
+     WebView. Unlike `setFocusCallback` / `setClickCallback`,
+     dialog callbacks RETURN VALUES to the engine
+     synchronously: the native UI thread is suspended while
+     waiting for the answer. Implementations MUST marshal to
+     the EDT (the library-provided implementation routes
+     through `DialogDispatcher` which uses
+     `SwingUtilities.invokeAndWait`)."
+   - States: "Anchoring the callback in `heap` is required so
+     the JVM does not garbage-collect the lambda while the
+     native side holds a global ref."
+4. No other changes to `EmbeddedWebView`. The `dispose()` path
+   already clears the heap, which transitively makes the
+   callback eligible for GC after the native side's
+   `cocoa_set_dialog_callback(nullptr)` clears its global ref
+   (called inside `webview_embed_destroy`).
+
+### 10. Extend OffscreenWebView with setDialogCallback
+File: `src/ca/weblite/webview/OffscreenWebView.java`
+
+1. Add import: `import ca.weblite.webview.WebViewDialogCallback;`.
+2. Add `public OffscreenWebView setDialogCallback(WebViewDialogCallback cb)`
+   following the same template as the heavyweight wrapper
+   (Operation 9) — `checkAlive()`, anchor in `heap` if non-null,
+   call `WebViewNative.webview_offscreen_set_dialog_callback(peer, cb)`,
+   return `this`.
+3. Javadoc:
+   - Mirrors the `EmbeddedWebView.setDialogCallback` Javadoc
+     above.
+   - Adds: "On macOS / Windows, where the offscreen engine
+     itself is a stub, this method has no effect — the native
+     stub is a no-op. Linux is the only platform where the
+     offscreen path actually dispatches dialog requests, and
+     STORY-004-002 implements the GTK signal-handler side."
+4. No other changes to `OffscreenWebView`.
+
+### 11. Extend WebViewNative with two new natives
+File: `src/ca/weblite/webview/WebViewNative.java`
+
+1. Add import (none needed — `WebViewDialogCallback` lives in
+   the same package).
+2. Add two `native static` method declarations, placed near the
+   existing `webview_embed_set_click_callback` and
+   `webview_offscreen_*` blocks:
+   - After `webview_embed_release_native_focus`
+     (`WebViewNative.java:251`):
+     ```
+     // Register (or clear, by passing null) a callback invoked for each
+     // JS-initiated UI dialog (alert / confirm / prompt) or <input type=file>
+     // click inside the embedded WebView.  The callback returns the answer
+     // synchronously, releasing the native UI thread once Java has the value.
+     // Implementations route through DialogDispatcher which marshals to the
+     // Swing EDT.  Per-platform delivery:
+     //   - macOS:   WKUIDelegate selectors on the WKWebView (this canvas).
+     //   - Linux:   script-dialog and run-file-chooser signals on
+     //              WebKitWebView (STORY-004-002).
+     //   - Windows: ICoreWebView2::add_ScriptDialogOpening event handler
+     //              (STORY-004-003); file picker remains OS-native.
+     native static void webview_embed_set_dialog_callback(long w, WebViewDialogCallback cb);
+     ```
+   - In the offscreen section, after
+     `webview_offscreen_execute_editing_command`
+     (`WebViewNative.java:353`):
+     ```
+     // Offscreen counterpart to webview_embed_set_dialog_callback.  Linux only;
+     // macOS / Windows native binaries provide a no-op stub.
+     native static void webview_offscreen_set_dialog_callback(long peer, WebViewDialogCallback cb);
+     ```
+3. Constraints / Invariants:
+   - Both methods accept null `cb` to clear the registration.
+   - Both methods are no-ops if `w` / `peer` is 0 (matches the
+     existing native-side null-guard pattern for the other
+     `*_set_*_callback` methods).
+   - Neither method ever throws via JNI.
+
+### 12. Regenerate JNI header
+Files:
+- `src/ca/weblite/webview/ca_weblite_webview_WebViewNative.h`
+- `src_c/ca_weblite_webview_WebViewNative.h`
+- `windows/ca_weblite_webview_WebViewNative.h`
+
+1. Re-derive the JNI header from the modified `WebViewNative`
+   class via `javac -h` (the existing project workflow — same
+   tooling that produced the current headers).
+2. Two new function prototypes must appear:
+   - `Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1dialog_1callback`
+   - `Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1dialog_1callback`
+3. Both with signatures `(JNIEnv*, jclass, jlong, jobject)` →
+   `void`.
+4. Copy the regenerated header to all three locations (the project
+   keeps copies in `src/`, `src_c/`, and `windows/` per the
+   existing pattern).
+
+### 13. Implement macOS WKUIDelegate Class
+File: `src_c/webview_embed.cpp`
+
+1. Add forward declarations / fields to the `Engine` struct (the
+   Cocoa-specific Engine struct around `webview_embed.cpp:1549`):
+   - `id ui_delegate = nullptr;` — per-engine `WKUIDelegate`
+     instance. Retained when assigned; released in
+     `cocoa_destroy_engine`.
+   - `jobject dialog_callback = nullptr;` — global ref to the
+     Java `WebViewDialogCallback`. Cleared in
+     `cocoa_set_dialog_callback` when replaced and in
+     `cocoa_destroy_engine`.
+   - Cached `jmethodID` cache (lazy): four mids for `onAlert` /
+     `onConfirm` / `onPrompt` / `onFilePicker`. Cache key is
+     the callback's `jclass`; refreshed when the callback is
+     replaced.
+2. Add `get_webview_embed_ui_delegate_cls()` once-per-JVM cached
+   Class builder, mirroring `get_webview_embed_delegate_cls()`
+   at `webview_embed.cpp:1684`. Class name:
+   `WebViewEmbedUIDelegate`. Conforms to `WKUIDelegate`
+   (registered via
+   `class_addProtocol(c, objc_getProtocol("WKUIDelegate"));`).
+   Four method implementations added via
+   `class_addMethod(c, sel("..."), (IMP)impl_fn, type_encoding);`.
+3. Add four C `IMP` functions, one per selector. Each takes
+   `(id self, SEL _cmd, ...)` per Objective-C calling convention.
+   Common skeleton:
+   ```
+   static void impl_alert(id self, SEL _cmd, id webView, id message,
+                          id frame, id completionHandler) {
+       Engine *e = get_engine_from_ui_delegate(self);
+       if (!e || !e->dialog_callback) {
+           ((void(^)())completionHandler)();
+           return;
+       }
+       JNIEnv *env = nullptr;
+       bool attached = ensure_jni_attached(e->jvm, &env);
+       jstring jmsg = ns_to_jstring(env, message);
+       jstring jpage = page_url_jstring(env, webView);
+       jstring jframe = frame_url_jstring(env, frame, webView);
+       jclass cls = env->GetObjectClass(e->dialog_callback);
+       jmethodID mid = env->GetMethodID(cls, "onAlert",
+                                        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+       env->CallVoidMethod(e->dialog_callback, mid, jmsg, jpage, jframe);
+       if (env->ExceptionCheck()) { env->ExceptionDescribe(); env->ExceptionClear(); }
+       env->DeleteLocalRef(jmsg); env->DeleteLocalRef(jpage);
+       env->DeleteLocalRef(jframe); env->DeleteLocalRef(cls);
+       if (attached) e->jvm->DetachCurrentThread();
+       ((void(^)())completionHandler)();
+   }
+   ```
+   Similar skeletons for `impl_confirm` (returns `jboolean`
+   from `CallBooleanMethod`, invokes
+   `((void(^)(BOOL))completionHandler)(result == JNI_TRUE);`),
+   `impl_prompt` (returns `jstring` from
+   `CallObjectMethod`, converts null→nil / non-null→NSString,
+   invokes
+   `((void(^)(NSString*))completionHandler)(nsResult);`), and
+   `impl_open_panel` (returns `jobjectArray` from
+   `CallObjectMethod`, builds `NSArray<NSURL*>*` via
+   `[NSURL fileURLWithPath:]`, invokes
+   `((void(^)(NSArray<NSURL*>*))completionHandler)(urls);`;
+   empty array → `nil`).
+4. `get_engine_from_ui_delegate(id self)` helper: reads the
+   associated Engine pointer set via
+   `objc_setAssociatedObject(ui_delegate, "eng", (id)e, OBJC_ASSOCIATION_ASSIGN);`
+   at delegate-construction time.
+5. For the open-panel selector, extract the `accept` hints
+   defensively:
+   ```
+   id parameters = ...;
+   NSArray *mimes = nil;
+   NSArray *exts = nil;
+   @try { mimes = [parameters valueForKey:@"_acceptedMIMETypes"]; }
+   @catch (NSException *ex) { mimes = nil; }
+   @try { exts = [parameters valueForKey:@"_acceptedFileExtensions"]; }
+   @catch (NSException *ex) { exts = nil; }
+   ```
+   Then convert each `NSArray<NSString*>` (or nil) to a
+   `jobjectArray` of UTF-8 jstrings via a helper
+   `ns_array_to_jstring_array(env, mimes)` (returns
+   zero-length array for nil input).
+6. Add `cocoa_set_dialog_callback` static function, mirroring
+   `cocoa_set_focus_callback` (line 1923) and
+   `cocoa_set_click_callback` (line 1940):
+   ```
+   static void cocoa_set_dialog_callback(Engine *e, JNIEnv *env, jobject cb) {
+       if (!e) return;
+       if (e->dialog_callback) {
+           env->DeleteGlobalRef(e->dialog_callback);
+           e->dialog_callback = nullptr;
+       }
+       if (cb) {
+           e->dialog_callback = env->NewGlobalRef(cb);
+       }
+   }
+   ```
+7. Inside `cocoa_create_engine` (line 1951), after the existing
+   script-message delegate registration block (lines 2083-2090):
+   ```
+   // Install the WKUIDelegate so JS-initiated dialogs (alert / confirm /
+   // prompt / <input type=file>) flow through Java instead of being
+   // silently dropped (the default behaviour when uiDelegate is nil).
+   Class ui_delegate_cls = get_webview_embed_ui_delegate_cls();
+   id ui_delegate = msg((id)ui_delegate_cls, sel("new"));
+   objc_setAssociatedObject(ui_delegate, "eng", (id)e, OBJC_ASSOCIATION_ASSIGN);
+   msg<void, id>(e->webview, sel("setUIDelegate:"), ui_delegate);
+   e->ui_delegate = ui_delegate;  // retain count of 1 from `new`; we hold the only ref
+   ```
+8. Inside `cocoa_destroy_engine` (existing function in the same
+   file): release `ui_delegate` and delete the
+   `dialog_callback` global ref:
+   ```
+   if (e->ui_delegate) {
+       msg<void, id>(e->webview, sel("setUIDelegate:"), nil);
+       msg(e->ui_delegate, sel("release"));
+       e->ui_delegate = nullptr;
+   }
+   if (e->dialog_callback) {
+       env->DeleteGlobalRef(e->dialog_callback);
+       e->dialog_callback = nullptr;
+   }
+   ```
+9. Add JNI bridge functions at the bottom of the file (the
+   existing function block where `webview_embed_set_focus_callback`
+   etc. live):
+   ```
+   JNIEXPORT void JNICALL
+   Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1dialog_1callback(
+       JNIEnv *env, jclass, jlong w, jobject cb) {
+       Engine *e = reinterpret_cast<Engine*>(w);
+       if (!e) return;
+   #if __APPLE__
+       cocoa_set_dialog_callback(e, env, cb);
+   #elif __linux__
+       // Linux implementation lands in STORY-004-002.
+       gtk_set_dialog_callback(e, env, cb);
+   #endif
+   }
+   ```
+   - The `__linux__` branch references `gtk_set_dialog_callback`,
+     which lands in STORY-004-002. For this canvas, the function
+     can be declared as an empty stub in the Linux build paths
+     to keep linking happy across all three branches:
+     ```
+     #if __linux__
+     static void gtk_set_dialog_callback(Engine *e, JNIEnv *env, jobject cb) {
+         // Stub — implemented in STORY-004-002.  Anchoring / clearing the
+         // global ref is the only thing this stub must do correctly so
+         // STORY-004-002 can wire signal handlers without re-doing the
+         // lifecycle code.
+         if (!e) return;
+         if (e->dialog_callback) { env->DeleteGlobalRef(e->dialog_callback); e->dialog_callback = nullptr; }
+         if (cb) { e->dialog_callback = env->NewGlobalRef(cb); }
+     }
+     #endif
+     ```
+     (The same field/ref dance, no signal connection. STORY-004-002
+     swaps in the `g_signal_connect` calls.)
+   - Similar offscreen variant:
+     ```
+     JNIEXPORT void JNICALL
+     Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1dialog_1callback(
+         JNIEnv *env, jclass, jlong peer, jobject cb) {
+         Offscreen *o = reinterpret_cast<Offscreen*>(peer);
+         if (!o) return;
+     #if __linux__
+         gtk_offscreen_set_dialog_callback(o, env, cb);
+     #else
+         // No offscreen engine on macOS / Windows.
+     #endif
+     }
+     ```
+     The `gtk_offscreen_set_dialog_callback` stub mirrors the
+     embedded one.
+10. Constraints / Invariants:
+    - No changes to any existing line in `cocoa_create_engine`
+      other than the additive block at step 7.
+    - The four selector IMPs MUST always invoke the completion
+      handler exactly once, even on error paths (null callback,
+      JNI exception, etc.). Failure to do so hangs the WebKit
+      JS thread forever.
+    - The Engine's `dialog_callback` field is read on every
+      dialog dispatch; concurrent `cocoa_set_dialog_callback`
+      replacement is racy in theory but irrelevant in practice
+      because callback replacement only happens at peer-attach
+      time (single-threaded EDT).
+    - The `_acceptedMIMETypes` / `_acceptedFileExtensions` KVC
+      reads are wrapped in `@try`/`@catch`; failure produces an
+      empty `jobjectArray` and the default `JFileChooser` shows
+      all files. Document the KVC use with an explanatory
+      comment in the code.
+
+### 14. Wire the Dialog Bridge — WebViewHeavyweightComponent
+File: `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
+
+1. Add imports:
+   - `import ca.weblite.webview.WebViewDialogCallback;`
+2. Inside `createPeer()` (currently
+   `WebViewHeavyweightComponent.java:409`), AFTER the existing
+   `embedded.setClickCallback(...)` block at
+   `WebViewHeavyweightComponent.java:491-501`, insert:
+   ```
+   // Install the dialog bridge so JS alert/confirm/prompt and
+   // <input type=file> route to the per-component WebViewDialogHandler.
+   // Anchored in EmbeddedWebView.heap by setDialogCallback so the JVM
+   // does not collect the lambda while the native side holds a global ref.
+   embedded.setDialogCallback(new WebViewDialogCallback() {
+       @Override public void onAlert(String message, String pageUrl, String frameUrl) {
+           dialogDispatcher.dispatchAlert(message, pageUrl, frameUrl);
+       }
+       @Override public boolean onConfirm(String message, String pageUrl, String frameUrl) {
+           return dialogDispatcher.dispatchConfirm(message, pageUrl, frameUrl);
+       }
+       @Override public String onPrompt(String message, String defaultValue, String pageUrl, String frameUrl) {
+           return dialogDispatcher.dispatchPrompt(message, defaultValue, pageUrl, frameUrl);
+       }
+       @Override public String[] onFilePicker(boolean multiple, String[] mimeTypes, String[] extensions, String pageUrl, String frameUrl) {
+           return dialogDispatcher.dispatchFilePicker(multiple, mimeTypes, extensions, pageUrl, frameUrl);
+       }
+   });
+   ```
+3. Logic / sequencing rationale:
+   - The dialog bridge install comes AFTER `setFocusCallback` and
+     `setClickCallback` in registration order, but ordering does
+     not matter functionally — these are independent native
+     callbacks.
+   - No `addOnBeforeLoad` / `addJavascriptCallback` calls — the
+     dialog channel does not use a JS shim or reserved binding.
+   - The anonymous `WebViewDialogCallback` captures `dialogDispatcher`
+     (the base-class field). On `dispose()`, the
+     `EmbeddedWebView.dispose()` path clears `heap` and the
+     native side's `cocoa_set_dialog_callback(nullptr)` is
+     called from `webview_embed_destroy`, releasing the global
+     ref. After dispose, the dispatcher's `disposed` flag
+     ensures dispatches return safe fallbacks if any in-flight
+     native callback fires before the native side has fully
+     torn down.
+4. Constraints / Invariants:
+   - Purely additive — no changes to existing `createPeer` lines.
+   - No changes to `dispose()` — the native destroy path
+     already handles callback cleanup.
+   - The component's `dispose()` method MUST also call
+     `dialogDispatcher.disposeAll()` so the dispatcher's
+     `disposed` flag flips before any in-flight handler runs
+     past the native teardown. Add this line in
+     `WebViewHeavyweightComponent.dispose()` immediately before
+     the existing `embedded.dispose()` call.
+
+### 15. Wire the Dialog Bridge — WebViewLightweightComponent
+File: `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
+
+1. Add imports:
+   - `import ca.weblite.webview.WebViewDialogCallback;`
+2. Inside `addNotify()` (currently
+   `WebViewLightweightComponent.java:189`), AFTER the existing
+   console-bridge and mouse-bridge installs and INSIDE the
+   `engine != null` branch (matches the late-install pattern
+   used by the other bridges), insert the exact-same anonymous
+   `WebViewDialogCallback` block from Operation 14 but targeting
+   `engine.setDialogCallback(...)` instead of `embedded.setDialogCallback`:
+   ```
+   engine.setDialogCallback(new WebViewDialogCallback() {
+       @Override public void onAlert(String message, String pageUrl, String frameUrl) {
+           dialogDispatcher.dispatchAlert(message, pageUrl, frameUrl);
+       }
+       @Override public boolean onConfirm(String message, String pageUrl, String frameUrl) {
+           return dialogDispatcher.dispatchConfirm(message, pageUrl, frameUrl);
+       }
+       @Override public String onPrompt(String message, String defaultValue, String pageUrl, String frameUrl) {
+           return dialogDispatcher.dispatchPrompt(message, defaultValue, pageUrl, frameUrl);
+       }
+       @Override public String[] onFilePicker(boolean multiple, String[] mimeTypes, String[] extensions, String pageUrl, String frameUrl) {
+           return dialogDispatcher.dispatchFilePicker(multiple, mimeTypes, extensions, pageUrl, frameUrl);
+       }
+   });
+   ```
+3. Logic / sequencing rationale: identical to Operation 14.
+4. Constraints / Invariants:
+   - On macOS / Windows, the offscreen engine is a stub and
+     `setDialogCallback` is a no-op there — handler registration
+     on the Java side still works but the lightweight component
+     on those platforms is itself stubbed (per the existing
+     README behaviour). The bridge install does not error out
+     in stub mode.
+   - The `engine != null` check around the existing console /
+     mouse bridges is inherited — when `engine == null`, the
+     dialog bridge is also skipped.
+   - The component's `removeNotify()` (or equivalent disposal
+     path) MUST also call `dialogDispatcher.disposeAll()` for
+     the same reason as Operation 14.
+
+### 16. Create Interactive Demo — WebViewDialogDemo
+Files:
+- `demos/WebViewDialogDemo/src/ca/weblite/webview/demos/WebViewDialogDemo.java`
+- `demos/WebViewDialogDemo/README.md` (optional — short)
+
+1. Responsibility: exercise every dialog kind in every handler
+   mode against an inline page, so AC verification is possible
+   without an external website.
+2. JFrame layout:
+   - Top: a `JComboBox<String>` with three items — "Default
+     handler (Swing dialogs)", "Custom handler (programmatic
+     answers)", "Drop handler (no UI)". Default selection is
+     index 0.
+   - Centre: a single `WebViewComponent.create()` filling most
+     of the content pane.
+   - Bottom: a `JTextArea` (read-only, scrollable) that
+     receives every captured `console.*` line so the demo can
+     verify JS-side return values without external tooling.
+3. Inline page (installed via
+   `addOnBeforeLoad("document.title='WebViewDialogDemo';")`
+   and `setUrl(...)` with a `data:text/html` URI carrying):
+   ```
+   <!doctype html>
+   <html><body style="font:14px sans-serif;padding:20px">
+   <h2>WebView Dialog Demo</h2>
+   <button onclick="alert('hello world')">Alert</button>
+   <button onclick="console.log('confirm =', confirm('proceed?'))">Confirm</button>
+   <button onclick="console.log('prompt =', JSON.stringify(prompt('name?', 'default')))">Prompt</button>
+   <input type="file" id="single" accept=".png,.jpg" onchange="console.log('files =', this.files.length)">
+   <input type="file" id="multi" accept="image/*,.pdf" multiple onchange="console.log('multi files =', this.files.length)">
+   </body></html>
+   ```
+4. Global Swing setup before `JFrame` show:
+   - `JPopupMenu.setDefaultLightWeightPopupEnabled(false);`
+     and the tooltip pendant — required for heavyweight on macOS
+     so any Swing popup (in this demo, the JFileChooser's "Open"
+     button menu, JOptionPane's button labels) paints above the
+     WKWebView. (Matches the existing
+     `WebViewHeavyweightDemo` setup.)
+5. Handler-mode switcher:
+   - On selection change, call
+     `wv.setDialogHandler(...)` with one of three values:
+     - **Default**:
+       `wv.setDialogHandler(WebViewDialogHandler.DEFAULT);` (or
+       `setDialogHandler(null)` would be DROP, so explicit
+       DEFAULT is required).
+     - **Custom**:
+       ```
+       wv.setDialogHandler(new WebViewDialogHandler() {
+           @Override public void alertOpened(WebViewAlertEvent e) {
+               appendLog("custom alert: " + e.message());
+           }
+           @Override public boolean confirmOpened(WebViewConfirmEvent e) {
+               appendLog("custom confirm: " + e.message());
+               return true;
+           }
+           @Override public String promptOpened(WebViewPromptEvent e) {
+               appendLog("custom prompt: " + e.message());
+               return "hardcoded";
+           }
+           @Override public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+               appendLog("custom file picker: multiple=" + e.multiple()
+                   + " ext=" + e.acceptedExtensions());
+               return Collections.singletonList(new File("/tmp/preselected.txt"));
+           }
+       });
+       ```
+     - **Drop**: `wv.setDialogHandler(null);`
+6. The demo registers a `ConsoleListener` that mirrors every
+   captured line into the JTextArea. The handler's
+   `appendLog(...)` helper also appends to the same area
+   (`SwingUtilities.invokeLater(() -> textArea.append(...))`).
+7. The demo is for AC verification, not full editor support —
+   `<input type="file">` selections are not actually read; the
+   demo just verifies the page's `change` event fires and
+   `files.length` matches the expected count.
+
+### 17. Update README
+File: `README.md`
+
+1. Locate the existing "Demos" / additional-demos paragraph
+   (currently under the demo discussion, around the
+   `WebViewContextMenuDemo` and `WebViewAsyncEvalDemo` bullets).
+2. Append a new bullet:
+   ```
+   * `demos/WebViewDialogDemo/` — exercises the new
+     `WebViewDialogHandler` API: the four default Swing dialogs
+     (alert / confirm / prompt / file picker), a custom handler
+     with programmatic answers, and the `setDialogHandler(null)`
+     drop mode for headless tests.
+   ```
+3. Add a new top-level subsection (sibling of "Talking to
+   JavaScript") titled **"Browser-initiated dialogs"**, placed
+   after "Talking to JavaScript" and before the "Demo" section.
+   Content:
+   - One paragraph describing what `window.alert` /
+     `window.confirm` / `window.prompt` and `<input type=file>`
+     do, and how `WebViewComponent.setDialogHandler` lets the
+     host customise or suppress them.
+   - A short code example:
+     ```java
+     wv.setDialogHandler(new WebViewDialogHandler() {
+         @Override public boolean confirmOpened(WebViewConfirmEvent e) {
+             return JOptionPane.showConfirmDialog(
+                 frame, e.message(), "Confirm",
+                 JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION;
+         }
+     });
+     ```
+   - A platform-status note documenting that this iteration
+     covers macOS heavyweight only; on Linux and Windows the
+     embedded WebView continues to show the platform-default
+     dialogs (WebKitGTK and WebView2 respectively) until
+     STORY-004-002 and STORY-004-003 land. The `setDialogHandler`
+     API itself is available everywhere; it just doesn't fire on
+     Linux / Windows yet.
+   - One bullet noting the `setDialogHandler(null)` drop
+     semantic for headless test environments.
+4. No other prose changes.
+
+### 18. Unit Tests — DialogDispatcherTest
+File: `test/ca/weblite/webview/DialogDispatcherTest.java`
+
+1. Test layout follows `EvalDispatcherTest` — JUnit 4, no real
+   engine, no Swing initialisation beyond what
+   `SwingUtilities.invokeAndWait` requires.
+2. Test cases:
+   - `testDefaultHandlerNotNull()`: a fresh `DialogDispatcher`
+     reports `getHandler() == WebViewDialogHandler.DEFAULT`.
+   - `testSetHandlerNullInstallsDrop()`: after
+     `setHandler(null)`, `getHandler()` is non-null but is NOT
+     identity-equal to `DEFAULT`. Dispatch returns the
+     drop-semantic values (alert no-op, confirm false, prompt
+     null, file picker empty array).
+   - `testSetHandlerCustomIsReturnedByGetter()`: after
+     `setHandler(custom)`, `getHandler() == custom`.
+   - `testDispatchAlertInvokesHandlerOnEdt()`: a custom handler
+     records `SwingUtilities.isEventDispatchThread()` and the
+     received event; after `dispatcher.dispatchAlert("msg",
+     "http://a", "http://b")` returns, assert the recorded
+     boolean is true, message matches, URLs match.
+   - `testDispatchConfirmReturnsHandlerValue()`: handler returns
+     `true`; dispatcher's `dispatchConfirm(...)` returns true.
+     Then change handler to return `false`; assert again.
+   - `testDispatchPromptReturnsHandlerValue()`: handler returns
+     `"answer"`; dispatcher's `dispatchPrompt(...)` returns
+     `"answer"`. Handler returns null; dispatcher returns null.
+   - `testDispatchFilePickerReturnsHandlerPaths()`: handler
+     returns
+     `Arrays.asList(new File("/tmp/a.png"), new File("/tmp/b.png"))`;
+     dispatcher's `dispatchFilePicker(...)` returns a String[]
+     of two elements `"/tmp/a.png"`, `"/tmp/b.png"`.
+   - `testDispatchFilePickerNormalisesExtensions()`: pass
+     `new String[]{".PNG", "JPG", ".png"}` as extensions; the
+     event's `acceptedExtensions()` is `["png","jpg"]`
+     (lowercase, dot-stripped, deduped, order-preserved).
+   - `testDispatchFilePickerNormalisesMimeTypes()`: pass
+     `new String[]{"Image/PNG", "image/png"}`; event's
+     `acceptedMimeTypes()` is `["image/png"]`.
+   - `testDispatchFilePickerHandlesNullArrays()`: pass null for
+     both arrays; event's lists are both empty; dispatch
+     succeeds.
+   - `testHandlerExceptionIsIsolated()`: handler throws a
+     `RuntimeException`; the dispatcher's `dispatchAlert` returns
+     normally (void); a custom uncaught-exception handler
+     installed for the test thread records the thrown
+     `RuntimeException`. Use a test-local
+     `Thread.UncaughtExceptionHandler` set via
+     `Thread.setDefaultUncaughtExceptionHandler` and restore
+     the prior handler in `@After`.
+   - `testHandlerExceptionConfirmReturnsFalse()`: handler throws;
+     `dispatchConfirm` returns `false` (the fallback).
+   - `testHandlerExceptionPromptReturnsNull()`: handler throws;
+     `dispatchPrompt` returns `null`.
+   - `testHandlerExceptionFilePickerReturnsEmpty()`: handler
+     throws; `dispatchFilePicker` returns `new String[0]`.
+   - `testDisposedDispatcherReturnsFallbacks()`: call
+     `disposeAll()`, then assert each `dispatch*` returns the
+     fallback value without invoking the (otherwise-throwing)
+     handler.
+   - `testDisposeAllIsIdempotent()`: call `disposeAll()` twice;
+     no exception.
+   - `testEdtCallFromEdtShortCircuits()`: use
+     `SwingUtilities.invokeAndWait(() -> dispatcher.dispatchAlert(...))`
+     so the test thread is the EDT during the inner dispatch.
+     Assert the handler still runs on the EDT and the dispatch
+     completes without re-entering `invokeAndWait`.
+3. Each test uses a mock `WebViewComponent` — since the
+   dispatcher only uses the source for event construction and
+   never calls methods on it during dispatch, a stub subclass
+   that overrides every abstract method to no-op suffices.
+4. Tests do NOT verify Swing-dialog rendering (that's the demo's
+   job); they verify the dispatcher's Java contract.
+
+## N · Norms
+
+- **Mirror the `WebViewMouseDispatcher` pattern for the
+  dispatcher class skeleton, not `ConsoleDispatcher`.** The
+  mouse dispatcher's `private final WebViewComponent source;`
+  field, EDT-marshal helper, and per-listener exception
+  isolation pattern are the closer template — both dispatchers
+  hold a reference to their owning component and produce
+  events parametrized by source. Diverges from
+  `WebViewMouseDispatcher` in two key places: single handler
+  reference instead of `CopyOnWriteArrayList`, and
+  `invokeAndWait` instead of `invokeLater`. Document both
+  divergences in `DialogDispatcher`'s class-level Javadoc.
+- **Accessor naming.** Value-object accessors use the no-`get`
+  style (`event.message()`, `event.multiple()`) to match
+  `ConsoleMessage`, `WebViewMouseEvent`, and the
+  fluent setters on `WebView`. Boolean accessors keep the `is`
+  prefix only when grammatically natural (`multiple()` not
+  `isMultiple()` because "multiple" is already adjectival;
+  `isContentEditable` etc. on existing types stay as-is).
+- **Null discipline.** Strings that have a "no value" semantic
+  use the empty string, not null, on the four event POJOs.
+  Lists on `WebViewFilePickerEvent` use empty
+  unmodifiable lists, not null. The single Java-side null
+  surface area is `WebViewDialogHandler.promptOpened`'s return
+  value (where null signals cancel per the JS contract); the
+  dispatcher carries that null verbatim to the native side,
+  which maps it to the platform's "user cancelled" outcome.
+- **`getDialogHandler() != null` is a never-relax invariant.**
+  Even after `setDialogHandler(null)`, `getDialogHandler()`
+  returns the DROP singleton. Even after `dispose()`,
+  `getDialogHandler()` returns whatever was last set (the
+  dispatcher's handler field outlives the native peer).
+  Document on the method Javadoc.
+- **`setDialogHandler(null) != setDialogHandler(DEFAULT)`.**
+  Null installs the drop singleton (no UI, returns JS-spec
+  cancel values). `DEFAULT` installs the Swing-dialogs default
+  instance. Callers wanting to reset to the framework default
+  must pass `WebViewDialogHandler.DEFAULT` explicitly. Document
+  on `setDialogHandler` Javadoc.
+- **JS-contract null vs Swing-side null in promptOpened.** The
+  Swing-default `promptOpened` calls
+  `JOptionPane.showInputDialog(...)` which returns null on
+  cancel and the entered text otherwise. The dispatcher
+  propagates that null verbatim to the native side, which on
+  macOS invokes the WKWebView completion handler with `nil`,
+  which JS sees as `null`. Do NOT coerce null to empty string
+  anywhere in this pipeline.
+- **Reserved-binding prefix is NOT touched.** This canvas adds
+  no `__webview_*` JS binding name and no JS shim. The
+  reserved-prefix invariant from
+  [[swing-webview-context-menu-and-dom-mouse-events]] and
+  [[swing-webview-devtools-and-console-api]] is preserved
+  verbatim.
+- **No JSON parser dependency.** The four event POJOs and
+  `WebViewDialogCallback` use primitive arguments only
+  (`String`, `String[]`, `boolean`). No JSON parsing happens
+  on the dispatch path — the JNI bridge passes UTF-8 jstrings
+  and `jobjectArray` of jstrings directly.
+- **`@try`/`@catch` is the macOS private-API
+  defensive-programming idiom.** Use it around the
+  `_acceptedMIMETypes` / `_acceptedFileExtensions` KVC reads.
+  Falling back to an empty `NSArray` on failure is correct —
+  the page's own client-side `accept` validation continues to
+  work and the user can still select files of any type. Do
+  NOT log the catch (the failure is expected on hypothetical
+  future macOS releases that hide the private accessors).
+- **Cached `jmethodID`s are resolved per-call, NOT cached.**
+  The existing `fire_click_callback` resolves
+  `cls = GetObjectClass(cb); mid = GetMethodID(cls, "invoke", ...)`
+  on every invocation
+  (`webview_embed.cpp:166-170`). Mirror that pattern in the
+  four dialog selectors. Caching across calls would require
+  cleaning up `GlobalRef` on callback replacement and adds
+  complexity for negligible perf gain (the modal dialog's
+  wall-clock duration dwarfs the GetMethodID cost).
+- **JNI exception clearing on every C-call boundary.** After
+  every `CallVoidMethod` / `CallBooleanMethod` /
+  `CallObjectMethod`, check `env->ExceptionCheck()` and clear
+  any pending Java exception with `env->ExceptionDescribe();
+  env->ExceptionClear();`. A pending Java exception
+  propagating into AppKit would crash the process — the C
+  side must always sanitize before returning to ObjC.
+- **Completion handler invocation is non-negotiable on every
+  exit path.** The four WKUIDelegate selector implementations
+  MUST invoke the completion handler exactly once, regardless
+  of error paths (null callback, JNI attach failure, exception
+  catch). A skipped completion handler hangs the page's JS
+  thread forever. The pattern: use a single tail-position
+  call to the completion block at the end of the function,
+  with early-return paths invoking the block with the
+  "safe default" arg (`alert: ()`, `confirm: NO`, `prompt: nil`,
+  `open-panel: nil`).
+- **`pom.xml` Java 8 target stays in force.** `default`
+  methods on interfaces, `Supplier<T>`,
+  `Function<T,R>`, `Collections.singletonList`,
+  `Collections.emptyList`, `Collections.unmodifiableList`,
+  `LinkedHashSet`, and `java.util.function` are all Java 8.
+- **Demo style.** New demos follow the existing pattern
+  documented under [[swing-webview-context-menu-and-dom-mouse-events]]
+  Norms (single Java source under
+  `demos/<DemoName>/src/...`, no Maven config, runnable via the
+  existing `run-*` scripts after the standard compile-and-run).
+  Demos are NOT shipped as Maven artifacts; they are reference
+  applications.
+- **Heavyweight popup prerequisite.** The demo MUST call
+  `JPopupMenu.setDefaultLightWeightPopupEnabled(false)` and
+  `ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false)`
+  at startup, before the JFrame is shown. Without this, the
+  `JFileChooser`'s File / View dropdowns and `JOptionPane`'s
+  message-area tooltips render BEHIND the WKWebView on
+  macOS. Document this at the top of the demo file with a
+  one-line comment.
+- **Unit-test conventions.** Tests live under
+  `test/ca/weblite/webview/`. Tests must run headless (no
+  `JFrame` shown). Tests that need EDT execution use
+  `SwingUtilities.invokeAndWait` directly; do not use a
+  TestFX-style framework (the project has no such dependency).
+- **EDT contract is non-negotiable.** Every dispatcher
+  invocation of the handler runs on the EDT, full stop. The
+  ban on `evalAsync(...).get()` from inside a handler is a
+  documented rule, not a runtime check. Document in
+  `WebViewDialogHandler` Javadoc.
+- **No automated tests for GUI integration.** Consistent with
+  [[swing-heavyweight-webview-embedding]],
+  [[swing-lightweight-webview-embedding]],
+  [[swing-webview-component-mode-selection]], and
+  [[swing-webview-context-menu-and-dom-mouse-events]]. The
+  20 STORY-004-001 ACs are verified by running
+  `WebViewDialogDemo` and exercising each branch manually on
+  macOS; `DialogDispatcherTest` covers the Java contract.
+
+## S · Safeguards
+
+- **Constructor null-checks.** `WebViewAlertEvent`,
+  `WebViewConfirmEvent`, `WebViewPromptEvent`,
+  `WebViewFilePickerEvent`, and `DialogDispatcher` constructors
+  all reject null `source` with `NullPointerException` whose
+  message names the offending parameter (`"source"`). Other
+  String fields coerce null to empty rather than throwing —
+  the native engine may legitimately report no value for
+  `pageUrl` / `frameUrl` etc., and empty-string-as-no-value is
+  the established convention.
+- **Handler exception isolation.** Each `WebViewDialogHandler`
+  invocation in `DialogDispatcher.runOnEdtAndCapture(Void)` is
+  wrapped in `try { ... } catch (Throwable t) { ... }` that
+  forwards to `Thread.getDefaultUncaughtExceptionHandler()`.
+  Matches the existing `ConsoleDispatcher.deliver` pattern
+  (`ConsoleDispatcher.java:235-241`) and
+  `WebViewMouseDispatcher.deliver` pattern
+  (`WebViewMouseDispatcher.java:316-323`). A misbehaving handler
+  cannot break the dispatcher pipeline, hang the native UI
+  thread, or prevent the completion handler from firing —
+  matches story AC20.
+- **InterruptedException handling.**
+  `SwingUtilities.invokeAndWait` can throw
+  `InterruptedException` if the calling thread is interrupted
+  while waiting. The dispatcher catches this, restores the
+  interrupt flag via `Thread.currentThread().interrupt()`, and
+  returns the fallback value. The native completion handler
+  still fires (with the fallback). No `InterruptedException`
+  ever escapes the dispatcher.
+- **InvocationTargetException unwrapping.** When
+  `invokeAndWait` wraps a handler exception, the dispatcher
+  catches `InvocationTargetException`, unwraps via
+  `getCause()`, and forwards the cause (not the wrapper) to
+  the uncaught-exception handler. This matches the convention
+  used elsewhere in the codebase and gives debuggers / loggers
+  the original throw site.
+- **EDT-in-a-handler self-deadlock.** A handler calling
+  `wv.evalAsync(js).get()` deadlocks because both calls park on
+  the EDT (the dispatcher holds the EDT for the handler
+  invocation; `evalAsync` continuations land on the EDT). The
+  dispatcher does NOT detect this — it is a documented caller
+  hazard. The fix is to restructure the handler to use
+  `.thenAccept(...)` instead of `.get()`, but that breaks the
+  synchronous dialog return. Real callers that need a
+  JS-round-trip from inside a handler should pre-compute the
+  needed value before the dialog opens, OR return a default
+  and finish the work asynchronously after the dialog closes.
+  Document in `WebViewDialogHandler` Javadoc.
+- **Dispatcher behaviour after dispose.** Calling
+  `dialogDispatcher.disposeAll()` is idempotent. After
+  disposal, every `dispatch*` call returns the safe fallback
+  (void / false / null / empty array) without invoking the
+  handler — even if the handler is non-null. The native
+  completion handler still fires with that fallback value,
+  releasing the WebKit JS thread cleanly.
+- **WKUIDelegate selector completion-handler invariant.** Every
+  selector implementation MUST invoke the completion handler
+  EXACTLY ONCE on every code path — including JNI attach
+  failure, exception catch, and null-callback short-circuit.
+  Skipping invocation hangs the page's JS thread forever and
+  is unrecoverable without page reload. Use a single
+  tail-call to the completion block, with early-return paths
+  invoking it with the safe-default arg. This is enforced
+  by code review; the language has no compiler check for it.
+- **`<input type="password">` is unaffected.** The WKUIDelegate
+  selectors for alert / confirm / prompt do not receive
+  password-field state; password values continue to be the
+  page's own concern. The dispatch payloads never carry
+  password input.
+- **`_acceptedMIMETypes` / `_acceptedFileExtensions` KVC
+  fallback.** The macOS open-panel selector wraps the two KVC
+  reads in `@try`/`@catch` and falls back to empty arrays on
+  failure. The default `JFileChooser` then shows all files
+  unfiltered. The page's own `<input accept="...">` validation
+  continues to work in JavaScript on the page side.
+- **JNI exception sanitization.** Every `CallVoidMethod` /
+  `CallBooleanMethod` / `CallObjectMethod` is followed by
+  `if (env->ExceptionCheck()) { env->ExceptionDescribe();
+  env->ExceptionClear(); }`. A leaked Java exception
+  propagating into ObjC crashes the process — sanitization is
+  mandatory.
+- **`AttachCurrentThread` / `DetachCurrentThread` symmetry.**
+  Each selector implementation tracks whether IT attached the
+  AppKit thread to the JVM (returns `JNI_OK` from
+  `AttachCurrentThreadAsDaemon`, OR `GetEnv` returned the
+  already-attached env). If attached locally, the selector
+  detaches before returning. If already attached, the
+  selector leaves the attachment in place. Asymmetric attach /
+  detach (or repeated detach) crashes the process.
+- **Listener mutation during dispatch.** Calling
+  `setDialogHandler(otherHandler)` from inside an
+  EDT-running handler invocation is legal — the volatile
+  handler field is re-read on every dispatch, so the new
+  handler takes effect for the NEXT dispatch. The CURRENT
+  dispatch completes with the handler it was called with.
+- **Pre-display handler registration.** Callers may register a
+  handler via `setDialogHandler` before the native peer
+  attaches; the handler reference lives in the Java-side
+  dispatcher and is read whenever a native dispatch arrives.
+  No buffering, no replay — dialogs are synchronous and there
+  is no JS in flight before the page loads.
+- **Dispose during open dialog.** If `dispose()` is called
+  while a Swing dialog is still showing on the EDT, the dialog
+  remains visible (the dispatcher's `disposed` flag does NOT
+  forcibly close it — that would race with the EDT). The
+  handler eventually completes when the user dismisses the
+  dialog; the captured value is returned to the dispatcher,
+  but the `disposed` flag (set by `disposeAll()`) overrides
+  it and the dispatcher returns the fallback to the native
+  side. The native side is responsible for not crashing when
+  the WKWebView has been deallocated; in practice the destroy
+  path calls `setUIDelegate:nil` BEFORE releasing the
+  delegate, so any in-flight completion handler points at a
+  still-valid WKWebView. Document this teardown ordering as a
+  Constraint on the `cocoa_destroy_engine` change in
+  Operation 13.
+- **Two simultaneous WebViews showing dialogs.** Each
+  `WebViewComponent` has its own `DialogDispatcher` and its
+  own native callback. Each dispatch independently calls
+  `SwingUtilities.invokeAndWait`. The EDT serialises them — the
+  second `JOptionPane.show*` call queues until the first one
+  dismisses. The native JS thread for the second component
+  blocks during the queue. No deadlock — the EDT eventually
+  pumps both. Document this in `WebViewDialogHandler` Javadoc
+  as "simultaneous dialogs queue on the EDT in registration
+  order".
+- **Reserved-prefix protection is preserved.** No new reserved
+  binding is added by this canvas. The existing
+  `RESERVED_BINDING_PREFIX = "__webview_"` discipline
+  continues unchanged.
+- **macOS-only coverage in this canvas.** Linux and Windows
+  builds continue to use the platform's default dialog
+  behaviour (WebKitGTK and WebView2 built-in dialogs) until
+  STORY-004-002 and STORY-004-003 land. `setDialogHandler`
+  registrations on Linux / Windows are silently inactive —
+  the handler reference is stored in the dispatcher but no
+  native callback is wired to invoke it. README documents
+  this explicitly per Operation 17. A future maintainer who
+  removes the macOS-only restriction MUST update this
+  documentation in lockstep.
+- **No `setDebug` coupling.** Dialog handling works in release
+  builds (`debug=false`). The `WKUIDelegate` is installed
+  unconditionally during `cocoa_create_engine`. Contrast with
+  `openDevTools` which DOES require debug.
+- **No GUI dependency at construction time.** Constructing a
+  `WebViewComponent`, calling `setDialogHandler`, and
+  constructing a `DialogDispatcher` MUST be possible in a
+  headless test environment (no `java.awt.HeadlessException`
+  thrown). The interface's `default` methods do invoke
+  `JOptionPane` / `JFileChooser`, but those classes only
+  trigger headless errors when their `show*` methods are
+  CALLED — declaring or constructing the handler is fine.
+  Tests that exercise the dispatcher use custom handlers
+  that do not invoke Swing.

--- a/spdd/prompt/12-20260518-2310-[Feat]-Browser-Initiated-Ui-Dialogs-Linux-Coverage.md
+++ b/spdd/prompt/12-20260518-2310-[Feat]-Browser-Initiated-Ui-Dialogs-Linux-Coverage.md
@@ -1,0 +1,1012 @@
+---
+generated_at: 2026-05-18T23:10:00-07:00
+---
+
+# REASONS Canvas: Browser-Initiated UI Dialogs — Linux WebKitGTK Coverage (Heavyweight + Lightweight)
+
+## R · Requirements
+
+- Wire the existing `WebViewDialogHandler` contract — designed and
+  shipped in STORY-004-001 / canvas-11 — to the Linux WebKitGTK
+  engines so JS-initiated `alert` / `confirm` / `prompt` and
+  `<input type="file">` clicks flow through the per-component
+  `DialogDispatcher` and end up on the Swing EDT, identical to the
+  macOS WKWebView path.
+- Both Linux engines are in scope:
+  - **Heavyweight** (`WebViewHeavyweightComponent` →
+    `EmbeddedWebView` → `gtk_create_engine` in
+    `src_c/webview_embed.cpp:456`).
+  - **Lightweight** (`WebViewLightweightComponent` →
+    `OffscreenWebView` → `gtk_off_create_engine` in
+    `src_c/webview_embed.cpp:1057`).
+- Connect two `g_signal_connect` handlers on every `WebKitWebView`
+  created by either engine:
+  - `script-dialog` (`WebKitScriptDialog *`) — fires for `alert` /
+    `confirm` / `prompt` / `before-unload`.  Returning `TRUE`
+    suppresses the default GTK dialog and lets the application drive
+    the response via `webkit_script_dialog_confirm_set_confirmed` /
+    `webkit_script_dialog_prompt_set_text`.
+  - `run-file-chooser` (`WebKitFileChooserRequest *`) — fires for
+    `<input type="file">` clicks.  Returning `TRUE` suppresses the
+    default GTK file chooser; the application calls
+    `webkit_file_chooser_request_select_files` (accept) or
+    `webkit_file_chooser_request_cancel` (cancel).
+- The two signal handlers MUST be shared code (single C function per
+  signal kind) registered at the two distinct `g_signal_connect`
+  sites — same approach as the existing `on_load_changed` /
+  `on_load_failed` handlers (lines 591-594) wired into both engines
+  individually.  Per the canvas-11 Approach §10 commitment, sharing
+  the function pointer keeps behaviour-symmetric across heavyweight
+  and lightweight modes.
+- `before-unload` (`WEBKIT_SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM`) MUST
+  route to `dispatchConfirm` — no dedicated `beforeUnloadOpened`
+  handler is introduced in this story.  Matches story
+  STORY-004-002 AC12 and the canvas-11 Norms commitment.
+- Each signal handler MUST find the `Engine *` (or `OffEngine *`)
+  via the `user_data` `gpointer` passed to `g_signal_connect` —
+  same pattern as the existing `on_message` and `on_run_press`
+  handlers, which already carry the engine pointer through this
+  channel.
+- Each handler MUST read the engine's `dialog_callback` `jobject`
+  global ref (already declared on both `Engine` and `OffEngine`
+  structs by STORY-004-001) and invoke the appropriate
+  `WebViewDialogCallback` method via JNI:
+  - `onAlert` — signature
+    `(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V`.
+  - `onConfirm` — signature
+    `(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z`.
+  - `onPrompt` — signature
+    `(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;`.
+  - `onFilePicker` — signature
+    `(Z[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;`.
+- The handlers run on the GTK main thread (the dedicated GTK pump
+  thread per the README "Heavyweight platform notes" section).  JNI
+  attach / detach MUST follow the existing `fire_click_callback`
+  pattern (line 402) — `GetEnv` first, fall back to
+  `AttachCurrentThread` if needed, detach only when this call
+  attached.
+- The handler MUST always return `TRUE` so the GTK default never
+  fires.  When `dialog_callback` is null (no handler installed yet,
+  or post-disposal), the handler MUST still return `TRUE` and
+  resolve the dialog with the JS-spec safe default:
+  - Alert: no `set_*` call; return `TRUE`.
+  - Confirm / before-unload:
+    `webkit_script_dialog_confirm_set_confirmed(dialog, FALSE)`.
+  - Prompt: no `set_text` call (engine treats absence as `null`);
+    return `TRUE`.
+  - File picker: `webkit_file_chooser_request_cancel(request)`.
+  This preserves the no-handler invariant — the JS thread always
+  resumes within bounded time even when the engine fires a dialog
+  before peer-attach finishes wiring the callback (in practice
+  impossible because no page is loaded yet, but the handler must
+  not assume it).
+- `pageUrl` and `frameUrl` MUST be populated from
+  `webkit_web_view_get_uri(WEBKIT_WEB_VIEW(web))`.  WebKitGTK's
+  script-dialog and file-chooser signals do not carry frame
+  information at this API level, so `frameUrl` equals `pageUrl` —
+  matches STORY-004-002 AC11 / AC18 (the AC verifies the top-level
+  case only).
+- `webkit_file_chooser_request_get_mime_types` returns a
+  NULL-terminated `const gchar *const *`.  The handler MUST convert
+  it to a `jobjectArray` of UTF-8 jstrings (empty array when the
+  page imposed no `accept`).  The DialogDispatcher normalises on
+  the Java side per canvas-11 Approach §9.
+- File-extension hints: WebKitGTK's
+  `webkit_file_chooser_request_get_mime_types_filter` returns a
+  `GtkFileFilter *` (or `NULL`).  This filter is opaque — it does
+  not expose the original `.ext` strings the page wrote.  The
+  handler MUST pass an **empty extensions array** to Java; the
+  Java-side normalisation (canvas-11 Operations §7) handles the
+  empty case correctly and the default `JFileChooser` falls through
+  to showing all files unfiltered.  This is a documented Linux
+  limitation; the page's own `<input accept="...">` validation
+  continues to work in JavaScript on the page side.
+- The implementation MUST NOT regress existing GTK behaviour for
+  any other dialog kind, signal, or load-cycle event.  Only the
+  two new `g_signal_connect` calls are added in each engine; no
+  existing signal handlers, scripts, or settings are modified.
+- The implementation MUST NOT add new JNI entry points
+  (`webview_embed_set_dialog_callback` and
+  `webview_offscreen_set_dialog_callback` are already in place
+  from STORY-004-001).  The implementation MUST NOT add Java-side
+  code (the `DialogDispatcher` is already wired and the
+  `WebViewDialogCallback` adapter is already installed at
+  peer-attach time on both Swing subclasses).  The story is purely
+  native: four new pieces of C / glib code in `src_c/webview_embed.cpp`.
+- Definition of Done:
+  - All 16 STORY-004-002 ACs from
+    `requirements/[User-story-4]browser-initiated-ui-dialogs.md` pass
+    on Linux in both `WebViewHeavyweightComponent` and
+    `WebViewLightweightComponent` modes.  Verified by running
+    `WebViewDialogDemo` on a Linux host with X11 + WebKitGTK 2.x
+    available.
+  - The existing 57-test Java suite continues to pass with zero
+    new failures (no Java code changes).
+  - README's "Browser-initiated dialogs" section is updated: the
+    Linux portion of the platform-status note now says "wired" for
+    both modes instead of "uses platform-default dialogs".
+- Out of scope (explicit non-goals):
+  - Windows WebView2 coverage — STORY-004-003.
+  - Standalone `WebView` integration (still scoped out per
+    STORY-004-001 requirements).
+  - Dedicated `beforeUnloadOpened` handler method — before-unload
+    routes to `confirmOpened` as documented.
+  - Surfacing file-extension hints to Java on Linux —
+    `webkit_file_chooser_request_get_mime_types_filter`'s
+    `GtkFileFilter` is opaque; documented as a Linux limitation.
+  - `WebKitPermissionRequest` (geolocation / notifications /
+    camera) — different signal, different shape, out of scope.
+  - `authenticate` signal (HTTP basic / digest auth) — different
+    channel, out of scope.
+  - Drag-and-drop file uploads — different code path, doesn't go
+    through `run-file-chooser`.
+
+## E · Entities
+
+This canvas does not introduce any new Java types.  All Java
+contracts (`WebViewDialogHandler`, four event POJOs,
+`WebViewDialogCallback`, `DialogDispatcher`,
+`WebViewComponent.setDialogHandler`, etc.) were shipped in
+STORY-004-001 / canvas-11 and remain unchanged.
+
+Native types touched (all in `src_c/webview_embed.cpp`):
+
+- **`Engine`** (line 348) — Linux heavyweight engine struct.  Already
+  carries `jobject dialog_callback` from STORY-004-001
+  (line 387 in this file, post-004-001).  No new fields.
+
+- **`OffEngine`** (line 976) — Linux lightweight (offscreen) engine
+  struct.  Already carries `jobject dialog_callback` from
+  STORY-004-001.  No new fields.
+
+- **`on_script_dialog`** (new static C function) — shared
+  `script-dialog` signal handler.  Same body works against both
+  `Engine *` and `OffEngine *` via a tiny templated / overloaded
+  dispatch helper (the only thing each variant does differently is
+  read the right `dialog_callback` field and call
+  `webkit_web_view_get_uri` against the right web-view widget).
+
+- **`on_run_file_chooser`** (new static C function) — shared
+  `run-file-chooser` signal handler.  Same shape — engine-aware via
+  the helper.
+
+- **`fire_dialog_callback`** family (four new static C helpers, one
+  per dialog kind) — JNI dispatch helpers that mirror the existing
+  `fire_click_callback` shape (line 402): attach the GTK pump
+  thread to the JVM if needed, resolve the `jmethodID`, call the
+  `WebViewDialogCallback` method, sanitize any pending JNI
+  exception, detach.  Each returns the dialog kind's natural type
+  (`void` / `jboolean` / `jstring` (owned local ref) / `jobjectArray`
+  (owned local ref)).
+
+- **README.md** (modified) — the "Browser-initiated dialogs"
+  platform-status subsection updates the Linux line to "wired
+  (heavyweight + lightweight) via WebKitGTK `script-dialog` and
+  `run-file-chooser` signals."
+
+```mermaid
+classDiagram
+direction TB
+
+class Engine {
+    +jobject dialog_callback
+    +GtkWidget* web
+    +JavaVM* jvm
+}
+
+class OffEngine {
+    +jobject dialog_callback
+    +GtkWidget* web
+    +JavaVM* jvm
+}
+
+class on_script_dialog {
+    <<C function>>
+    +invoke(WebKitWebView, WebKitScriptDialog, gpointer) gboolean
+}
+
+class on_run_file_chooser {
+    <<C function>>
+    +invoke(WebKitWebView, WebKitFileChooserRequest, gpointer) gboolean
+}
+
+class fire_dialog_alert {
+    <<C helper>>
+}
+
+class fire_dialog_confirm {
+    <<C helper>>
+}
+
+class fire_dialog_prompt {
+    <<C helper>>
+}
+
+class fire_dialog_file_picker {
+    <<C helper>>
+}
+
+class WebKitWebView {
+    <<external>>
+    +signal "script-dialog"
+    +signal "run-file-chooser"
+}
+
+class WebViewDialogCallback {
+    <<Java interface>>
+    +onAlert(String, String, String) void
+    +onConfirm(String, String, String) boolean
+    +onPrompt(String, String, String, String) String
+    +onFilePicker(boolean, String[], String[], String, String) String[]
+}
+
+WebKitWebView ..> on_script_dialog : signal
+WebKitWebView ..> on_run_file_chooser : signal
+on_script_dialog ..> fire_dialog_alert : routes alert
+on_script_dialog ..> fire_dialog_confirm : routes confirm + before-unload
+on_script_dialog ..> fire_dialog_prompt : routes prompt
+on_run_file_chooser ..> fire_dialog_file_picker
+fire_dialog_alert ..> WebViewDialogCallback : JNI
+fire_dialog_confirm ..> WebViewDialogCallback : JNI
+fire_dialog_prompt ..> WebViewDialogCallback : JNI
+fire_dialog_file_picker ..> WebViewDialogCallback : JNI
+Engine "1" *-- "1" WebKitWebView
+OffEngine "1" *-- "1" WebKitWebView
+```
+
+## A · Approach
+
+1. **Signal-handler dispatch model:**
+   - Each signal handler receives the engine pointer via the
+     `gpointer user_data` slot of `g_signal_connect`.  This is the
+     established convention in this file (e.g. line 607 passes `e`
+     into the script-message handler).
+   - The `Engine` and `OffEngine` structs share the relevant
+     fields by name (`dialog_callback`, `web`, `jvm`).  Rather
+     than templating, factor the engine-agnostic JNI work into
+     four `fire_dialog_*` helpers that take the three fields as
+     plain arguments — this avoids dragging GTK-engine
+     struct definitions into the JNI helpers and keeps each helper
+     a small, single-purpose function.
+
+2. **`script-dialog` handler flow** (per dialog-kind branch on
+   `webkit_script_dialog_get_dialog_type`):
+   - **`WEBKIT_SCRIPT_DIALOG_ALERT`:**
+     - Read message via `webkit_script_dialog_get_message(dialog)`.
+     - Call `fire_dialog_alert(jvm, callback, message, pageUrl,
+       frameUrl)`.
+     - Return `TRUE`.  No need to set anything on the dialog —
+       alert has no payload.
+   - **`WEBKIT_SCRIPT_DIALOG_CONFIRM` and
+     `WEBKIT_SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM`:**
+     - Read message.
+     - Call `fire_dialog_confirm(...)`; capture `jboolean` result.
+     - `webkit_script_dialog_confirm_set_confirmed(dialog,
+       result == JNI_TRUE)`.
+     - Return `TRUE`.  Mapping `BEFORE_UNLOAD_CONFIRM` →
+       `dispatchConfirm` matches the canvas-11 commitment.
+   - **`WEBKIT_SCRIPT_DIALOG_PROMPT`:**
+     - Read message via `_get_message`; read default via
+       `webkit_script_dialog_prompt_get_default_text`.
+     - Call `fire_dialog_prompt(...)`; capture `jstring`-derived
+       UTF-8 (or NULL for cancel).
+     - On non-NULL: `webkit_script_dialog_prompt_set_text(dialog,
+       resultCstr)`.  On NULL: do NOT call `_set_text` — WebKitGTK
+       treats the absence as "user cancelled" and the page sees
+       `null`.
+     - Return `TRUE`.
+
+3. **`run-file-chooser` handler flow:**
+   - Read `gboolean multiple =
+     webkit_file_chooser_request_get_select_multiple(request)`.
+   - Read `const gchar *const *mimes =
+     webkit_file_chooser_request_get_mime_types(request)`.  NULL or
+     empty when the page imposed no `accept`.  Length is determined
+     by NULL-termination.
+   - Build `jobjectArray jmimes` (UTF-8 jstrings).
+   - Build `jobjectArray jexts` as **empty** — see Requirements:
+     WebKitGTK's `GtkFileFilter` does not expose the original
+     extensions back to the host.  Java-side normalisation handles
+     the empty case.
+   - Read pageUrl via `webkit_web_view_get_uri(webView)`; frameUrl
+     equals pageUrl (no per-frame info available from this signal).
+   - Call `fire_dialog_file_picker(...)`; capture
+     `jobjectArray jresult` of file paths.
+   - If `jresult` is NULL or zero-length: call
+     `webkit_file_chooser_request_cancel(request)`.
+   - Otherwise: convert to a `const gchar **` of UTF-8 paths and
+     call `webkit_file_chooser_request_select_files(request,
+     paths)`.  WebKitGTK takes ownership semantics per its docs —
+     it copies the strings, so we free the array (and our copied
+     strings) immediately after.
+   - Return `TRUE`.
+
+4. **JNI attach / detach + exception sanitization:**
+   - The GTK pump thread is NOT a JVM-attached thread by default
+     (the existing `fire_click_callback` proves this — it
+     defensively `AttachCurrentThread`s).  The new `fire_dialog_*`
+     helpers follow the same pattern.
+   - Every `CallVoidMethod` / `CallBooleanMethod` /
+     `CallObjectMethod` is followed by
+     `if (env->ExceptionCheck()) { env->ExceptionDescribe();
+     env->ExceptionClear(); }` — pending Java exceptions
+     propagating into GLib's signal-handler machinery would
+     terminate the process.
+   - Each helper detaches the JVM only if it attached locally.
+
+5. **Why `fire_dialog_*` helpers don't cache `jmethodID`:**
+   - The existing `fire_click_callback` resolves
+     `GetObjectClass` + `GetMethodID` on every invocation
+     (line 413-415).  Replicate that pattern.  Caching across
+     calls would require cleaning up `GlobalRef`s on callback
+     replacement; the cache-miss cost is dwarfed by the modal
+     dialog's wall-clock duration.
+
+6. **Null-callback safety:**
+   - The engine's `dialog_callback` field can legitimately be NULL
+     (no caller has wired the bridge yet, or the engine is being
+     destroyed and the field was cleared first).  Both signal
+     handlers MUST short-circuit safely in this state:
+     - Alert: just return `TRUE`.
+     - Confirm / before-unload: `_set_confirmed(dialog, FALSE)` +
+       return `TRUE`.
+     - Prompt: no `_set_text` (engine returns `null` to the page)
+       + return `TRUE`.
+     - File picker: `_cancel(request)` + return `TRUE`.
+   - This preserves the no-handler invariant: the JS thread always
+     resumes within bounded time even when the engine fires a
+     dialog before peer-attach has wired the callback.
+
+7. **EDT marshaling and the synchronous JS contract:**
+   - The native handler invokes the Java method synchronously
+     (e.g. `CallBooleanMethod` for confirm).  The Java side
+     (`DialogDispatcher.dispatchConfirm`) hops to the EDT via
+     `SwingUtilities.invokeAndWait`, runs the handler, and
+     returns.  Only then does the native handler call
+     `webkit_script_dialog_confirm_set_confirmed` and return
+     `TRUE`.
+   - During this round-trip the GTK pump thread is blocked.  That
+     is correct per the JS contract — WebKitGTK suspends the JS
+     thread for the duration of any `script-dialog` handler
+     anyway; we're just doing the suspension inside our handler
+     while we wait for the Java answer.
+   - The GTK pump and the AWT EDT are decoupled threads per
+     `README.md` ("A dedicated GTK pump thread drives the
+     WebKitGTK main loop independently of AWT's X11 event loop").
+     No mutual blocking dependency exists; `invokeAndWait` from
+     the GTK pump is deadlock-free.  This is the same shape
+     `WebViewClickCallback` already uses (via `invokeLater` — the
+     new path adds the wait but doesn't change the threading
+     topology).
+
+8. **Suppression-of-GTK-default invariant:**
+   - Returning `TRUE` from both handlers claims the dialog;
+     WebKitGTK does not invoke any further default behaviour.
+   - The handler is always installed in this story (one
+     `g_signal_connect` per engine instance).  The Java side
+     decides via `setDialogHandler` what UI to show; the GTK
+     defaults are gone permanently for any
+     `WebViewComponent`-managed engine.  This is the desired
+     behaviour and matches STORY-004-002 AC1 / AC2 / AC13.
+   - Callers wanting the GTK default back have no escape hatch in
+     this story — by design, since the canvas-11 design committed
+     to "the GTK default is fully suppressed once the bridge is
+     installed."  If a future caller needs the GTK default,
+     they can install a custom handler that calls the native
+     dialog APIs directly (out of scope here).
+
+9. **README update strategy:**
+   - The "Browser-initiated dialogs" section already exists from
+     STORY-004-001.  This canvas only edits the platform-status
+     note inside it to mark Linux as wired.  The macOS / Windows
+     descriptions are unchanged.
+   - The Linux file-picker `accept`-extension limitation is
+     documented in the same section as a one-line note.
+
+## S · Structure
+
+### Inheritance Relationships
+1. No new Java types; existing `WebViewDialogHandler` / event POJOs
+   / `WebViewDialogCallback` / `DialogDispatcher` /
+   `WebViewComponent` API surface from STORY-004-001 is unchanged.
+2. Native C functions are static-linkage helpers in
+   `src_c/webview_embed.cpp`; no header changes.
+
+### Dependencies
+1. `on_script_dialog` (new) → WebKitGTK 2.x `script-dialog` signal
+   on `WebKitWebView`; `webkit_script_dialog_get_dialog_type`,
+   `_get_message`, `_prompt_get_default_text`,
+   `_confirm_set_confirmed`, `_prompt_set_text`;
+   `webkit_web_view_get_uri`.
+2. `on_run_file_chooser` (new) → WebKitGTK 2.x `run-file-chooser`
+   signal; `webkit_file_chooser_request_get_select_multiple`,
+   `_get_mime_types`, `_select_files`, `_cancel`;
+   `webkit_web_view_get_uri`.
+3. `fire_dialog_alert` / `_confirm` / `_prompt` / `_file_picker`
+   (new) → `JavaVM->GetEnv` / `AttachCurrentThread` /
+   `DetachCurrentThread`; `JNIEnv->GetObjectClass` /
+   `GetMethodID` / `CallVoidMethod` / `CallBooleanMethod` /
+   `CallObjectMethod` / `NewStringUTF` / `GetStringUTFChars` /
+   `ReleaseStringUTFChars` / `NewObjectArray` /
+   `SetObjectArrayElement` / `FindClass` / `ExceptionCheck` /
+   `ExceptionDescribe` / `ExceptionClear` / `DeleteLocalRef` /
+   `DeleteGlobalRef`.
+4. `gtk_create_engine` (modified) → `g_signal_connect` for
+   `script-dialog` and `run-file-chooser`, both passing the
+   `Engine *` as `user_data`.
+5. `gtk_off_create_engine` (modified) → same two
+   `g_signal_connect` calls, passing the `OffEngine *` as
+   `user_data`.
+
+### Layered Architecture
+1. **Native engine layer** (`src_c/webview_embed.cpp`): two new
+   shared signal-handler functions, four new JNI dispatch
+   helpers, two new `g_signal_connect` registration sites
+   (one per engine).  No changes to anything outside the
+   GTK `#ifdef` block.
+2. **JNI surface**: unchanged.  `webview_embed_set_dialog_callback`
+   and `webview_offscreen_set_dialog_callback` are already wired
+   to `gtk_set_dialog_callback` / `gtk_off_set_dialog_callback`
+   by STORY-004-001.
+3. **Engine wrapper layer** (`EmbeddedWebView` /
+   `OffscreenWebView`): unchanged.
+4. **Dispatcher layer** (`DialogDispatcher`): unchanged.
+5. **Component API layer** (`WebViewComponent`): unchanged.
+6. **Public contract layer** (`WebViewDialogHandler` + event
+   POJOs): unchanged.
+7. **Wiring layer** (`WebViewHeavyweightComponent.createPeer()`,
+   `WebViewLightweightComponent.addNotify()`): unchanged — the
+   `WebViewDialogCallback` adapters they install at peer-attach
+   time start receiving events automatically once this canvas
+   wires the native signal handlers.
+8. **Demo layer** (`demos/WebViewDialogDemo/`): unchanged.  The
+   demo's three handler modes start working on Linux as soon as
+   this canvas lands.
+
+## O · Operations
+
+### 1. Add JNI Dispatch Helper — fire_dialog_alert
+File: `src_c/webview_embed.cpp`
+Location: alongside `fire_click_callback` (line 402), inside the
+`WEBVIEW_GTK` `#ifdef` block (lines 240-1523).
+
+1. Responsibility: invoke
+   `WebViewDialogCallback.onAlert(String, String, String)V`
+   on the JVM, attaching the GTK pump thread if needed and
+   sanitizing any pending JNI exception before returning.
+   Mirrors `fire_click_callback` (line 402-423) shape.
+2. Signature:
+   ```
+   static void fire_dialog_alert(
+       JavaVM *jvm, jobject callback,
+       const char *message, const char *pageUrl, const char *frameUrl);
+   ```
+3. Logic:
+   - If `jvm == nullptr` or `callback == nullptr`, return
+     immediately.
+   - `JNIEnv *env = nullptr; bool detach = false;`
+   - `if (jvm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+     jvm->AttachCurrentThread((void**)&env, nullptr); detach =
+     true; }`.
+   - If `env == nullptr`, return.
+   - Convert each `const char *` to a `jstring` via
+     `env->NewStringUTF(s ? s : "")`.
+   - `jclass cls = env->GetObjectClass(callback);`
+   - `jmethodID m = env->GetMethodID(cls, "onAlert",
+     "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");`
+   - If `m != nullptr`: `env->CallVoidMethod(callback, m, jmsg,
+     jpage, jframe);`.
+   - `if (env->ExceptionCheck()) { env->ExceptionDescribe();
+     env->ExceptionClear(); }`.
+   - `env->DeleteLocalRef(jmsg); env->DeleteLocalRef(jpage);
+     env->DeleteLocalRef(jframe); env->DeleteLocalRef(cls);`.
+   - `if (detach) jvm->DetachCurrentThread();`.
+4. Constraints: never throws back into C++ /
+   GLib.  Always sanitizes any pending Java exception before
+   returning.
+
+### 2. Add JNI Dispatch Helper — fire_dialog_confirm
+File: `src_c/webview_embed.cpp` (same area as Operation 1).
+
+1. Responsibility: invoke
+   `WebViewDialogCallback.onConfirm(String, String, String)Z`;
+   return the `jboolean` answer (or `JNI_FALSE` on any error).
+2. Signature:
+   ```
+   static jboolean fire_dialog_confirm(
+       JavaVM *jvm, jobject callback,
+       const char *message, const char *pageUrl, const char *frameUrl);
+   ```
+3. Logic: shaped like Operation 1 but:
+   - Method ID via `GetMethodID(cls, "onConfirm",
+     "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")`.
+   - `jboolean result = env->CallBooleanMethod(callback, m, jmsg,
+     jpage, jframe);`.
+   - On exception: clear it and set `result = JNI_FALSE`.
+   - Return `result` (false on null jvm / callback / env / cls /
+     mid / exception — i.e. the safe default for "no answer").
+
+### 3. Add JNI Dispatch Helper — fire_dialog_prompt
+File: `src_c/webview_embed.cpp` (same area).
+
+1. Responsibility: invoke
+   `WebViewDialogCallback.onPrompt(String, String, String, String)Ljava/lang/String;`;
+   return a newly-allocated UTF-8 `char *` (caller owns; free with
+   `g_free` — see Norms for the allocator choice) or `NULL` on cancel /
+   error.
+2. Signature:
+   ```
+   static char *fire_dialog_prompt(
+       JavaVM *jvm, jobject callback,
+       const char *message, const char *defaultValue,
+       const char *pageUrl, const char *frameUrl);
+   ```
+3. Logic:
+   - Initial `char *result = nullptr;`.
+   - Attach + resolve method via
+     `GetMethodID(cls, "onPrompt",
+     "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;")`.
+   - `jstring jresult = (jstring)env->CallObjectMethod(callback,
+     m, jmsg, jdefault, jpage, jframe);`.
+   - On exception: clear, force `jresult = nullptr` (so result
+     stays null → cancel).
+   - If `jresult != nullptr`:
+     - `const char *cstr = env->GetStringUTFChars(jresult,
+       nullptr);`.
+     - If `cstr != nullptr`: `result = g_strdup(cstr);
+       env->ReleaseStringUTFChars(jresult, cstr);`.
+     - `env->DeleteLocalRef(jresult);`.
+   - Clean up local refs + detach.
+   - Return `result`.  Caller MUST `g_free(result)` when done
+     (matches existing `g_free(s)` discipline used after
+     `jsc_value_to_string` results, line 605).
+
+### 4. Add JNI Dispatch Helper — fire_dialog_file_picker
+File: `src_c/webview_embed.cpp` (same area).
+
+1. Responsibility: invoke
+   `WebViewDialogCallback.onFilePicker(boolean, String[], String[], String, String)[Ljava/lang/String;`;
+   return a newly-allocated NULL-terminated `gchar **` of UTF-8
+   paths (caller owns; free with `g_strfreev`) or `NULL` on cancel
+   / error.  The empty-array case (zero-length array from Java) is
+   ALSO surfaced as `NULL` — the caller treats `NULL` as "cancel"
+   uniformly.
+2. Signature:
+   ```
+   static gchar **fire_dialog_file_picker(
+       JavaVM *jvm, jobject callback,
+       gboolean multiple,
+       const gchar *const *mimeTypes,
+       const gchar *const *extensions,
+       const char *pageUrl, const char *frameUrl);
+   ```
+3. Logic:
+   - Initial `gchar **result = nullptr;`.
+   - Build `jobjectArray jmimes`: find `java/lang/String` via
+     `env->FindClass`.  Count entries in `mimeTypes` until NULL.
+     `NewObjectArray(count, stringCls, nullptr)` then loop
+     `SetObjectArrayElement(arr, i, NewStringUTF(mimes[i]))` +
+     `DeleteLocalRef` for each `NewStringUTF` result.  When
+     `mimeTypes == nullptr`, build a zero-length array (still
+     non-null per the canvas-11 contract).
+   - Build `jobjectArray jexts` analogously (always zero-length on
+     Linux today — see Requirements).
+   - Resolve method via
+     `GetMethodID(cls, "onFilePicker",
+     "(Z[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;")`.
+   - `jobjectArray jresult = (jobjectArray)env->CallObjectMethod(
+     callback, m, (jboolean)multiple, jmimes, jexts, jpage,
+     jframe);`.
+   - On exception: clear, force `jresult = nullptr`.
+   - If `jresult != nullptr` AND its length > 0:
+     - Allocate `result = g_new0(gchar *, length + 1);` (last
+       entry remains `NULL` for `_strfreev`).
+     - For each element: read `jstring` →
+       `GetStringUTFChars` → `g_strdup` → `ReleaseStringUTFChars`
+       → store in `result[i]` → `DeleteLocalRef`.
+     - If the resulting array would have zero non-null entries
+       (defensive), free it and set `result = nullptr`.
+   - Clean up local refs (jmimes, jexts, jpage, jframe, jresult,
+     cls, stringCls).
+   - Detach if attached.
+   - Return `result`.  Caller MUST `g_strfreev(result)` when done.
+
+### 5. Add Signal Handler — on_script_dialog
+File: `src_c/webview_embed.cpp` (alongside `fire_dialog_*`
+helpers).
+
+1. Responsibility: handle the `script-dialog` signal on any
+   `WebKitWebView` created by either GTK engine.  Shared by both
+   heavyweight and lightweight; engine pointer arrives via
+   `user_data`.  But the engine pointer is one of two types
+   (`Engine *` or `OffEngine *`), so this story uses two thin
+   wrapper handlers that extract the right field and call a shared
+   inner function.
+2. Inner function (engine-agnostic):
+   ```
+   static gboolean handle_script_dialog(
+       JavaVM *jvm, jobject dialog_callback,
+       const gchar *page_url,
+       WebKitScriptDialog *dialog);
+   ```
+   Logic:
+   - `WebKitScriptDialogType type = webkit_script_dialog_get_dialog_type(dialog);`
+   - `const gchar *message = webkit_script_dialog_get_message(dialog);` (returns const, do NOT free).
+   - `const char *frame_url = page_url ? page_url : "";` (no per-frame info on this signal).
+   - Switch on `type`:
+     - `case WEBKIT_SCRIPT_DIALOG_ALERT`:
+       - `fire_dialog_alert(jvm, dialog_callback, message, page_url, frame_url);`
+       - (no `set_*` call needed.)
+     - `case WEBKIT_SCRIPT_DIALOG_CONFIRM`:
+     - `case WEBKIT_SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM`:
+       - `jboolean ok = JNI_FALSE;`
+       - If `dialog_callback != nullptr`:
+         `ok = fire_dialog_confirm(jvm, dialog_callback, message, page_url, frame_url);`
+       - `webkit_script_dialog_confirm_set_confirmed(dialog, ok == JNI_TRUE);`
+     - `case WEBKIT_SCRIPT_DIALOG_PROMPT`:
+       - `const gchar *def = webkit_script_dialog_prompt_get_default_text(dialog);`
+       - `char *answer = nullptr;`
+       - If `dialog_callback != nullptr`:
+         `answer = fire_dialog_prompt(jvm, dialog_callback, message, def ? def : "", page_url, frame_url);`
+       - If `answer != nullptr`:
+         `webkit_script_dialog_prompt_set_text(dialog, answer);
+         g_free(answer);`
+       - (If null: do NOT call `_set_text`; engine returns null to
+         the page, matching the JS-spec cancel semantic.)
+     - `default`: nothing — silently let it through (TRUE return
+       still suppresses any default; the unknown type doesn't reach
+       Java).
+   - Return `TRUE`.
+3. Thin wrappers:
+   ```
+   static gboolean on_script_dialog_engine(
+       WebKitWebView *web, WebKitScriptDialog *dialog, gpointer user_data) {
+       Engine *e = static_cast<Engine *>(user_data);
+       if (!e) return TRUE;
+       const gchar *uri = webkit_web_view_get_uri(web);
+       return handle_script_dialog(e->jvm, e->dialog_callback, uri, dialog);
+   }
+
+   static gboolean on_script_dialog_off_engine(
+       WebKitWebView *web, WebKitScriptDialog *dialog, gpointer user_data) {
+       OffEngine *e = static_cast<OffEngine *>(user_data);
+       if (!e) return TRUE;
+       const gchar *uri = webkit_web_view_get_uri(web);
+       return handle_script_dialog(e->jvm, e->dialog_callback, uri, dialog);
+   }
+   ```
+4. Constraints:
+   - Always returns `TRUE` so the GTK default never fires.
+   - Reads `dialog_callback` AT INVOCATION (the field is
+     volatile-like for read purposes — the GTK pump is the only
+     thread that touches it during the dialog lifecycle; the JNI
+     setter via `gtk_set_dialog_callback` is called by the EDT but
+     ordering is enforced by the natural happens-before of the
+     `g_signal_connect` install and any subsequent dialog signal).
+   - On null `dialog_callback`, applies the safe default per
+     Requirements §safe-default and Approach §6.
+
+### 6. Add Signal Handler — on_run_file_chooser
+File: `src_c/webview_embed.cpp` (alongside `on_script_dialog`).
+
+1. Responsibility: handle the `run-file-chooser` signal on any
+   `WebKitWebView` created by either GTK engine.  Same
+   shared-inner-function + two-wrappers pattern as Operation 5.
+2. Inner function:
+   ```
+   static gboolean handle_run_file_chooser(
+       JavaVM *jvm, jobject dialog_callback,
+       const gchar *page_url,
+       WebKitFileChooserRequest *request);
+   ```
+   Logic:
+   - `gboolean multiple = webkit_file_chooser_request_get_select_multiple(request);`
+   - `const gchar *const *mime_types = webkit_file_chooser_request_get_mime_types(request);`
+     (NULL or NULL-terminated array of UTF-8 strings; do NOT free.)
+   - `const char *frame_url = page_url ? page_url : "";`
+   - If `dialog_callback == nullptr`:
+     `webkit_file_chooser_request_cancel(request);
+     return TRUE;`
+   - `gchar **paths = fire_dialog_file_picker(jvm, dialog_callback,
+     multiple, mime_types, /* extensions */ nullptr, page_url,
+     frame_url);`
+   - If `paths == nullptr` (cancel / empty):
+     `webkit_file_chooser_request_cancel(request);`
+   - Else:
+     - `webkit_file_chooser_request_select_files(request,
+       (const gchar *const *)paths);`
+     - WebKitGTK copies the strings internally — the canonical
+       reference is the WebKitGTK 2.x docs for
+       `webkit_file_chooser_request_select_files`.
+     - Free with `g_strfreev(paths);`.
+   - Return `TRUE`.
+3. Thin wrappers `on_run_file_chooser_engine` /
+   `on_run_file_chooser_off_engine` — same shape as Operation 5's
+   wrappers but reading `WebKitFileChooserRequest *` from the
+   second arg and using `OffEngine *` vs `Engine *`.
+4. Constraints:
+   - Always returns `TRUE` so the GTK default file picker never
+     fires.
+   - Always resolves the request — `_select_files` OR `_cancel`,
+     never neither — so the page's JS `change` event always fires
+     within bounded time.
+
+### 7. Connect Signal Handlers in gtk_create_engine
+File: `src_c/webview_embed.cpp` (modify `gtk_create_engine` at
+line 456).
+
+1. Locate the existing `load-changed` / `load-failed`
+   registration block (lines 591-594).
+2. AFTER that block (so dialog handlers are wired immediately
+   after the load handlers but BEFORE the external-message
+   manager setup at line 597), insert:
+   ```
+   // Wire JS-initiated dialogs (alert / confirm / prompt /
+   // <input type=file>) to the per-engine Java DialogDispatcher
+   // via the dialog_callback global ref.  Returning TRUE from each
+   // handler suppresses the default GTK dialog; the Java side
+   // decides what UI (if any) to show, with default behaviour
+   // being Swing dialogs anchored on the host JFrame.  See
+   // WebViewDialogHandler for the full contract.
+   g_signal_connect(WEBKIT_WEB_VIEW(e->web), "script-dialog",
+                    (GCallback)on_script_dialog_engine, e);
+   g_signal_connect(WEBKIT_WEB_VIEW(e->web), "run-file-chooser",
+                    (GCallback)on_run_file_chooser_engine, e);
+   ```
+3. Constraints:
+   - The two `g_signal_connect` calls pass `e` (the `Engine *`) as
+     `user_data`.  The signal handlers read `e->jvm`,
+     `e->dialog_callback`, and `e->web` from it.
+   - Both registrations happen unconditionally — i.e. before the
+     caller has wired any `WebViewDialogHandler`.  The handlers
+     short-circuit safely when `dialog_callback` is NULL.
+   - No `g_signal_handler_disconnect` is added in
+     `gtk_destroy_engine` because the GTK widget destruction
+     (line 830-834) automatically removes all signal handlers
+     connected to the widget.
+
+### 8. Connect Signal Handlers in gtk_off_create_engine
+File: `src_c/webview_embed.cpp` (modify `gtk_off_create_engine`
+at line 1057).
+
+1. Locate the existing `script-message-received::external`
+   registration block (lines 1092-1102).
+2. AFTER that block (so dialog handlers are wired immediately
+   after the message handler), insert:
+   ```
+   // Wire JS-initiated dialogs to the per-engine Java
+   // DialogDispatcher.  Same shape as gtk_create_engine; the
+   // offscreen variants of the signal handlers route through
+   // OffEngine instead of Engine but call the same inner
+   // handle_script_dialog / handle_run_file_chooser logic.
+   g_signal_connect(WEBKIT_WEB_VIEW(e->web), "script-dialog",
+                    (GCallback)on_script_dialog_off_engine, e);
+   g_signal_connect(WEBKIT_WEB_VIEW(e->web), "run-file-chooser",
+                    (GCallback)on_run_file_chooser_off_engine, e);
+   ```
+3. Constraints:
+   - Same as Operation 7, with `e` of type `OffEngine *`.
+   - No disconnection in `gtk_off_destroy_engine` (line 1180) —
+     widget destruction at line 1184 removes the handlers.
+
+### 9. Update README — mark Linux wired
+File: `README.md`.
+
+1. Locate the "Browser-initiated dialogs" subsection (added by
+   STORY-004-001's canvas).  The current platform-status
+   paragraph reads:
+   > "**Platform coverage (current).**  macOS heavyweight
+   > (WKWebView) routes all four dialog kinds through the handler
+   > in this release (STORY-004-001).  On Linux and Windows,
+   > `setDialogHandler` stores the handler reference but the
+   > embedded engine continues to use its built-in dialogs until
+   > STORY-004-002 (WebKitGTK signal handlers) and STORY-004-003
+   > (WebView2 `ScriptDialogOpening` event) land. ..."
+2. Rewrite to:
+   > "**Platform coverage (current).**  macOS heavyweight
+   > (WKWebView) routes all four dialog kinds through the handler
+   > (STORY-004-001).  Linux WebKitGTK routes all four kinds
+   > through the handler in both heavyweight and lightweight modes
+   > via the `script-dialog` and `run-file-chooser` signals
+   > (STORY-004-002).  On Windows, `setDialogHandler` stores the
+   > handler reference but the embedded engine continues to use
+   > its built-in dialogs until STORY-004-003 (WebView2
+   > `ScriptDialogOpening` event) lands.  On Windows,
+   > `<input type="file">` will continue to use the OS-native
+   > dialog even after STORY-004-003 — WebView2 exposes no public
+   > hook for it, so `filePickerOpened` never fires on Windows."
+3. Add a small Linux-specific limitation note in the same
+   subsection (after the platform-coverage paragraph):
+   > "On Linux, the `WebViewFilePickerEvent.acceptedExtensions`
+   > list is always empty even when the page wrote
+   > `<input accept=".png,.jpg">` — WebKitGTK exposes the
+   > extension filter as an opaque `GtkFileFilter` rather than
+   > the original extension strings.  The page's MIME-type hints
+   > (`accept="image/png"` etc.) are surfaced via
+   > `acceptedMimeTypes`; the page's own client-side `accept`
+   > validation continues to work."
+4. No other prose changes.
+
+## N · Norms
+
+- **Mirror `fire_click_callback`'s JNI pattern.**  The four new
+  `fire_dialog_*` helpers follow the same shape: defensive
+  `GetEnv` + `AttachCurrentThread` + detach-only-if-we-attached;
+  `GetObjectClass` + `GetMethodID` per call (no caching);
+  `ExceptionCheck` / `Describe` / `Clear` after every
+  `Call*Method`; local-ref cleanup via `DeleteLocalRef`.
+  Consistency with the existing pattern is worth more than the
+  micro-optimisation of method-id caching.
+- **Two wrappers per signal, one shared inner.**  The
+  `Engine` / `OffEngine` divergence is a single line — read the
+  right `dialog_callback` field, the right `jvm`, and pass them
+  plus the page URL into a shared inner function.  This avoids
+  template hackery while keeping the bulk of the logic in one
+  place.
+- **Always return `TRUE`** from both signal handlers.  This is the
+  invariant that suppresses the GTK default.  A future maintainer
+  must NOT add a `return FALSE` branch — that would re-enable the
+  GTK default dialog, which immediately breaks STORY-004-002
+  AC1 / AC2 / AC13 and reintroduces the `transient_for` glitch the
+  story is meant to fix.
+- **Always resolve the dialog before returning.**  Every code
+  path in `on_script_dialog` and `on_run_file_chooser` must call
+  the appropriate `_set_confirmed` / `_set_text` / `_select_files`
+  / `_cancel` function (or, for alert, just return) so the page's
+  JS thread always resumes within bounded time.  In particular,
+  the null-callback path MUST resolve the dialog with the safe
+  default, NEVER leave it un-resolved.
+- **String memory ownership.**  Strings returned from
+  `fire_dialog_prompt` are caller-owned (`g_strdup`'d UTF-8) and
+  must be `g_free`'d after `webkit_script_dialog_prompt_set_text`.
+  Arrays returned from `fire_dialog_file_picker` are caller-owned
+  (`gchar **` allocated with `g_new0`, each entry `g_strdup`'d) and
+  must be `g_strfreev`'d after
+  `webkit_file_chooser_request_select_files`.  WebKitGTK copies
+  the strings internally per the WebKitGTK 2.x docs, so freeing
+  immediately after the call is correct.
+- **No new headers, no new dependencies.**  All required types
+  (`WebKitScriptDialog`, `WebKitFileChooserRequest`,
+  `WebKitScriptDialogType` enum, `_get_message`,
+  `_get_dialog_type`, `_prompt_get_default_text`,
+  `_confirm_set_confirmed`, `_prompt_set_text`,
+  `_get_select_multiple`, `_get_mime_types`, `_select_files`,
+  `_cancel`) are part of the WebKitGTK 2.x public API and live
+  under `webkit2/webkit2.h` which is already included via the
+  GTK `#include` block at the top of
+  `src_c/webview_embed.cpp`.
+- **Use only long-stable WebKitGTK accessors.**  All of the
+  accessors named in Operations 5 and 6 have been in WebKitGTK
+  since 2.0; no version conditional is needed (the existing
+  project supports both `libwebkit2gtk-4.0-dev` and
+  `libwebkit2gtk-4.1-dev` per README, and these accessors are
+  identical between the two).  Do NOT introduce
+  `webkit_script_dialog_ref` / `_close` — the synchronous return
+  model keeps the dialog alive for the duration of the signal
+  handler.
+- **JNI attach defensiveness.**  Always check the return of
+  `AttachCurrentThread` (some pathological JVM states can reject
+  it).  If it fails, the helper returns the safe default (void /
+  FALSE / NULL / NULL) and the dialog still resolves via the
+  Operations 5/6 null-callback path.
+- **No JS shim, no reserved binding.**  This story is pure native
+  signal-handler wiring; the `__webview_*` reserved-prefix
+  convention is untouched.
+- **No JSON dependency.**  All payloads are primitive strings
+  (`jstring`) or string arrays (`jobjectArray` of `jstring`); no
+  JSON encoding / decoding involved.
+- **`pom.xml` Java 8 target stays in force.**  No Java code
+  changes in this story, so the language-level target is
+  trivially preserved.
+- **No automated tests for GUI integration.**  Consistent with
+  the existing canvases for the heavyweight / lightweight
+  components and with STORY-004-001's testing strategy.  Manual
+  AC verification via `WebViewDialogDemo` on a real Linux host
+  (X11 + WebKitGTK 2.x) is the chosen approach.  The 27
+  `DialogDispatcherTest` cases shipped in STORY-004-001 continue
+  to cover the Java-side dispatcher contract, including the
+  paths that STORY-004-002's native code exercises end-to-end.
+
+## S · Safeguards
+
+- **Signal handler ALWAYS returns `TRUE`.**  Every code path in
+  `on_script_dialog_*` and `on_run_file_chooser_*` returns
+  `TRUE`.  A `FALSE` return re-enables the GTK default dialog,
+  immediately violating AC1 / AC2 / AC13.
+- **Signal handler ALWAYS resolves the dialog or request before
+  returning.**  Required state transitions:
+  - Alert: nothing to set.  Just return.
+  - Confirm / before-unload: `_set_confirmed` MUST be called
+    (even on the null-callback / exception path; pass `FALSE`).
+  - Prompt: either `_set_text(answer)` for non-null answer, OR
+    no `_set_text` call for null (engine treats absence as cancel).
+    The handler MUST NOT both call `_set_text` and treat the
+    answer as cancel.
+  - File picker: `_select_files` for non-empty result, OR
+    `_cancel` for empty / null result.  Never neither.
+- **Null `dialog_callback` is a legitimate, non-fatal state.**
+  The handler MUST short-circuit safely (per Approach §6) — never
+  invoke any `fire_dialog_*` helper with a null callback.  This
+  preserves the no-handler invariant during peer-attach windows
+  and post-disposal teardown.
+- **JNI attach / detach symmetry.**  Each `fire_dialog_*` helper
+  detaches the JVM IFF it attached locally.  Asymmetric
+  attach/detach (especially detach-without-attach) crashes the
+  process.  The `bool detach = ...` pattern from
+  `fire_click_callback` is the canonical mechanism.
+- **JNI exception sanitization on every C-call boundary.**  After
+  every `Call*Method`, check `ExceptionCheck` and clear any
+  pending exception.  A pending Java exception propagating into
+  GLib signal-dispatch infrastructure terminates the process.
+  The helper's return value defaults to the safe sentinel on
+  any exception path.
+- **Allocator discipline.**  Strings allocated for return from
+  `fire_dialog_prompt` use `g_strdup` (the GLib allocator
+  WebKitGTK / GTK expect), not `strdup` or `new[]`.  Free with
+  `g_free`.  Arrays allocated for return from
+  `fire_dialog_file_picker` use `g_new0(gchar*, n+1)` so the
+  NULL terminator is implicit, and each element uses `g_strdup`.
+  Free with `g_strfreev` (handles each entry + the outer array).
+  Failure to use the matching allocator pair will eventually
+  trigger heap corruption on any allocator-aware build.
+- **WebKitGTK string return-value contracts.**
+  `webkit_script_dialog_get_message`,
+  `_prompt_get_default_text`,
+  `webkit_file_chooser_request_get_mime_types`, and
+  `webkit_web_view_get_uri` all return strings owned by the
+  caller's `WebKit*` object — DO NOT free.  Their lifetime is
+  bound by the dialog / request / web-view object lifetime; the
+  handler is the only user during its own synchronous run, so
+  the values are safe to use without copying.
+- **`webkit_file_chooser_request_select_files` argument
+  ownership.**  Per WebKitGTK docs, the function copies the
+  string array internally; the caller is free to (and should)
+  `g_strfreev` the array immediately after the call.  Do NOT
+  leave the array allocated for the request's lifetime — that's
+  the request's job, not ours.
+- **`webkit_script_dialog_prompt_set_text` argument ownership.**
+  Per WebKitGTK docs, the function copies the string internally;
+  free our `g_strdup`'d copy immediately after.
+- **Identical behaviour across heavyweight and lightweight.**
+  STORY-004-002 AC14 explicitly asserts that the same page input
+  produces identical Java field values in both modes.  Because
+  the two thin wrappers call a SHARED inner function that
+  receives identical inputs (page URL, message, default text,
+  multiple flag, mime-types array), behaviour is byte-identical
+  by construction.  A future maintainer modifying one wrapper
+  without the other will violate this AC.
+- **No `g_signal_handler_disconnect` in destroy paths.**  GTK
+  removes all signal handlers automatically when the widget is
+  destroyed (`gtk_widget_destroy` at lines 830-834 / 1184).
+  Adding an explicit disconnect would be redundant and risks
+  use-after-free if the handler ID isn't stored correctly.
+- **Disposal race safety.**  `gtk_destroy_engine` and
+  `gtk_off_destroy_engine` already clear `dialog_callback` to
+  NULL before destroying the widget (added in STORY-004-001).
+  Any signal handler that fires during the destroy window
+  observes the cleared field via the Approach §6 null-callback
+  path and resolves the dialog with the safe default.
+- **`<input type=file>` empty-extensions-array Java contract.**
+  The Java-side `DialogDispatcher.normaliseExtensions` (canvas-11
+  Operation 7) accepts a `String[]` argument including null /
+  empty.  Passing a zero-length `jobjectArray` from Operation 4
+  resolves cleanly to `Collections.emptyList()` on the
+  `WebViewFilePickerEvent`; the default `JFileChooser` falls
+  through to "show all files".
+- **`before-unload` routing.**  Mapping
+  `WEBKIT_SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM` to
+  `dispatchConfirm` matches the canvas-11 commitment and
+  STORY-004-002 AC12.  A future maintainer adding a dedicated
+  `beforeUnloadOpened` to `WebViewDialogHandler` MUST also
+  update Operation 5's switch branch to route to it; until then,
+  the two enum values share the confirm handler.
+- **Linux-only.**  Both `g_signal_connect` calls and all five
+  new functions (4 fire helpers + 2 inner handlers + 2×2
+  wrappers + ...) live inside the existing `#ifdef WEBVIEW_GTK`
+  block.  They are invisible to the macOS and Windows builds.
+- **Native code review focus.**  The macOS implementation
+  (STORY-004-001) is the closest precedent and the gold standard;
+  this story's code should be reviewed against it for
+  thread-attach symmetry, exception sanitization, and
+  string-ownership discipline.  Any divergence between platforms
+  on those three axes is a likely bug.

--- a/spdd/prompt/13-20260518-2355-[Feat]-Browser-Initiated-Ui-Dialogs-Windows-Coverage.md
+++ b/spdd/prompt/13-20260518-2355-[Feat]-Browser-Initiated-Ui-Dialogs-Windows-Coverage.md
@@ -1,0 +1,1160 @@
+---
+generated_at: 2026-05-18T23:55:00-07:00
+---
+
+# REASONS Canvas: Browser-Initiated UI Dialogs — Windows WebView2 Coverage
+
+## R · Requirements
+
+- Wire the existing `WebViewDialogHandler` contract — designed and
+  shipped in STORY-004-001 / canvas-11, with Linux WebKitGTK coverage
+  added in STORY-004-002 / canvas-12 — to the Windows WebView2
+  engine so JS-initiated `alert` / `confirm` / `prompt` (and
+  `before-unload`) flow through the per-component
+  `DialogDispatcher` and end up on the Swing EDT.
+- The Windows engine is `windows/webview_embed.cc`, which hosts an
+  `ICoreWebView2` controller created lazily in the controller-ready
+  callback inside `create_engine`.  The new wiring lives entirely
+  inside that callback plus a new `ScriptDialogHandler` class
+  defined alongside the existing `FocusHandler` / `MsgHandler`.
+- Suppress WebView2's built-in dialogs by calling
+  `settings->put_AreDefaultScriptDialogsEnabled(FALSE)` right after
+  the existing `put_AreDevToolsEnabled` /
+  `put_AreDefaultContextMenusEnabled` calls
+  (`windows/webview_embed.cc:430-437`).  Without this, both the
+  built-in WebView2 dialog AND the Java-side Swing dialog would
+  appear simultaneously — visibly violating story
+  STORY-004-003 AC12.
+- Register a `ScriptDialogHandler` (implementing
+  `ICoreWebView2ScriptDialogOpeningEventHandler`) via
+  `webview->add_ScriptDialogOpening(handler, &e->script_dialog_token)`
+  right after the existing `add_WebMessageReceived` site
+  (`windows/webview_embed.cc:447-449`).  Follow the established
+  `CallbackBase<Iface>` template pattern used by `FocusHandler` /
+  `MsgHandler` for reference-counted COM lifetime.
+- The handler's `Invoke` runs on the WebView2 worker thread per
+  engine (the dedicated message-pump thread created in
+  `create_engine` — `windows/webview_embed.cc:562+`).  It MUST:
+  1. Read `args->get_Kind`, `args->get_Message`, `args->get_Uri`,
+     and (for prompt) `args->get_DefaultText`.
+  2. Call `args->GetDeferral(&deferral)` to defer the response —
+     the WebView2 worker thread must keep pumping the message
+     queue while we wait for the EDT to produce an answer, so we
+     CANNOT block synchronously inside `Invoke`.
+  3. Return `S_OK` immediately, with the deferral held by a
+     worker thread we spin up to do the JNI hop into
+     `DialogDispatcher`.
+  4. When Java returns, marshal back onto the WebView2 worker
+     thread via the existing `dispatch_to_thread(e, [...]{...})`
+     helper, apply the answer to the args
+     (`args->Accept()` / `args->put_ResultText(...)`), call
+     `deferral->Complete()`, then release the deferral and args.
+- The blocking-block-the-worker alternative discussed in the
+  analysis (canvas-11 Approach §"deadlock risk?" for Windows) is
+  REJECTED: the worker thread also services WM_DISPATCH messages,
+  controller event callbacks, JS execution, and rendering ticks;
+  blocking it inside `Invoke` would freeze unrelated engine
+  operations and risk deadlocking the `dispatch_to_thread` call
+  the dispatcher itself needs to feed the answer back.  The
+  deferral pattern is the supported / documented one and is what
+  the WebView2 SDK examples use.
+- Use the JS-thread suspension: WebView2 holds the page's JS
+  thread suspended for the duration of the open dialog (the
+  caller's `alert(...)` / `confirm(...)` / `prompt(...)` does
+  not return until our `deferral->Complete()` fires).  This is
+  correct per the JS contract and is the same effective
+  behaviour the Linux / macOS branches produce via their native
+  synchronous return models.
+- The `Engine` struct must carry an
+  `EventRegistrationToken script_dialog_token{}` alongside the
+  existing `message_token`, `got_focus_token`, `lost_focus_token`
+  (`windows/webview_embed.cc:107-109`).  No need to call
+  `remove_ScriptDialogOpening` explicitly — engine destruction
+  releases the controller / webview which detaches all event
+  handlers; mirrors how `destroy_engine` already handles the
+  three existing tokens.
+- `before-unload` routes to `dispatchConfirm` — same as Linux.
+  WebView2 surfaces this as
+  `COREWEBVIEW2_SCRIPT_DIALOG_KIND_BEFOREUNLOAD`; the handler's
+  switch maps it to `fire_dialog_confirm` exactly like the
+  regular `_CONFIRM` kind.  Matches story STORY-004-003 AC9 and
+  the canvas-11 / canvas-12 commitments.
+- The four JNI dispatch helpers (`fire_dialog_alert` /
+  `fire_dialog_confirm` / `fire_dialog_prompt` /
+  `fire_dialog_file_picker`) introduced on Linux in
+  STORY-004-002 are NOT shared into the Windows binary —
+  Windows is built from a separate translation unit
+  (`windows/webview_embed.cc`) that doesn't include
+  `src_c/webview_embed.cpp`.  The Windows side needs its own
+  copies of the three relevant helpers (alert / confirm /
+  prompt; no file picker — see below).  The helpers are
+  byte-equivalent to the GTK versions modulo
+  `g_strdup` → `strdup` / `g_free` → `free`.
+- File picker: WebView2 exposes NO public hook for
+  `<input type="file">`.  This story does NOT intercept the
+  file picker.  `<input type="file">` continues to open the
+  OS-native Common Item Dialog as today; the page receives the
+  selection through the normal `change` event.
+  `WebViewFilePickerEvent` does not fire on Windows.  This is a
+  documented platform limitation per STORY-004-003 AC4 and the
+  canvas-11 design.  No `fire_dialog_file_picker` helper is
+  needed on Windows.
+- Handler exceptions are caught by the Java side
+  (`DialogDispatcher`'s try/catch forwards to
+  `Thread.getDefaultUncaughtExceptionHandler`); on the Windows
+  native side, `Invoke` and the deferred completion code MUST
+  always call `deferral->Complete()` exactly once on every code
+  path, even when the Java answer is the "safe fallback"
+  (alert: no-op; confirm: false; prompt: null).  A skipped
+  `Complete` hangs the page's JS thread forever.  Matches story
+  STORY-004-003 AC13.
+- `pageUrl` and `frameUrl` MUST both be populated from
+  `args->get_Uri`.  WebView2 does not expose a separate frame
+  URL on the dialog event args at this SDK version, so
+  `frameUrl` equals `pageUrl` (top-level only).  This matches
+  STORY-004-003 AC11's verification (which only checks the
+  top-level case) and the canvas-11 analysis resolution.
+  Document the equality in the README's Windows note.
+- The Java side and the JNI surface are already complete:
+  - `WebViewDialogHandler`, four event POJOs, `DialogDispatcher`,
+    `WebViewDialogCallback`, `WebViewComponent.setDialogHandler`,
+    `EmbeddedWebView.setDialogCallback`, the Java-side
+    `WebViewDialogCallback` adapter installed at peer-attach in
+    `WebViewHeavyweightComponent.createPeer()` — all unchanged.
+  - `Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1dialog_1callback`
+    (`windows/webview_embed.cc:970-988`) already stores/clears
+    the `dialog_callback` global ref correctly.
+  - `Engine::dialog_callback` field exists at
+    `windows/webview_embed.cc:132`.  `destroy_engine` already
+    clears it (`windows/webview_embed.cc:621-630`).
+  STORY-004-003 only adds the event-handler side that consumes
+  this field.
+- The implementation MUST NOT regress any other existing Windows
+  WebView2 behaviour.  Only:
+  1. One `settings->put_AreDefaultScriptDialogsEnabled(FALSE)` call.
+  2. One `webview->add_ScriptDialogOpening` registration.
+  3. One new `EventRegistrationToken` field in `Engine`.
+  4. One new `ScriptDialogHandler` class.
+  5. Three new `fire_dialog_*` JNI helpers (alert / confirm /
+     prompt — no file_picker on Windows).
+- Definition of Done:
+  - All 13 STORY-004-003 ACs from
+    `requirements/[User-story-4]browser-initiated-ui-dialogs.md`
+    pass on Windows 11 with the system WebView2 Runtime installed.
+    Verified by running `WebViewDialogDemo` on a Windows host.
+  - The existing 57-test Java suite continues to pass with zero
+    new failures (no Java code changes).
+  - The macOS heavyweight (STORY-004-001) and Linux WebKitGTK
+    (STORY-004-002) implementations continue to work unchanged —
+    no shared code is touched.
+  - README's "Browser-initiated dialogs" subsection is updated:
+    the Windows portion of the platform-status note now says
+    "wired" for alert/confirm/prompt and "uses the OS-native
+    Common Item Dialog (no WebView2 hook); `filePickerOpened`
+    never fires on Windows" for the file picker.
+- Out of scope (explicit non-goals):
+  - Intercepting `<input type="file">` on Windows.  WebView2
+    has no public hook; documented as a permanent platform
+    limitation.
+  - `NewWindowRequested`, `PermissionRequested`,
+    `BasicAuthenticationRequested`, `WebResourceRequested`,
+    `DocumentTitleChanged` — different event channels, out of
+    scope for this story.
+  - Standalone `WebView` integration (scoped out per canvas-11).
+  - Dedicated `beforeUnloadOpened` handler method —
+    `before-unload` routes to `confirmOpened` as documented.
+  - Migrating the vendored WebView2 SDK header
+    (`windows/script/Microsoft.Web.WebView2.0.8.355`) to a newer
+    version.  The vendored SDK supports
+    `ICoreWebView2ScriptDialogOpeningEventHandler` and
+    `ICoreWebView2Settings::put_AreDefaultScriptDialogsEnabled`,
+    which are sufficient.
+
+## E · Entities
+
+This canvas introduces no new Java types.  All Java contracts
+(`WebViewDialogHandler`, four event POJOs,
+`WebViewDialogCallback`, `DialogDispatcher`,
+`WebViewComponent.setDialogHandler`) were shipped in STORY-004-001
+and remain unchanged.
+
+Native types touched (all in `windows/webview_embed.cc`):
+
+- **`Engine`** (line 100, in the `embed_win` namespace) —
+  Windows engine struct.  Already carries `jobject dialog_callback`
+  (line 132) from STORY-004-001.  This canvas adds one new field:
+  `EventRegistrationToken script_dialog_token{}` alongside the
+  existing `message_token` / `got_focus_token` / `lost_focus_token`
+  at lines 107-109.
+
+- **`ScriptDialogHandler`** (new C++ class) — implements
+  `ICoreWebView2ScriptDialogOpeningEventHandler` via the existing
+  `CallbackBase<Iface>` template (line 190).  Stores an
+  `Engine *` like `FocusHandler` / `MsgHandler`.  Its `Invoke`
+  reads the dialog args, gets a deferral, spawns a worker
+  thread for the JNI hop, and returns `S_OK` immediately.
+
+- **`fire_dialog_alert` / `fire_dialog_confirm` /
+  `fire_dialog_prompt`** (three new C++ helper functions) —
+  byte-equivalent to the GTK versions from STORY-004-002 but
+  using `strdup` / `free` rather than `g_strdup` / `g_free`
+  (no GLib on Windows).  They live alongside the existing
+  `fire_focus_callback` / `fire_click_callback` at
+  `windows/webview_embed.cc:135-188`.  No
+  `fire_dialog_file_picker` is added — WebView2 has no
+  public file-picker hook.
+
+- **`dispatch_to_thread`** (existing helper, line 530) — used
+  unchanged.  The completion-side code in
+  `ScriptDialogHandler` worker thread posts a lambda via
+  this helper to marshal the answer back onto the WebView2
+  worker thread for `Accept` / `put_ResultText` /
+  `deferral->Complete`.
+
+- **README.md** (modified) — "Browser-initiated dialogs"
+  platform-status subsection updates the Windows line to
+  "wired (alert / confirm / prompt) via WebView2's
+  `add_ScriptDialogOpening` event" and explicitly notes that
+  `<input type="file">` continues to use the OS-native Common
+  Item Dialog because WebView2 exposes no public hook.
+
+```mermaid
+classDiagram
+direction TB
+
+class Engine {
+    +HWND parent
+    +HWND child
+    +DWORD thread_id
+    +ICoreWebView2Controller* controller
+    +ICoreWebView2* webview
+    +EventRegistrationToken message_token
+    +EventRegistrationToken got_focus_token
+    +EventRegistrationToken lost_focus_token
+    +EventRegistrationToken script_dialog_token
+    +jobject dialog_callback
+    +JavaVM* jvm
+}
+
+class CallbackBase {
+    <<template>>
+    +AddRef() ULONG
+    +Release() ULONG
+    +QueryInterface(REFIID, LPVOID*) HRESULT
+}
+
+class ScriptDialogHandler {
+    -Engine* m_engine
+    +Invoke(ICoreWebView2, ICoreWebView2ScriptDialogOpeningEventArgs) HRESULT
+}
+
+class fire_dialog_alert {
+    <<C function>>
+}
+
+class fire_dialog_confirm {
+    <<C function>>
+}
+
+class fire_dialog_prompt {
+    <<C function>>
+}
+
+class ICoreWebView2 {
+    <<external>>
+    +add_ScriptDialogOpening(handler, &token) HRESULT
+}
+
+class ICoreWebView2Settings {
+    <<external>>
+    +put_AreDefaultScriptDialogsEnabled(BOOL) HRESULT
+}
+
+class ICoreWebView2ScriptDialogOpeningEventArgs {
+    <<external>>
+    +get_Uri(LPWSTR*) HRESULT
+    +get_Kind(COREWEBVIEW2_SCRIPT_DIALOG_KIND*) HRESULT
+    +get_Message(LPWSTR*) HRESULT
+    +get_DefaultText(LPWSTR*) HRESULT
+    +Accept() HRESULT
+    +put_ResultText(LPCWSTR) HRESULT
+    +GetDeferral(ICoreWebView2Deferral**) HRESULT
+}
+
+class WebViewDialogCallback {
+    <<Java interface>>
+    +onAlert(String, String, String) void
+    +onConfirm(String, String, String) boolean
+    +onPrompt(String, String, String, String) String
+}
+
+ScriptDialogHandler --|> CallbackBase
+ICoreWebView2 ..> ScriptDialogHandler : add_ScriptDialogOpening
+ICoreWebView2 ..> ICoreWebView2Settings : configures
+ScriptDialogHandler ..> ICoreWebView2ScriptDialogOpeningEventArgs : reads
+ScriptDialogHandler ..> fire_dialog_alert : routes alert
+ScriptDialogHandler ..> fire_dialog_confirm : routes confirm + before-unload
+ScriptDialogHandler ..> fire_dialog_prompt : routes prompt
+fire_dialog_alert ..> WebViewDialogCallback : JNI
+fire_dialog_confirm ..> WebViewDialogCallback : JNI
+fire_dialog_prompt ..> WebViewDialogCallback : JNI
+Engine "1" *-- "1" ICoreWebView2
+```
+
+## A · Approach
+
+1. **Two-thread deferral pattern.**  WebView2's
+   `ScriptDialogOpening` event fires on the engine's dedicated
+   WebView2 worker thread (the one created in `create_engine` that
+   runs the message pump and services `WM_EMBED_DISPATCH` /
+   `WM_EMBED_QUIT` messages).  We CANNOT block that thread
+   synchronously waiting for the EDT, because:
+   - The dispatcher's `dispatch_to_thread(e, ...)` for the
+     completion-side code re-enters the same worker thread.  If
+     the worker is blocked inside `Invoke`, the completion-side
+     `PostThreadMessage` arrives but is never picked up — classic
+     self-deadlock.
+   - Other operations on the same engine (concurrent
+     `webview_embed_eval`, `webview_embed_set_bounds`,
+     repaint ticks) all use `dispatch_to_thread` and would queue
+     indefinitely.
+   - The WebView2 SDK explicitly documents the
+     `GetDeferral` / `Complete` pattern for any handler that
+     needs to perform work that might involve other threads.
+
+   Therefore the flow is:
+
+   ```
+   WebView2 worker (Invoke)         Java worker          EDT
+   ----------------------           -----------          ---
+   Read Kind/Message/Uri
+   GetDeferral -> deferral
+   spawn std::thread([...]{
+     fire_dialog_*(jvm, cb, ...)
+                            -- JNI --> DialogDispatcher
+                                       invokeAndWait ->
+                                                       handler.X
+                                                       <- return
+                            <-------- answer
+     dispatch_to_thread(e, [...]{
+       Accept / put_ResultText
+       deferral->Complete()
+       deferral->Release()
+       args->Release()
+     });
+   }).detach();
+   return S_OK    // worker stays free to pump messages
+   ```
+
+   The Java worker thread does block on the EDT (via the
+   dispatcher's `invokeAndWait`), but that's a single Java thread
+   per dialog — it doesn't starve the WebView2 worker.
+
+2. **Why `std::thread` rather than reusing a fixed worker pool.**
+   Dialogs are user-driven, low-frequency, and modal — they don't
+   come in bursts.  Each `Invoke` spinning a single `std::thread`
+   for the duration of the modal is cheap relative to the
+   dialog's wall-clock lifetime (user-action time).  A thread
+   pool adds complexity (queueing, lifecycle) for no measurable
+   benefit.  Match the existing patterns in
+   `webview_embed_dispatch` (line 822) which also spins a
+   short-lived thread via `dispatch_to_thread` indirectly.
+
+3. **`fire_dialog_*` helpers are byte-equivalent across
+   platforms.**  The Linux side (STORY-004-002) defines them in
+   `src_c/webview_embed.cpp` inside `namespace embed`.  Windows
+   needs its own copies inside `namespace embed_win` in
+   `windows/webview_embed.cc`.  The translation-unit divergence
+   is by design — the Windows build doesn't include
+   `src_c/webview_embed.cpp` (separate `cl.exe` invocation per
+   `script/build.bat`), so the symbols would conflict if
+   shared.  The platform-specific allocator (`g_strdup` vs.
+   plain `strdup`, `g_free` vs. plain `free`) further justifies
+   the per-binary copy.  The MS-CRT `strdup` is widely available
+   in `<cstring>` / `<string.h>`; if the existing Windows file
+   already uses `_strdup` (the Microsoft-recommended name) we
+   follow that.
+
+4. **JNI dispatch from the Java worker thread.**  The
+   `std::thread` spawned by `ScriptDialogHandler::Invoke` is
+   NOT a JVM-attached thread.  The `fire_dialog_*` helpers must
+   `AttachCurrentThreadAsDaemon` (or `AttachCurrentThread`) and
+   detach on exit.  Same pattern as the GTK helpers but the
+   thread is short-lived rather than persistent — daemon
+   attachment avoids any concern about the thread keeping the
+   JVM alive past intended shutdown.  Decision: use
+   `AttachCurrentThread` (matching the existing
+   `fire_focus_callback` and `fire_click_callback` patterns at
+   `windows/webview_embed.cc:135-188`) since those also work on
+   one-shot WebView2 worker invocations.
+
+5. **Completion-side marshaling via `dispatch_to_thread`.**
+   `args->Accept()`, `args->put_ResultText(...)`, and
+   `deferral->Complete()` MUST be called on the WebView2 worker
+   thread per Microsoft's threading model for WebView2 — any
+   COM call on the engine's interfaces is bound to the thread
+   they were created on.  Once the Java worker has the answer,
+   it queues a lambda via `dispatch_to_thread(e, [...] {...})`
+   that performs the three COM calls on the worker.  Inside the
+   lambda the deferral and args are released via their
+   `ComPtr`-style smart pointers (or explicit `Release` if we
+   use raw pointers like the rest of the codebase does — see
+   Norms).
+
+6. **Per-kind result mapping (inside the completion-side
+   lambda):**
+   - **Alert:** `args->Accept()` is optional for alert (no
+     payload to convey); just call `deferral->Complete()`.
+     Calling `Accept` is harmless on a no-payload dialog and
+     matches the SDK's intent — call it for clarity.
+   - **Confirm / Before-unload:** if Java returned `true`, call
+     `args->Accept()`.  If `false`, do NOT call `Accept`
+     (WebView2 interprets "no Accept" as "user clicked
+     Cancel").  Then `deferral->Complete()`.
+   - **Prompt:** if Java returned a non-null string, call
+     `args->put_ResultText(utf16)` and then `args->Accept()`.
+     If Java returned `null`, do NOT call `put_ResultText` or
+     `Accept` (cancel).  Then `deferral->Complete()`.
+
+7. **`COREWEBVIEW2_SCRIPT_DIALOG_KIND` switch.**  The handler
+   reads the kind once at the start of `Invoke` and stores it
+   for the completion-side lambda.  Switch cases:
+   - `_ALERT` → `fire_dialog_alert` →
+     completion: `Accept` + `Complete`.
+   - `_CONFIRM` / `_BEFOREUNLOAD` → `fire_dialog_confirm` →
+     completion: `Accept` iff `true` + `Complete`.
+   - `_PROMPT` → `fire_dialog_prompt` → completion:
+     `put_ResultText` + `Accept` iff non-null + `Complete`.
+   - default (unknown kind from a future SDK): just
+     `Complete` the deferral.  Don't `Accept`.  Avoids
+     bricking the page on a kind we don't recognise.
+
+8. **UTF-16 / UTF-8 conversion.**  WebView2 API uses
+   `LPWSTR` (UTF-16) throughout.  Existing codebase has
+   `utf8_to_wide` (line 644) for the outgoing direction and
+   `WideCharToMultiByte` for incoming (line 285-287).  Wrap
+   the existing pattern in tiny helpers `wide_to_utf8(LPWSTR
+   in) -> std::string` and reuse `utf8_to_wide` for outgoing.
+   `args->get_Uri`, `_get_Message`, `_get_DefaultText` all
+   return `LPWSTR` that must be released with
+   `CoTaskMemFree`; capture the strings, copy to `std::string`,
+   then immediately `CoTaskMemFree` so the rest of the
+   pipeline can work in UTF-8.
+
+9. **Settings change is unconditional.**  The
+   `put_AreDefaultScriptDialogsEnabled(FALSE)` call happens
+   every time the controller-ready callback runs, regardless
+   of whether the Java side has registered a handler.  The
+   `Java_..._set_dialog_callback` JNI bridge is what wires the
+   actual response path; until that's called, the
+   `ScriptDialogHandler` invokes a null Java callback and the
+   handler returns the safe default
+   (no-op for alert; false for confirm; null for prompt).
+   The page's JS thread still resumes within bounded time.
+   This matches the canvas-12 (Linux) null-callback safety
+   invariant.
+
+10. **No remove on destroy.**  `destroy_engine` (line 580)
+    already releases the controller and webview interfaces,
+    which detaches all event handlers including
+    `ScriptDialogOpening`.  Adding an explicit
+    `remove_ScriptDialogOpening` would be redundant and
+    introduces a potential use-after-free if the token is
+    re-used.  Match the existing pattern for the message /
+    focus tokens — they aren't explicitly removed either.
+
+11. **README update strategy.**  The "Browser-initiated
+    dialogs" section already exists and was updated by
+    STORY-004-002 for Linux.  This canvas tweaks the same
+    platform-status paragraph to mark Windows as wired for the
+    three dialog kinds, with a one-paragraph note about the
+    OS-native file picker.  No structural changes to the
+    README.
+
+## S · Structure
+
+### Inheritance Relationships
+1. No new Java types; existing `WebViewDialogHandler`, four event
+   POJOs, `WebViewDialogCallback`, `DialogDispatcher`,
+   `WebViewComponent` API surface from STORY-004-001 is
+   unchanged.
+2. `ScriptDialogHandler` (new) inherits from the existing
+   `CallbackBase<ICoreWebView2ScriptDialogOpeningEventHandler>`
+   template (windows/webview_embed.cc:190) — same pattern as
+   `FocusHandler`, `MsgHandler`, `EnvHandler`,
+   `ControllerHandler`.
+
+### Dependencies
+1. `ScriptDialogHandler::Invoke` (new) → reads
+   `ICoreWebView2ScriptDialogOpeningEventArgs::get_Uri /
+   _get_Kind / _get_Message / _get_DefaultText / GetDeferral`;
+   spawns a `std::thread` that calls one of the three
+   `fire_dialog_*` helpers via JNI then `dispatch_to_thread`s
+   the completion lambda back to the WebView2 worker.
+2. `fire_dialog_alert / _confirm / _prompt` (new) → JNI
+   `AttachCurrentThread` / `GetObjectClass` / `GetMethodID` /
+   `CallVoidMethod` / `CallBooleanMethod` / `CallObjectMethod` /
+   `NewStringUTF` / `GetStringUTFChars` /
+   `ReleaseStringUTFChars` / `ExceptionCheck` /
+   `ExceptionDescribe` / `ExceptionClear` / `DeleteLocalRef` /
+   `DetachCurrentThread`.
+3. `create_engine`'s controller-ready callback (modified) →
+   adds `settings->put_AreDefaultScriptDialogsEnabled(FALSE)`
+   inside the existing settings block (line 430-437); adds a
+   `webview->add_ScriptDialogOpening` registration right after
+   the `add_WebMessageReceived` site (line 447-449).
+
+### Layered Architecture
+1. **Native engine layer** (`windows/webview_embed.cc`): three
+   new `fire_dialog_*` JNI helpers, one new
+   `ScriptDialogHandler` class, two new lines in the
+   controller-ready callback
+   (`put_AreDefaultScriptDialogsEnabled(FALSE)` plus
+   `add_ScriptDialogOpening`), one new field in the `Engine`
+   struct (`script_dialog_token`).  No changes outside the
+   `embed_win` namespace.
+2. **JNI surface**: unchanged.
+   `webview_embed_set_dialog_callback` already exists and works.
+3. **Engine wrapper layer** (`EmbeddedWebView`): unchanged.
+4. **Dispatcher layer** (`DialogDispatcher`): unchanged.
+5. **Component API layer** (`WebViewComponent`): unchanged.
+6. **Public contract layer** (`WebViewDialogHandler` + event
+   POJOs): unchanged.
+7. **Wiring layer**
+   (`WebViewHeavyweightComponent.createPeer()`): unchanged —
+   the `WebViewDialogCallback` adapter it installs at
+   peer-attach time starts receiving Windows dialog events
+   automatically once this canvas wires the
+   `ScriptDialogHandler`.
+8. **Demo layer** (`demos/WebViewDialogDemo/`): unchanged.
+
+## O · Operations
+
+### 1. Add Engine Field — script_dialog_token
+File: `windows/webview_embed.cc`
+
+1. Locate the `Engine` struct (line 100).
+2. Find the three existing token fields:
+   ```
+   EventRegistrationToken message_token{};
+   EventRegistrationToken got_focus_token{};
+   EventRegistrationToken lost_focus_token{};
+   ```
+   (Lines 107-109.)
+3. Add one new field immediately after, before the existing
+   `jobject focus_callback` field:
+   ```
+   // EventRegistrationToken for the ScriptDialogOpening handler
+   // registered in create_engine.  Not explicitly removed in
+   // destroy_engine -- the controller / webview Release calls
+   // there detach all event handlers transitively (same as
+   // message_token / got_focus_token / lost_focus_token).
+   EventRegistrationToken script_dialog_token{};
+   ```
+4. Constraints:
+   - Zero-initialised (`{}`).  WebView2 fills it in via
+     `add_ScriptDialogOpening`'s out parameter.
+   - No corresponding cleanup in `destroy_engine` — see
+     Approach §10.
+
+### 2. Add JNI Dispatch Helper — fire_dialog_alert
+File: `windows/webview_embed.cc`
+Location: alongside the existing `fire_focus_callback` (line
+135) and `fire_click_callback` (line 161), inside the
+`namespace embed_win` block.
+
+1. Responsibility: invoke
+   `WebViewDialogCallback.onAlert(String, String, String)V`
+   on the JVM.  Mirrors the Linux `fire_dialog_alert` from
+   STORY-004-002 modulo the allocator (uses `std::string` for
+   transient copies; no `g_strdup` / `g_free` needed since we
+   don't return strings).
+2. Signature:
+   ```
+   static void fire_dialog_alert(
+       JavaVM *jvm, jobject callback,
+       const char *message, const char *pageUrl,
+       const char *frameUrl);
+   ```
+3. Logic:
+   - If `jvm == nullptr` or `callback == nullptr`, return.
+   - `JNIEnv *env = nullptr; bool detach = false;`
+   - `if (jvm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+     if (jvm->AttachCurrentThread((void**)&env, nullptr) != JNI_OK
+         || !env) return;
+     detach = true; }`
+   - `jstring jmsg = env->NewStringUTF(message ? message : "");`
+   - `jstring jpage = env->NewStringUTF(pageUrl ? pageUrl : "");`
+   - `jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");`
+   - `jclass cls = env->GetObjectClass(callback);`
+   - `jmethodID m = env->GetMethodID(cls, "onAlert",
+     "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");`
+   - If `m != nullptr`:
+     `env->CallVoidMethod(callback, m, jmsg, jpage, jframe);`
+   - `if (env->ExceptionCheck()) { env->ExceptionDescribe();
+     env->ExceptionClear(); }`
+   - `env->DeleteLocalRef(jmsg); env->DeleteLocalRef(jpage);
+     env->DeleteLocalRef(jframe); env->DeleteLocalRef(cls);`
+   - `if (detach) jvm->DetachCurrentThread();`
+4. Constraints: never throws back into C++.  Always sanitizes
+   pending Java exceptions before returning.  Identical
+   contract to the Linux `fire_dialog_alert`.
+
+### 3. Add JNI Dispatch Helper — fire_dialog_confirm
+File: `windows/webview_embed.cc` (same area as Operation 2).
+
+1. Responsibility: invoke
+   `WebViewDialogCallback.onConfirm(String, String, String)Z`;
+   return the `jboolean` answer (or `JNI_FALSE` on any error).
+2. Signature:
+   ```
+   static jboolean fire_dialog_confirm(
+       JavaVM *jvm, jobject callback,
+       const char *message, const char *pageUrl,
+       const char *frameUrl);
+   ```
+3. Logic:
+   - Same shell as Operation 2.  Resolve method via
+     `GetMethodID(cls, "onConfirm",
+     "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z")`.
+   - `jboolean result = JNI_FALSE;`
+   - `if (m != nullptr) result =
+     env->CallBooleanMethod(callback, m, jmsg, jpage, jframe);`
+   - On exception: clear, force `result = JNI_FALSE`.
+   - Clean up local refs, detach if attached, return `result`.
+4. Constraints: returns `JNI_FALSE` on any error path — the
+   safe default for "no answer" (matches the JS-spec cancel
+   semantic).
+
+### 4. Add JNI Dispatch Helper — fire_dialog_prompt
+File: `windows/webview_embed.cc` (same area).
+
+1. Responsibility: invoke
+   `WebViewDialogCallback.onPrompt(String, String, String, String)Ljava/lang/String;`;
+   return a newly-allocated UTF-8 `char *` (caller owns; free
+   with `free`) or `nullptr` on cancel / error.
+2. Signature:
+   ```
+   static char *fire_dialog_prompt(
+       JavaVM *jvm, jobject callback,
+       const char *message, const char *defaultValue,
+       const char *pageUrl, const char *frameUrl);
+   ```
+3. Logic:
+   - Same shell as Operation 2/3.
+   - `char *result = nullptr;`
+   - Resolve method via
+     `GetMethodID(cls, "onPrompt",
+     "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;")`.
+   - `jstring jresult = (jstring)env->CallObjectMethod(
+     callback, m, jmsg, jdefault, jpage, jframe);`
+   - On exception: clear, force `jresult = nullptr`.
+   - If `jresult != nullptr`:
+     `const char *cstr = env->GetStringUTFChars(jresult,
+     nullptr);
+     if (cstr != nullptr) {
+       size_t n = strlen(cstr);
+       result = (char *)malloc(n + 1);
+       if (result) memcpy(result, cstr, n + 1);
+       env->ReleaseStringUTFChars(jresult, cstr);
+     }
+     env->DeleteLocalRef(jresult);`
+   - Clean up other local refs, detach if attached.
+   - Return `result`.  Caller MUST `free(result)` when done.
+4. Constraints: uses plain `malloc`/`free` (no GLib on Windows).
+   Returns `nullptr` for cancel — completion-side code MUST
+   check for null and use the "don't accept" path
+   (WebView2 returns null to the page).
+
+### 5. Add ScriptDialogHandler Class
+File: `windows/webview_embed.cc`
+Location: alongside `FocusHandler` / `MsgHandler` at line
+246+, inside `namespace embed_win`.
+
+1. Responsibility: handle the `ScriptDialogOpening` event on
+   `ICoreWebView2`.  Spawn a JNI worker thread; on Java's
+   return, marshal back to the WebView2 worker via
+   `dispatch_to_thread` and complete the deferral.
+2. Declaration:
+   ```
+   class ScriptDialogHandler : public CallbackBase<
+       ICoreWebView2ScriptDialogOpeningEventHandler> {
+   public:
+       explicit ScriptDialogHandler(Engine *e) : m_engine(e) {}
+       HRESULT STDMETHODCALLTYPE Invoke(
+           ICoreWebView2 *,
+           ICoreWebView2ScriptDialogOpeningEventArgs *args) override;
+   private:
+       Engine *m_engine;
+   };
+   ```
+3. `Invoke` implementation:
+   1. `if (!args || !m_engine) return S_OK;`
+   2. Read the kind:
+      ```
+      COREWEBVIEW2_SCRIPT_DIALOG_KIND kind =
+          COREWEBVIEW2_SCRIPT_DIALOG_KIND_ALERT;
+      args->get_Kind(&kind);
+      ```
+   3. Read the strings:
+      ```
+      LPWSTR uri_w = nullptr;
+      LPWSTR msg_w = nullptr;
+      LPWSTR def_w = nullptr;
+      args->get_Uri(&uri_w);
+      args->get_Message(&msg_w);
+      if (kind == COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT) {
+          args->get_DefaultText(&def_w);
+      }
+      ```
+   4. Convert to UTF-8 `std::string`:
+      ```
+      std::string uri = wide_to_utf8(uri_w);
+      std::string msg = wide_to_utf8(msg_w);
+      std::string def = wide_to_utf8(def_w);
+      if (uri_w) CoTaskMemFree(uri_w);
+      if (msg_w) CoTaskMemFree(msg_w);
+      if (def_w) CoTaskMemFree(def_w);
+      ```
+   5. Get the deferral (AddRef on args so we keep it alive
+      across the threads):
+      ```
+      ICoreWebView2Deferral *deferral = nullptr;
+      HRESULT hr = args->GetDeferral(&deferral);
+      if (FAILED(hr) || !deferral) {
+          // Can't defer -- accept synchronously with the safe
+          // default and let the engine resume.  This branch is
+          // rare and a sign of an SDK-level error; logging it
+          // helps diagnose.
+          WV_LOG("GetDeferral failed: HRESULT=0x%08lx",
+                 (unsigned long)hr);
+          return S_OK;
+      }
+      args->AddRef();
+      ```
+   6. Spawn the JNI worker thread:
+      ```
+      Engine *e = m_engine;
+      std::thread([e, args, deferral, kind, uri, msg, def] {
+          // Invoke Java synchronously from this worker.
+          jobject cb = e ? e->dialog_callback : nullptr;
+          JavaVM *jvm = e ? e->jvm : nullptr;
+          // Result placeholders for the completion-side lambda.
+          jboolean confirmed = JNI_FALSE;
+          char *prompt_answer = nullptr;
+          switch (kind) {
+              case COREWEBVIEW2_SCRIPT_DIALOG_KIND_ALERT:
+                  if (cb) fire_dialog_alert(
+                      jvm, cb, msg.c_str(),
+                      uri.c_str(), uri.c_str());
+                  break;
+              case COREWEBVIEW2_SCRIPT_DIALOG_KIND_CONFIRM:
+              case COREWEBVIEW2_SCRIPT_DIALOG_KIND_BEFOREUNLOAD:
+                  if (cb) confirmed = fire_dialog_confirm(
+                      jvm, cb, msg.c_str(),
+                      uri.c_str(), uri.c_str());
+                  break;
+              case COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT:
+                  if (cb) prompt_answer = fire_dialog_prompt(
+                      jvm, cb, msg.c_str(), def.c_str(),
+                      uri.c_str(), uri.c_str());
+                  break;
+              default:
+                  break;
+          }
+
+          // Marshal back to the WebView2 worker thread to apply
+          // the answer and complete the deferral.  ICoreWebView2*
+          // methods are bound to the thread the engine was
+          // created on (the engine's worker thread); calling
+          // Accept / put_ResultText / Complete from the Java
+          // worker would violate WebView2's threading model.
+          dispatch_to_thread(e, [args, deferral, kind, confirmed,
+                                 prompt_answer] {
+              switch (kind) {
+                  case COREWEBVIEW2_SCRIPT_DIALOG_KIND_ALERT:
+                      args->Accept();
+                      break;
+                  case COREWEBVIEW2_SCRIPT_DIALOG_KIND_CONFIRM:
+                  case COREWEBVIEW2_SCRIPT_DIALOG_KIND_BEFOREUNLOAD:
+                      if (confirmed == JNI_TRUE) args->Accept();
+                      // else: don't Accept -- WebView2 returns
+                      // false to the page.
+                      break;
+                  case COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT:
+                      if (prompt_answer != nullptr) {
+                          std::wstring wtxt = utf8_to_wide(
+                              prompt_answer);
+                          args->put_ResultText(wtxt.c_str());
+                          args->Accept();
+                          free(prompt_answer);
+                      }
+                      // else: don't put_ResultText, don't Accept
+                      // -- WebView2 returns null to the page.
+                      break;
+                  default:
+                      break;
+              }
+              deferral->Complete();
+              deferral->Release();
+              args->Release();
+          });
+      }).detach();
+      ```
+   7. `return S_OK;`
+4. Constraints:
+   - Always returns `S_OK` immediately (after launching the
+     worker thread).  The actual response happens
+     asynchronously when Java returns.
+   - `args` is `AddRef`'d before the worker thread launches and
+     `Release`'d inside the completion-side lambda — covers
+     the case where WebView2 would otherwise release `args`
+     after `Invoke` returns.
+   - The deferral is `Release`'d inside the completion-side
+     lambda too.
+   - On null `dialog_callback`, the safe-default path runs:
+     alert → Accept (it has no payload); confirm → don't
+     Accept (returns false to page); prompt → don't
+     put_ResultText / Accept (returns null to page).  Page's
+     JS thread always resumes.
+
+### 6. Add UTF-16 / UTF-8 Conversion Helper
+File: `windows/webview_embed.cc`
+Location: alongside the existing `utf8_to_wide` (line 644),
+inside `namespace embed_win`.
+
+1. Responsibility: convert a (possibly null) `LPWSTR` to a
+   `std::string` UTF-8.  Returns an empty string for null
+   input.  Used by `ScriptDialogHandler::Invoke` to convert
+   the `_get_Uri` / `_get_Message` / `_get_DefaultText`
+   return values before the JNI worker thread launches (so
+   `CoTaskMemFree` can happen on the WebView2 worker thread
+   that owns those COM allocations).
+2. Signature:
+   ```
+   static std::string wide_to_utf8(LPCWSTR w);
+   ```
+3. Logic:
+   - If `w == nullptr` or `*w == L'\0'`, return `std::string()`.
+   - `int n = WideCharToMultiByte(CP_UTF8, 0, w, -1, nullptr, 0,
+     nullptr, nullptr);`
+   - If `n <= 0`, return `std::string()`.
+   - `std::string s(n, '\0');`
+   - `WideCharToMultiByte(CP_UTF8, 0, w, -1, &s[0], n,
+     nullptr, nullptr);`
+   - If `!s.empty() && s.back() == '\0'` `s.pop_back();`
+   - Return `s`.
+4. Constraints:
+   - Mirrors the inline pattern used in `engine_on_message`
+     (line 285-288).  Factor it into a named helper so
+     `ScriptDialogHandler::Invoke` doesn't duplicate the
+     boilerplate.
+
+### 7. Suppress Built-in WebView2 Dialogs
+File: `windows/webview_embed.cc`
+Location: the controller-ready callback inside
+`create_engine`, around line 430-437.
+
+1. Find the existing settings block:
+   ```
+   ICoreWebView2Settings *settings = nullptr;
+   if (SUCCEEDED(e->webview->get_Settings(&settings)) &&
+       settings) {
+       settings->put_AreDevToolsEnabled(
+           e->debug ? TRUE : FALSE);
+       settings->put_AreDefaultContextMenusEnabled(TRUE);
+       settings->Release();
+   }
+   ```
+2. Add `put_AreDefaultScriptDialogsEnabled(FALSE)` before
+   `settings->Release()`:
+   ```
+   ICoreWebView2Settings *settings = nullptr;
+   if (SUCCEEDED(e->webview->get_Settings(&settings)) &&
+       settings) {
+       settings->put_AreDevToolsEnabled(
+           e->debug ? TRUE : FALSE);
+       settings->put_AreDefaultContextMenusEnabled(TRUE);
+       // Suppress WebView2's built-in alert / confirm / prompt
+       // dialogs.  Java drives the response via the
+       // ScriptDialogHandler registered below.  STORY-004-003.
+       settings->put_AreDefaultScriptDialogsEnabled(FALSE);
+       settings->Release();
+   }
+   ```
+3. Constraints:
+   - Unconditional — the setting is applied every time an
+     engine is created, regardless of whether the Java side
+     has wired a handler.  The `ScriptDialogHandler` runs the
+     null-callback safe-default path when no handler is wired,
+     so the JS thread still resumes within bounded time.
+
+### 8. Register the ScriptDialogOpening Handler
+File: `windows/webview_embed.cc`
+Location: the controller-ready callback in `create_engine`,
+right after the `add_WebMessageReceived` site
+(lines 447-449).
+
+1. Find the existing message-handler registration:
+   ```
+   auto *mh = new MsgHandler(e);
+   e->webview->add_WebMessageReceived(mh, &e->message_token);
+   mh->Release();
+   ```
+2. Insert the dialog-handler registration immediately after:
+   ```
+   // Wire JS-initiated dialogs (alert / confirm / prompt /
+   // before-unload) to the per-engine Java DialogDispatcher
+   // via the dialog_callback global ref.  WebView2's built-in
+   // dialogs are suppressed by
+   // put_AreDefaultScriptDialogsEnabled(FALSE) above.  File
+   // picker (<input type=file>) is NOT intercepted -- WebView2
+   // exposes no public hook; the OS-native Common Item Dialog
+   // continues to appear as before.  STORY-004-003.
+   auto *sdh = new ScriptDialogHandler(e);
+   e->webview->add_ScriptDialogOpening(
+       sdh, &e->script_dialog_token);
+   sdh->Release();
+   ```
+3. Constraints:
+   - The `new` / `Release` pattern matches `MsgHandler` /
+     `FocusHandler` registrations — `add_ScriptDialogOpening`
+     retains its own ref so we drop ours immediately.
+   - No `remove_ScriptDialogOpening` call in
+     `destroy_engine` — controller / webview Release detaches
+     handlers transitively.
+
+### 9. Update README — mark Windows wired
+File: `README.md`.
+
+1. Locate the "Browser-initiated dialogs" subsection
+   (added by canvas-11, updated by canvas-12).  The current
+   platform-status paragraph reads:
+   > "**Platform coverage (current).**  macOS heavyweight
+   > (WKWebView) routes all four dialog kinds through the
+   > handler (STORY-004-001).  Linux WebKitGTK routes all four
+   > kinds through the handler in both heavyweight and
+   > lightweight modes via the `script-dialog` and
+   > `run-file-chooser` signals (STORY-004-002).  On Windows,
+   > `setDialogHandler` stores the handler reference but the
+   > embedded engine continues to use its built-in dialogs
+   > until STORY-004-003 (WebView2 `ScriptDialogOpening`
+   > event) lands.  On Windows, `<input type="file">` will
+   > continue to use the OS-native dialog even after
+   > STORY-004-003 — WebView2 exposes no public hook for it,
+   > so `filePickerOpened` never fires on Windows."
+2. Rewrite to:
+   > "**Platform coverage (current).**  macOS heavyweight
+   > (WKWebView) routes all four dialog kinds through the
+   > handler (STORY-004-001).  Linux WebKitGTK routes all four
+   > kinds through the handler in both heavyweight and
+   > lightweight modes via the `script-dialog` and
+   > `run-file-chooser` signals (STORY-004-002).  Windows
+   > WebView2 routes alert / confirm / prompt (and
+   > before-unload) through the handler via the
+   > `ScriptDialogOpening` event combined with
+   > `put_AreDefaultScriptDialogsEnabled(FALSE)`
+   > (STORY-004-003).  On Windows, `<input type="file">`
+   > continues to use the OS-native Common Item Dialog —
+   > WebView2 exposes no public hook for the file picker, so
+   > `filePickerOpened` never fires on Windows.  On Windows,
+   > `frameUrl()` equals `pageUrl()` for now (top-level
+   > only) because the `ScriptDialogOpening` event args do
+   > not expose a separate frame URL."
+3. No other prose changes.
+
+## N · Norms
+
+- **Mirror the existing `CallbackBase<Iface>` template** for
+  the new `ScriptDialogHandler` class.  Match the
+  `FocusHandler` / `MsgHandler` shape: minimal constructor
+  taking `Engine *`, override `Invoke`, store the engine
+  pointer in a private member.  Don't add lifecycle logic
+  beyond what `CallbackBase` provides.
+- **Mirror `fire_focus_callback` / `fire_click_callback`'s JNI
+  pattern** for the three new `fire_dialog_*` helpers
+  (`windows/webview_embed.cc:135-188`).  Per-call
+  `GetObjectClass` + `GetMethodID`; `ExceptionCheck` /
+  `Describe` / `Clear` after every `Call*Method`; defensive
+  `AttachCurrentThread` with detach-iff-we-attached.
+  Consistency with the existing pattern beats method-id
+  caching.
+- **Mirror Linux `fire_dialog_*` signatures** from
+  STORY-004-002.  The Java JNI signature strings
+  (`(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V`
+  etc.) MUST be byte-identical across platforms — the same
+  Java `WebViewDialogCallback` interface is the target.
+  Method-name strings (`"onAlert"`, `"onConfirm"`,
+  `"onPrompt"`) likewise byte-identical.
+- **Two-thread deferral pattern.**  Use `GetDeferral` +
+  `std::thread([..]{...}).detach()` for the JNI hop +
+  `dispatch_to_thread(e, [..]{...})` for the WebView2
+  completion side.  Do NOT block the WebView2 worker thread
+  synchronously in `Invoke`.  This is the only thread-safe
+  pattern documented by Microsoft for any WebView2 event that
+  involves cross-thread waits.
+- **AddRef args before the worker thread, Release inside the
+  completion lambda.**  WebView2 owns the args lifetime
+  inside `Invoke`; without `AddRef` it may release them
+  between the `S_OK` return and our completion lambda.  The
+  deferral is similarly captured by ref and released inside
+  the completion lambda.
+- **UTF-16 / UTF-8 conversion.**  Use the new `wide_to_utf8`
+  helper for incoming `LPWSTR` strings; use the existing
+  `utf8_to_wide` for the outgoing `put_ResultText` call.
+  ALWAYS `CoTaskMemFree` the strings returned by
+  `get_Uri` / `_get_Message` / `_get_DefaultText` — they are
+  COM-allocated strings the caller owns.
+- **Plain `malloc` / `free`** for the `fire_dialog_prompt`
+  return path.  No GLib on Windows; matching the Linux
+  side's `g_strdup` / `g_free` would require linking glib,
+  which isn't part of the Windows toolchain.  The caller
+  (the completion-side lambda) MUST `free` the returned
+  string exactly once.
+- **JNI exception sanitization on every C-call boundary.**
+  After every `Call*Method`, check `ExceptionCheck` and clear
+  any pending exception via `ExceptionDescribe` +
+  `ExceptionClear`.  A pending Java exception propagating
+  back through C++ into the WebView2 worker terminates the
+  process — same rule as Linux / macOS.
+- **Always Complete the deferral on every path.**  Every
+  branch of the completion-side lambda's switch (including
+  the `default` / unknown-kind branch) MUST call
+  `deferral->Complete()` exactly once.  A skipped Complete
+  hangs the page's JS thread forever.  Same invariant as the
+  Linux signal handlers' "always resolve the dialog" rule
+  but expressed through `Complete` instead of a
+  webkit_script_dialog_*_set_* call.
+- **No `remove_ScriptDialogOpening` in destroy paths.**  The
+  controller's `Release` call in `destroy_engine` (line 580+)
+  detaches the handler transitively.  Match the existing
+  pattern for `message_token` / `got_focus_token` /
+  `lost_focus_token`.
+- **No new headers.**  All required types
+  (`ICoreWebView2ScriptDialogOpeningEventHandler`,
+  `ICoreWebView2ScriptDialogOpeningEventArgs`,
+  `ICoreWebView2Deferral`, `ICoreWebView2Settings`,
+  `COREWEBVIEW2_SCRIPT_DIALOG_KIND` enum) live in the
+  vendored WebView2 SDK headers already included via
+  `windows/script/Microsoft.Web.WebView2.0.8.355/build/native/include`
+  (per `windows/script/build.bat:36-37`).
+- **`extern "C"` discipline is preserved.**  The file's
+  trailing `extern "C" {` block (line 843) wraps all JNI
+  exports.  No JNI bridges are added by this story (the
+  `webview_embed_set_dialog_callback` bridge already exists
+  from STORY-004-001 and works correctly).  No new symbols
+  need C linkage.
+- **No Java code changes.**  This story is purely native.
+  The 27 `DialogDispatcherTest` cases shipped in
+  STORY-004-001 continue to cover the Java contract that
+  STORY-004-003's native code exercises end-to-end.
+- **No automated tests for GUI integration.**  Consistent
+  with macOS / Linux stories and the existing canvases.
+  Manual AC verification via `WebViewDialogDemo` on a real
+  Windows 11 host with the WebView2 Runtime installed.
+
+## S · Safeguards
+
+- **Always Complete the deferral.**  Every branch of the
+  completion-side lambda in `ScriptDialogHandler::Invoke`
+  MUST call `deferral->Complete()` exactly once.  Skipping
+  `Complete` (including via an exception escape we forgot to
+  catch) leaves the page's JS thread suspended forever and
+  is unrecoverable without page reload.
+- **Always Release the deferral and args** inside the
+  completion-side lambda.  We `AddRef`'d both before
+  launching the worker thread; without the matching
+  `Release` we leak the COM objects on every dialog.
+- **No COM calls on the wrong thread.**  `args->Accept`,
+  `args->put_ResultText`, and `deferral->Complete` MUST be
+  called on the WebView2 worker thread (`e->thread_id`).
+  The Java worker thread is NOT a WebView2 thread — calling
+  these methods from there would silently misbehave or
+  crash per WebView2's threading model.  Enforced by always
+  routing the completion through `dispatch_to_thread(e, ...)`.
+- **AddRef before crossing threads.**  Both `args` and
+  `deferral` are `AddRef`'d in `Invoke` before launching
+  the worker thread; without this, WebView2 may release
+  them after `S_OK` returns, and the completion-side lambda
+  references freed memory.
+- **JNI attach / detach symmetry.**  The three
+  `fire_dialog_*` helpers detach the JVM iff they attached
+  locally.  The Java worker thread spawned by `Invoke` is
+  new each time, so each helper invocation attaches and
+  detaches fresh — no thread-local JVM attachment state to
+  manage.
+- **JNI exception sanitization on every C-call boundary.**
+  After every `Call*Method`, check `ExceptionCheck` and
+  clear.  A pending Java exception propagating into the
+  WebView2 SDK terminates the process.
+- **Null `dialog_callback` is a legitimate, non-fatal state.**
+  `Invoke` MUST short-circuit safely when
+  `e->dialog_callback` is null (no caller has wired the
+  bridge yet, or the engine is being destroyed and the
+  field was cleared first).  The safe-default flow runs:
+  alert → Accept; confirm → don't Accept; prompt → don't
+  put_ResultText / Accept.  Page's JS thread always resumes.
+- **Disposal race safety.**  `destroy_engine` already clears
+  `dialog_callback` to NULL (line 621-630, from STORY-004-001)
+  before releasing the controller and webview.  Any
+  in-flight `Invoke` running on the worker thread observes
+  the cleared field via the Approach §6 null-callback path
+  and resolves the dialog with the safe default.
+- **Heap-string ownership.**  `fire_dialog_prompt`'s return
+  value is malloc-allocated and the completion-side lambda
+  MUST `free` it exactly once after using it (or, on cancel,
+  unconditionally — the lambda checks `prompt_answer !=
+  nullptr` and either frees or no-ops, but the malloc'd
+  buffer if any is ALWAYS freed in the lambda).
+- **UTF-16 conversion safety.**  `wide_to_utf8` handles null
+  input and `WideCharToMultiByte` failures by returning an
+  empty string.  `utf8_to_wide` for the outgoing
+  `put_ResultText` direction is already proven by existing
+  callers in the file.
+- **Settings change is idempotent.**  Calling
+  `put_AreDefaultScriptDialogsEnabled(FALSE)` multiple times
+  is harmless — WebView2 just stores the latest value.  No
+  reset on engine disposal is needed (the engine itself is
+  destroyed).
+- **`before-unload` routing.**  Mapping
+  `COREWEBVIEW2_SCRIPT_DIALOG_KIND_BEFOREUNLOAD` to
+  `fire_dialog_confirm` matches the canvas-11 commitment,
+  the canvas-12 Linux behaviour, and STORY-004-003 AC9.  A
+  future maintainer adding a dedicated `beforeUnloadOpened`
+  to `WebViewDialogHandler` MUST update both this switch
+  branch AND the Linux `handle_script_dialog` switch in
+  lockstep.
+- **No file-picker interception on Windows.**  WebView2 has
+  no public hook for `<input type="file">` clicks.  The
+  `ScriptDialogHandler` does NOT receive file-picker
+  events; the OS-native Common Item Dialog continues to
+  appear unchanged.  A future maintainer trying to "fix"
+  this by adding a `fire_dialog_file_picker` helper to
+  Windows will find no SDK hook to call it from — this is
+  a permanent platform limitation.
+- **Windows-only.**  All new code lives in
+  `windows/webview_embed.cc`.  Linux (`src_c/webview_embed.cpp`)
+  and macOS (`src_c/webview_embed.cpp` under `WEBVIEW_COCOA`)
+  are untouched.  The Java side is untouched.
+- **No regression of macOS / Linux paths.**  No shared code
+  is modified.  The macOS `cocoa_create_engine` + WKUIDelegate
+  path (STORY-004-001) and the Linux `gtk_create_engine` /
+  `gtk_off_create_engine` + WebKitGTK signal-handler path
+  (STORY-004-002) operate identically before and after this
+  canvas.
+- **Frame URL equality with page URL.**  WebView2's
+  `ScriptDialogOpening` event args expose `get_Uri` (the
+  top-level page URL) but no separate frame URL.  Both
+  `pageUrl` and `frameUrl` fields on the Java event POJOs
+  are populated from `get_Uri` on Windows.  Documented in
+  the README's Windows note.  AC11 of STORY-004-003 only
+  verifies the top-level case, so this is AC-compliant.
+- **Vendored SDK version compatibility.**  The interfaces
+  used (`ICoreWebView2ScriptDialogOpeningEventHandler`,
+  `ICoreWebView2ScriptDialogOpeningEventArgs`,
+  `ICoreWebView2Deferral`,
+  `put_AreDefaultScriptDialogsEnabled`,
+  `COREWEBVIEW2_SCRIPT_DIALOG_KIND` enum) are all part of
+  the WebView2 SDK 1.0.x baseline that the vendored
+  `Microsoft.Web.WebView2.0.8.355` package provides.  No
+  version bump is required.

--- a/src/ca/weblite/webview/DialogDispatcher.java
+++ b/src/ca/weblite/webview/DialogDispatcher.java
@@ -1,0 +1,284 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import javax.swing.SwingUtilities;
+
+/**
+ * <p><strong>Internal:</strong> not part of the public API surface.
+ * Use {@link WebViewComponent#setDialogHandler} /
+ * {@link WebViewComponent#getDialogHandler} instead.  This class is
+ * {@code public} only because the consuming Swing subclasses live in
+ * a different package and Java has no cross-package-but-non-public
+ * access modifier; matches the existing pattern used by
+ * {@code ConsoleDispatcher}, {@code WebViewMouseDispatcher},
+ * {@code EvalDispatcher}, {@code EmbeddedWebView}, and
+ * {@code OffscreenWebView}.
+ *
+ * <p>Per-component fan-out hub for browser-initiated UI dialogs.
+ * Holds the single active {@link WebViewDialogHandler} reference and
+ * marshals each native-side dispatch onto the Swing EDT via
+ * {@link SwingUtilities#invokeAndWait}.  Captures the handler's return
+ * value and propagates it back to the native side, which then
+ * completes the platform's deferral / completion handler and releases
+ * the page's JavaScript thread.
+ *
+ * <p><strong>Threading:</strong> the four {@code dispatch*} entry
+ * points are invoked from whatever native UI thread the engine runs
+ * on (AppKit main, GTK main, WebView2 worker).  Each method hops to
+ * the EDT, runs the handler, and returns the captured value
+ * synchronously.  Handler exceptions are caught and forwarded to
+ * {@link Thread#getDefaultUncaughtExceptionHandler()} (matches the
+ * established {@code ConsoleDispatcher} pattern); a safe fallback
+ * value is returned so the native completion handler always fires.
+ *
+ * <p><strong>Divergence from {@code ConsoleDispatcher} /
+ * {@code WebViewMouseDispatcher}:</strong> dialogs need a single
+ * resolver, not a listener list, so this class holds a single
+ * volatile handler reference and uses {@code invokeAndWait} rather
+ * than {@code invokeLater}.  Disposal flips a {@code disposed} flag;
+ * subsequent dispatches return safe fallbacks without invoking the
+ * handler.
+ */
+public final class DialogDispatcher {
+
+    /** Internal drop singleton — installed when caller passes
+     *  {@code null} to {@link #setHandler}.  Returns the JS-spec
+     *  cancel values synchronously without UI.  Stateless; package-
+     *  private (callers reset to the framework default by passing
+     *  {@link WebViewDialogHandler#DEFAULT}). */
+    static final WebViewDialogHandler DROP = new WebViewDialogHandler() {
+        @Override public void alertOpened(WebViewAlertEvent e) { }
+        @Override public boolean confirmOpened(WebViewConfirmEvent e) {
+            return false;
+        }
+        @Override public String promptOpened(WebViewPromptEvent e) {
+            return null;
+        }
+        @Override public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+            return Collections.emptyList();
+        }
+    };
+
+    private final WebViewComponent source;
+    private volatile WebViewDialogHandler handler = WebViewDialogHandler.DEFAULT;
+    private volatile boolean disposed = false;
+
+    public DialogDispatcher(WebViewComponent source) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+    }
+
+    /** Replace the active handler.  Passing {@code null} installs an
+     *  internal drop handler that returns the JS-spec cancel values
+     *  without UI — useful for headless tests.  To reset to the
+     *  framework default, pass {@link WebViewDialogHandler#DEFAULT}
+     *  explicitly. */
+    public void setHandler(WebViewDialogHandler h) {
+        handler = (h == null) ? DROP : h;
+    }
+
+    /** @return the active handler; never {@code null}.  Returns
+     *  {@link WebViewDialogHandler#DEFAULT} when no caller has set
+     *  one; returns the internal drop singleton when caller passed
+     *  {@code null} to {@link #setHandler}. */
+    public WebViewDialogHandler getHandler() {
+        return handler;
+    }
+
+    /**
+     * Flip the dispatcher into disposed state.  After this call, every
+     * {@code dispatch*} method returns the safe fallback (void / false
+     * / null / empty array) without invoking the handler.  Idempotent.
+     * Called from the Swing subclass's disposal path so the native
+     * completion handler still fires cleanly even when the native
+     * teardown races with an in-flight dialog event.
+     */
+    public void disposeAll() {
+        disposed = true;
+    }
+
+    /** @return whether the dispatcher has been disposed. */
+    public boolean isDisposed() {
+        return disposed;
+    }
+
+    // ---------------------------------------------------------------------
+    // Native-facing dispatch entry points (invoked from JNI through the
+    // WebViewDialogCallback adapter installed at peer-attach time).
+    // ---------------------------------------------------------------------
+
+    /** Native dispatch for {@code window.alert}. */
+    public void dispatchAlert(String message, String pageUrl, String frameUrl) {
+        if (disposed) return;
+        final WebViewAlertEvent event = new WebViewAlertEvent(
+            source, message, pageUrl, frameUrl);
+        runOnEdtVoid(new Runnable() {
+            @Override public void run() {
+                handler.alertOpened(event);
+            }
+        });
+    }
+
+    /** Native dispatch for {@code window.confirm}. */
+    public boolean dispatchConfirm(String message, String pageUrl,
+                                   String frameUrl) {
+        if (disposed) return false;
+        final WebViewConfirmEvent event = new WebViewConfirmEvent(
+            source, message, pageUrl, frameUrl);
+        final boolean[] cell = new boolean[1];
+        runOnEdtVoid(new Runnable() {
+            @Override public void run() {
+                cell[0] = handler.confirmOpened(event);
+            }
+        });
+        return cell[0];
+    }
+
+    /** Native dispatch for {@code window.prompt}; {@code null} return
+     *  signals cancel. */
+    public String dispatchPrompt(String message, String defaultValue,
+                                 String pageUrl, String frameUrl) {
+        if (disposed) return null;
+        final WebViewPromptEvent event = new WebViewPromptEvent(
+            source, message, defaultValue, pageUrl, frameUrl);
+        final String[] cell = new String[1];
+        runOnEdtVoid(new Runnable() {
+            @Override public void run() {
+                cell[0] = handler.promptOpened(event);
+            }
+        });
+        return cell[0];
+    }
+
+    /** Native dispatch for {@code <input type="file">} click; returns
+     *  an array of absolute file paths.  Empty array signals cancel. */
+    public String[] dispatchFilePicker(boolean multiple, String[] mimeTypes,
+                                       String[] extensions, String pageUrl,
+                                       String frameUrl) {
+        if (disposed) return new String[0];
+        final List<String> normExts = normaliseExtensions(extensions);
+        final List<String> normMimes = normaliseMimeTypes(mimeTypes);
+        final WebViewFilePickerEvent event = new WebViewFilePickerEvent(
+            source, multiple, normExts, normMimes, pageUrl, frameUrl);
+        final Object[] cell = new Object[1];
+        runOnEdtVoid(new Runnable() {
+            @Override public void run() {
+                cell[0] = handler.filePickerOpened(event);
+            }
+        });
+        @SuppressWarnings("unchecked")
+        List<File> files = (List<File>) cell[0];
+        if (files == null || files.isEmpty()) return new String[0];
+        List<String> paths = new ArrayList<String>(files.size());
+        for (File f : files) {
+            if (f != null) paths.add(f.getAbsolutePath());
+        }
+        return paths.toArray(new String[0]);
+    }
+
+    // ---------------------------------------------------------------------
+    // EDT marshal + exception isolation.
+    // ---------------------------------------------------------------------
+
+    /**
+     * Run {@code r} on the EDT, blocking the caller until it
+     * completes.  Handler exceptions are caught and forwarded to
+     * {@link Thread#getDefaultUncaughtExceptionHandler()} so they do
+     * not propagate to the native side.
+     */
+    private void runOnEdtVoid(final Runnable r) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            try {
+                r.run();
+            } catch (Throwable t) {
+                forwardUncaught(t);
+            }
+            return;
+        }
+        final Runnable wrapped = new Runnable() {
+            @Override public void run() {
+                try {
+                    r.run();
+                } catch (Throwable t) {
+                    forwardUncaught(t);
+                }
+            }
+        };
+        try {
+            SwingUtilities.invokeAndWait(wrapped);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            // Fall through; caller gets the cell's current (zero-init)
+            // value, which is the safe fallback.
+        } catch (InvocationTargetException ite) {
+            // wrapped.run already caught and forwarded any handler
+            // exception; an ITE here means invokeAndWait itself
+            // failed (the wrapped Runnable threw before our catch
+            // could swallow — should be impossible since we wrap
+            // everything, but be defensive).
+            Throwable cause = ite.getCause();
+            forwardUncaught(cause == null ? ite : cause);
+        }
+    }
+
+    private static void forwardUncaught(Throwable t) {
+        try {
+            Thread.UncaughtExceptionHandler h =
+                Thread.getDefaultUncaughtExceptionHandler();
+            if (h != null) {
+                h.uncaughtException(Thread.currentThread(), t);
+            } else {
+                t.printStackTrace();
+            }
+        } catch (Throwable ignored) {
+            // Last-ditch: an uncaught-handler that itself throws.  Print
+            // the original stack trace and move on.
+            try { t.printStackTrace(); } catch (Throwable ignored2) {}
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Accept-attribute normalisation: lower-case, strip leading dot
+    // (extensions only), deduplicate preserving insertion order.
+    // ---------------------------------------------------------------------
+
+    static List<String> normaliseExtensions(String[] input) {
+        if (input == null || input.length == 0) return Collections.emptyList();
+        LinkedHashSet<String> seen = new LinkedHashSet<String>();
+        for (String raw : input) {
+            if (raw == null) continue;
+            String s = raw.toLowerCase(Locale.ROOT).trim();
+            if (s.startsWith(".")) s = s.substring(1);
+            if (s.isEmpty()) continue;
+            seen.add(s);
+        }
+        if (seen.isEmpty()) return Collections.emptyList();
+        return Collections.unmodifiableList(new ArrayList<String>(seen));
+    }
+
+    static List<String> normaliseMimeTypes(String[] input) {
+        if (input == null || input.length == 0) return Collections.emptyList();
+        LinkedHashSet<String> seen = new LinkedHashSet<String>();
+        for (String raw : input) {
+            if (raw == null) continue;
+            String s = raw.toLowerCase(Locale.ROOT).trim();
+            if (s.isEmpty()) continue;
+            seen.add(s);
+        }
+        if (seen.isEmpty()) return Collections.emptyList();
+        return Collections.unmodifiableList(new ArrayList<String>(seen));
+    }
+}

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -411,6 +411,44 @@ public class EmbeddedWebView {
     }
 
     /**
+     * Register (or clear, by passing {@code null}) a callback invoked
+     * for each JS-initiated UI dialog ({@code alert} / {@code confirm}
+     * / {@code prompt}) or {@code <input type="file">} click inside the
+     * embedded WebView.  Unlike {@link #setFocusCallback} /
+     * {@link #setClickCallback}, dialog callbacks RETURN VALUES to the
+     * engine synchronously: the native UI thread is suspended while
+     * waiting for the answer.  Implementations MUST marshal to the
+     * EDT (the library-provided implementation routes through
+     * {@link DialogDispatcher} which uses
+     * {@code SwingUtilities.invokeAndWait}).
+     *
+     * <p>Anchoring the callback in {@code heap} is required so the JVM
+     * does not garbage-collect the lambda while the native side holds
+     * a global ref.
+     *
+     * <p>Per-platform delivery:
+     * <ul>
+     *   <li><b>macOS</b>: {@code WKUIDelegate} selectors on the
+     *       {@code WKWebView} — wired in STORY-004-001 (this story).</li>
+     *   <li><b>Linux heavyweight</b>: {@code script-dialog} and
+     *       {@code run-file-chooser} signals on {@code WebKitWebView} —
+     *       wired in STORY-004-002.</li>
+     *   <li><b>Windows</b>: {@code ICoreWebView2::add_ScriptDialogOpening}
+     *       event handler — wired in STORY-004-003 (file picker remains
+     *       OS-native; {@code <input type="file">} is not interceptable
+     *       in WebView2).</li>
+     * </ul>
+     */
+    public EmbeddedWebView setDialogCallback(WebViewDialogCallback cb) {
+        checkAlive();
+        if (cb != null) {
+            heap.add(cb);
+        }
+        WebViewNative.webview_embed_set_dialog_callback(peer, cb);
+        return this;
+    }
+
+    /**
      * Windows-only: force Win32 keyboard focus back to the AWT-owned parent
      * HWND, so subsequent keystrokes route to AWT instead of the WebView2
      * child HWND.  Used by the Java-side global focus-owner listener when

--- a/src/ca/weblite/webview/OffscreenWebView.java
+++ b/src/ca/weblite/webview/OffscreenWebView.java
@@ -285,6 +285,37 @@ public class OffscreenWebView {
         return this;
     }
 
+    /**
+     * Register (or clear, by passing {@code null}) a callback invoked for
+     * each JS-initiated UI dialog ({@code alert} / {@code confirm} /
+     * {@code prompt}) or {@code <input type="file">} click inside the
+     * offscreen WebView.  Unlike {@code setFocusCallback} /
+     * {@code setClickCallback} on {@link EmbeddedWebView}, dialog
+     * callbacks RETURN VALUES to the engine synchronously: the native
+     * UI thread is suspended while waiting for the answer.
+     * Implementations MUST marshal to the EDT (the library-provided
+     * implementation routes through {@link DialogDispatcher} which uses
+     * {@code SwingUtilities.invokeAndWait}).
+     *
+     * <p>Anchoring the callback in {@code heap} is required so the JVM
+     * does not garbage-collect the lambda while the native side holds
+     * a global ref.
+     *
+     * <p>On macOS / Windows, where the offscreen engine itself is a
+     * stub, this method has no effect — the native stub is a no-op.
+     * Linux is the only platform where the offscreen path actually
+     * dispatches dialog requests, and STORY-004-002 implements the GTK
+     * signal-handler side.
+     */
+    public OffscreenWebView setDialogCallback(WebViewDialogCallback cb) {
+        checkAlive();
+        if (cb != null) {
+            heap.add(cb);
+        }
+        WebViewNative.webview_offscreen_set_dialog_callback(peer, cb);
+        return this;
+    }
+
     /** Release native resources. */
     public void dispose() {
         if (peer != 0L) {

--- a/src/ca/weblite/webview/WebViewAlertEvent.java
+++ b/src/ca/weblite/webview/WebViewAlertEvent.java
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+/**
+ * Immutable carrier of one {@code window.alert} request raised by the
+ * embedded page, surfaced to {@link WebViewDialogHandler#alertOpened}.
+ *
+ * <p>All accessors return non-null values.  {@code message},
+ * {@code pageUrl}, and {@code frameUrl} are the empty string when the
+ * native engine reports no value (the engine may legitimately do so;
+ * empty is the "no value" sentinel for these fields).
+ */
+public final class WebViewAlertEvent {
+
+    private final WebViewComponent source;
+    private final String message;
+    private final String pageUrl;
+    private final String frameUrl;
+
+    WebViewAlertEvent(WebViewComponent source, String message,
+                      String pageUrl, String frameUrl) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+        this.message = message == null ? "" : message;
+        this.pageUrl = pageUrl == null ? "" : pageUrl;
+        this.frameUrl = frameUrl == null ? "" : frameUrl;
+    }
+
+    /** @return the WebView component the alert originated from; never null. */
+    public WebViewComponent source() { return source; }
+
+    /** @return the alert message; never null, may be empty. */
+    public String message() { return message; }
+
+    /** @return the top-level document URL; never null, may be empty. */
+    public String pageUrl() { return pageUrl; }
+
+    /** @return the initiating frame's URL; never null, may be empty.
+     *  Equals {@link #pageUrl()} when the alert came from the top-level
+     *  frame. */
+    public String frameUrl() { return frameUrl; }
+
+    @Override
+    public String toString() {
+        String m = message;
+        if (m.length() > 80) m = m.substring(0, 80) + "...";
+        return "WebViewAlertEvent[message=" + m + ", pageUrl=" + pageUrl + "]";
+    }
+}

--- a/src/ca/weblite/webview/WebViewConfirmEvent.java
+++ b/src/ca/weblite/webview/WebViewConfirmEvent.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+/**
+ * Immutable carrier of one {@code window.confirm} request raised by the
+ * embedded page, surfaced to {@link WebViewDialogHandler#confirmOpened}.
+ *
+ * <p>Shape matches {@link WebViewAlertEvent} verbatim — both events
+ * carry only a single message string plus the page / frame URLs.  The
+ * two classes are intentionally distinct types (rather than a shared
+ * base or a single discriminated event) so handler method signatures
+ * stay honest about which dialog kind they handle.
+ */
+public final class WebViewConfirmEvent {
+
+    private final WebViewComponent source;
+    private final String message;
+    private final String pageUrl;
+    private final String frameUrl;
+
+    WebViewConfirmEvent(WebViewComponent source, String message,
+                        String pageUrl, String frameUrl) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+        this.message = message == null ? "" : message;
+        this.pageUrl = pageUrl == null ? "" : pageUrl;
+        this.frameUrl = frameUrl == null ? "" : frameUrl;
+    }
+
+    /** @return the WebView component the confirm originated from; never null. */
+    public WebViewComponent source() { return source; }
+
+    /** @return the confirm message; never null, may be empty. */
+    public String message() { return message; }
+
+    /** @return the top-level document URL; never null, may be empty. */
+    public String pageUrl() { return pageUrl; }
+
+    /** @return the initiating frame's URL; never null, may be empty. */
+    public String frameUrl() { return frameUrl; }
+
+    @Override
+    public String toString() {
+        String m = message;
+        if (m.length() > 80) m = m.substring(0, 80) + "...";
+        return "WebViewConfirmEvent[message=" + m + ", pageUrl=" + pageUrl + "]";
+    }
+}

--- a/src/ca/weblite/webview/WebViewDialogCallback.java
+++ b/src/ca/weblite/webview/WebViewDialogCallback.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * Internal JNI bridge interface invoked by the native engine when the
+ * embedded page raises a UI dialog ({@code window.alert},
+ * {@code window.confirm}, {@code window.prompt}, or
+ * {@code <input type="file">}).  Each method returns the answer
+ * synchronously; the native side waits for the return value before
+ * releasing the page's JavaScript thread.
+ *
+ * <p><strong>Not part of the public application API.</strong>
+ * Application code customises dialog behaviour by installing a
+ * {@link WebViewDialogHandler} via
+ * {@link ca.weblite.webview.swing.WebViewComponent#setDialogHandler};
+ * this interface is the underlying bridge that the library wires from
+ * the Swing component to the native engine via JNI.  It is
+ * {@code public} only because the JNI bridge in
+ * {@code src_c/webview_embed.cpp} and {@code windows/webview_embed.cc}
+ * needs to call methods on instances of it, and Java has no
+ * cross-package-but-non-public access modifier.  The same constraint
+ * applies to {@link WebViewClickCallback} and
+ * {@link WebViewFocusCallback}.
+ *
+ * <p><strong>Threading.</strong>  The native engine invokes these
+ * methods from whatever native UI thread the engine runs on — AppKit
+ * main on macOS, the GTK main thread on Linux, the WebView2 worker
+ * thread on Windows.  Implementations MUST marshal to the Swing EDT
+ * before touching any Swing state.  The library-provided
+ * implementation in {@code WebViewHeavyweightComponent} and
+ * {@code WebViewLightweightComponent} delegates to
+ * {@link DialogDispatcher}, which performs the EDT hop via
+ * {@link javax.swing.SwingUtilities#invokeAndWait}.
+ */
+public interface WebViewDialogCallback {
+
+    /** Invoked for {@code window.alert(message)}. */
+    void onAlert(String message, String pageUrl, String frameUrl);
+
+    /** Invoked for {@code window.confirm(message)}; return {@code true}
+     *  for OK, {@code false} for Cancel. */
+    boolean onConfirm(String message, String pageUrl, String frameUrl);
+
+    /** Invoked for {@code window.prompt(message, defaultValue)}; return
+     *  the entered text on OK, or {@code null} on Cancel (the page
+     *  sees {@code null} as the {@code prompt} return value). */
+    String onPrompt(String message, String defaultValue,
+                    String pageUrl, String frameUrl);
+
+    /**
+     * Invoked when the user clicks an {@code <input type="file">}
+     * element.  The {@code mimeTypes} and {@code extensions} arrays
+     * may be {@code null} when the page imposed no constraint.
+     * Return a non-null array of absolute file paths; an empty array
+     * means the user cancelled (the page receives an empty
+     * {@code FileList}).
+     */
+    String[] onFilePicker(boolean multiple, String[] mimeTypes,
+                          String[] extensions, String pageUrl,
+                          String frameUrl);
+}

--- a/src/ca/weblite/webview/WebViewDialogHandler.java
+++ b/src/ca/weblite/webview/WebViewDialogHandler.java
@@ -1,0 +1,168 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import java.awt.Window;
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+/**
+ * Handler interface for browser-initiated UI dialogs raised by the
+ * embedded page: {@code window.alert}, {@code window.confirm},
+ * {@code window.prompt}, and {@code <input type="file">} clicks.
+ *
+ * <p><strong>Default behaviour.</strong>  All four methods are
+ * {@code default} and show standard Swing dialogs ({@link JOptionPane}
+ * for alert / confirm / prompt; {@link JFileChooser} for file picker),
+ * modal to the host {@code JFrame} resolved via
+ * {@link SwingUtilities#getWindowAncestor}.  Callers that want stock
+ * behaviour do nothing — the framework's {@link #DEFAULT} instance is
+ * pre-installed on every {@link ca.weblite.webview.swing.WebViewComponent}.
+ *
+ * <p><strong>Custom behaviour.</strong>  Implement one or more methods
+ * to override the default Swing dialog for that kind.  Un-overridden
+ * methods fall through to the default Swing dialog.  Install with
+ * {@link ca.weblite.webview.swing.WebViewComponent#setDialogHandler}.
+ *
+ * <p><strong>Suppression / headless tests.</strong>  Pass {@code null}
+ * to {@code setDialogHandler} to install a drop handler that returns
+ * the JS-spec cancel values synchronously without UI ({@code alert}
+ * no-op; {@code confirm} false; {@code prompt} null; file picker empty
+ * list).  Use {@link #DEFAULT} explicitly to reset to the stock Swing
+ * defaults — note that {@code setDialogHandler(null)} and
+ * {@code setDialogHandler(DEFAULT)} are NOT equivalent.
+ *
+ * <p><strong>Threading.</strong>  Every method runs on the Swing Event
+ * Dispatch Thread, marshaled from whatever native thread fired the
+ * dialog.  The native engine's JavaScript thread is suspended while
+ * the handler runs — that is correct per the JS contract for
+ * {@code alert} / {@code confirm} / {@code prompt}, which are
+ * synchronous in the page.  The {@code <input type="file">} path is
+ * asynchronous in JS but Java-side it still blocks the modal pump
+ * until the user dismisses the picker.
+ *
+ * <p><strong>EDT-deadlock hazard.</strong>  Because the EDT is busy
+ * running the handler, calling
+ * {@code wv.evalAsync(js).get()} (or any other synchronous wait on an
+ * EDT-scheduled task) from inside a handler DEADLOCKS — the
+ * continuation can never run while the EDT is parked in the handler.
+ * Handlers MAY freely call {@code wv.setUrl}, {@code wv.eval},
+ * {@code wv.dispatch(r)} (those enqueue work on the native UI thread,
+ * which is itself blocked waiting for the handler to return; the
+ * enqueued work runs after the handler returns and the dialog closes).
+ *
+ * <p><strong>Exception isolation.</strong>  Exceptions thrown from a
+ * handler method are caught by {@link DialogDispatcher} and forwarded
+ * to {@link Thread#getDefaultUncaughtExceptionHandler()}; they do not
+ * propagate to the native engine.  When a handler throws, the
+ * dispatcher returns the safe fallback to the native side (alert:
+ * void; confirm: false; prompt: null; file picker: empty list) so the
+ * engine's JS thread is released cleanly.
+ *
+ * <p><strong>Platform coverage (this iteration).</strong>  macOS
+ * heavyweight WKWebView is wired today (STORY-004-001).  Linux
+ * WebKitGTK (STORY-004-002) and Windows WebView2 (STORY-004-003) wire
+ * the same contract through their respective native engine callbacks
+ * in subsequent stories — the Java API is final.  On platforms not yet
+ * wired, the embedded engine continues to use its built-in dialogs and
+ * the handler installed here is not invoked.
+ */
+public interface WebViewDialogHandler {
+
+    /**
+     * Stock handler instance whose methods invoke the {@code default}
+     * implementations as-is (Swing dialogs anchored on the host
+     * {@code JFrame}).  Stateless; safe to share across components and
+     * threads.  Returned by
+     * {@link ca.weblite.webview.swing.WebViewComponent#getDialogHandler}
+     * when no caller has installed a custom handler.  Pass to
+     * {@code setDialogHandler} to reset to defaults after a previous
+     * custom or null installation.
+     */
+    WebViewDialogHandler DEFAULT = new WebViewDialogHandler() {};
+
+    /**
+     * Invoked when the page calls {@code window.alert(message)}.
+     * Default: shows a modal {@link JOptionPane#showMessageDialog}.
+     */
+    default void alertOpened(WebViewAlertEvent event) {
+        Window host = SwingUtilities.getWindowAncestor(event.source());
+        JOptionPane.showMessageDialog(host, event.message(),
+            "JavaScript Alert", JOptionPane.PLAIN_MESSAGE);
+    }
+
+    /**
+     * Invoked when the page calls {@code window.confirm(message)}.
+     * Default: shows a modal {@link JOptionPane#showConfirmDialog}
+     * with OK/Cancel buttons and returns {@code true} when the user
+     * clicks OK.
+     */
+    default boolean confirmOpened(WebViewConfirmEvent event) {
+        Window host = SwingUtilities.getWindowAncestor(event.source());
+        int r = JOptionPane.showConfirmDialog(host, event.message(),
+            "JavaScript Confirm", JOptionPane.OK_CANCEL_OPTION);
+        return r == JOptionPane.OK_OPTION;
+    }
+
+    /**
+     * Invoked when the page calls {@code window.prompt(message, default)}.
+     * Default: shows a modal {@link JOptionPane#showInputDialog} with
+     * the page-supplied default value pre-populated.  Returns the
+     * entered text on OK, or {@code null} on Cancel — the page sees
+     * {@code null} as the {@code prompt} return value per the JS
+     * contract.
+     */
+    default String promptOpened(WebViewPromptEvent event) {
+        Window host = SwingUtilities.getWindowAncestor(event.source());
+        Object r = JOptionPane.showInputDialog(host, event.message(),
+            "JavaScript Prompt", JOptionPane.QUESTION_MESSAGE,
+            null, null, event.defaultValue());
+        return r == null ? null : r.toString();
+    }
+
+    /**
+     * Invoked when the page user clicks an {@code <input type="file">}
+     * element.  Default: shows a modal {@link JFileChooser} honouring
+     * the page's {@code multiple} and {@code accept} attributes
+     * (extensions only — Swing's {@link FileNameExtensionFilter} does
+     * not filter by MIME type).  Returns the chosen files on OK, or
+     * an empty list on Cancel; the page receives an empty
+     * {@code FileList} in the latter case.
+     */
+    default List<File> filePickerOpened(WebViewFilePickerEvent event) {
+        Window host = SwingUtilities.getWindowAncestor(event.source());
+        JFileChooser chooser = new JFileChooser();
+        chooser.setMultiSelectionEnabled(event.multiple());
+        if (!event.acceptedExtensions().isEmpty()) {
+            String[] exts = event.acceptedExtensions()
+                .toArray(new String[0]);
+            chooser.setFileFilter(
+                new FileNameExtensionFilter("Accepted files", exts));
+            chooser.setAcceptAllFileFilterUsed(false);
+        }
+        int r = chooser.showOpenDialog(host);
+        if (r != JFileChooser.APPROVE_OPTION) {
+            return Collections.emptyList();
+        }
+        if (event.multiple()) {
+            File[] sel = chooser.getSelectedFiles();
+            return sel == null
+                ? Collections.<File>emptyList()
+                : Arrays.asList(sel);
+        }
+        File f = chooser.getSelectedFile();
+        return f == null
+            ? Collections.<File>emptyList()
+            : Collections.singletonList(f);
+    }
+}

--- a/src/ca/weblite/webview/WebViewFilePickerEvent.java
+++ b/src/ca/weblite/webview/WebViewFilePickerEvent.java
@@ -1,0 +1,83 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable carrier of one {@code <input type="file">} click raised by
+ * the embedded page, surfaced to
+ * {@link WebViewDialogHandler#filePickerOpened}.
+ *
+ * <p>The accepted-extensions and accepted-mime-types lists are derived
+ * from the page's {@code <input accept="...">} attribute and normalised
+ * by {@link DialogDispatcher} before construction: lowercase, leading
+ * dot stripped (extensions only), duplicates removed in insertion
+ * order.  Both lists are never null and are unmodifiable views; empty
+ * means the page imposed no restriction.
+ */
+public final class WebViewFilePickerEvent {
+
+    private final WebViewComponent source;
+    private final boolean multiple;
+    private final List<String> acceptedExtensions;
+    private final List<String> acceptedMimeTypes;
+    private final String pageUrl;
+    private final String frameUrl;
+
+    WebViewFilePickerEvent(WebViewComponent source, boolean multiple,
+                           List<String> acceptedExtensions,
+                           List<String> acceptedMimeTypes,
+                           String pageUrl, String frameUrl) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+        this.multiple = multiple;
+        this.acceptedExtensions = freeze(acceptedExtensions);
+        this.acceptedMimeTypes = freeze(acceptedMimeTypes);
+        this.pageUrl = pageUrl == null ? "" : pageUrl;
+        this.frameUrl = frameUrl == null ? "" : frameUrl;
+    }
+
+    private static List<String> freeze(List<String> in) {
+        if (in == null || in.isEmpty()) return Collections.emptyList();
+        return Collections.unmodifiableList(new ArrayList<String>(in));
+    }
+
+    /** @return the WebView component the file picker originated from; never null. */
+    public WebViewComponent source() { return source; }
+
+    /** @return {@code true} when the page's {@code <input>} carries the
+     *  {@code multiple} attribute. */
+    public boolean multiple() { return multiple; }
+
+    /** @return unmodifiable list of normalised file extensions (lower-case,
+     *  no leading dot, deduplicated, insertion order preserved); empty
+     *  when the page imposed no extension constraint.  Never null. */
+    public List<String> acceptedExtensions() { return acceptedExtensions; }
+
+    /** @return unmodifiable list of normalised MIME types (lower-case,
+     *  deduplicated, insertion order preserved); empty when the page
+     *  imposed no MIME constraint.  Never null. */
+    public List<String> acceptedMimeTypes() { return acceptedMimeTypes; }
+
+    /** @return the top-level document URL; never null, may be empty. */
+    public String pageUrl() { return pageUrl; }
+
+    /** @return the initiating frame's URL; never null, may be empty. */
+    public String frameUrl() { return frameUrl; }
+
+    @Override
+    public String toString() {
+        return "WebViewFilePickerEvent[multiple=" + multiple
+            + ", extensions=" + acceptedExtensions.size()
+            + ", mimeTypes=" + acceptedMimeTypes.size()
+            + ", pageUrl=" + pageUrl + "]";
+    }
+}

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -266,6 +266,23 @@ native static void webview_embed_release_native_focus(long w);
 // Swing EDT.
 native static void webview_embed_set_attach_callback(long w, Object cb);
 
+// Register (or clear, by passing null) a callback invoked for each
+// JS-initiated UI dialog (alert / confirm / prompt) or
+// <input type=file> click inside the embedded WebView.  The callback
+// returns the answer synchronously, releasing the native UI thread
+// once Java has the value.  Implementations route through
+// DialogDispatcher which marshals to the Swing EDT via
+// SwingUtilities.invokeAndWait.  Per-platform delivery:
+//   - macOS:   WKUIDelegate selectors on the WKWebView (STORY-004-001).
+//   - Linux:   script-dialog and run-file-chooser signals on
+//              WebKitWebView (STORY-004-002).
+//   - Windows: ICoreWebView2::add_ScriptDialogOpening event handler
+//              plus put_AreDefaultScriptDialogsEnabled(FALSE)
+//              (STORY-004-003); file picker remains OS-native.
+// cb may be null to clear the registration.  Passing 0 for w is a
+// silent no-op.  Never throws via JNI.
+native static void webview_embed_set_dialog_callback(long w, WebViewDialogCallback cb);
+
 
 // ---------------------------------------------------------------------------
 // Lightweight / offscreen API (currently Linux-only).
@@ -367,6 +384,13 @@ native static int webview_offscreen_open_devtools(long peer);
 // webview_embed_execute_editing_command.  Linux only; macOS / Windows
 // stubs no-op.  Never throws via JNI.
 native static void webview_offscreen_execute_editing_command(long peer, int cmdId);
+
+// Offscreen counterpart to webview_embed_set_dialog_callback.  Used by
+// WebViewLightweightComponent on Linux to bridge JS-initiated dialogs
+// in the offscreen engine to the per-component DialogDispatcher.
+// macOS / Windows native binaries provide a no-op stub (the offscreen
+// engine on those platforms is itself a stub).  Never throws via JNI.
+native static void webview_offscreen_set_dialog_callback(long peer, WebViewDialogCallback cb);
 
 
 }

--- a/src/ca/weblite/webview/WebViewPromptEvent.java
+++ b/src/ca/weblite/webview/WebViewPromptEvent.java
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+/**
+ * Immutable carrier of one {@code window.prompt} request raised by the
+ * embedded page, surfaced to {@link WebViewDialogHandler#promptOpened}.
+ *
+ * <p>The {@link #defaultValue()} carries whatever the page passed as
+ * the second argument to {@code prompt(message, defaultValue)}.  JS
+ * coerces a missing second argument to the empty string; the native
+ * engine reports this as an empty string.  A page that explicitly
+ * passes {@code null} is JS-coerced to the string {@code "null"} by
+ * the engine, so {@link #defaultValue()} never carries the literal
+ * Java null.
+ */
+public final class WebViewPromptEvent {
+
+    private final WebViewComponent source;
+    private final String message;
+    private final String defaultValue;
+    private final String pageUrl;
+    private final String frameUrl;
+
+    WebViewPromptEvent(WebViewComponent source, String message,
+                       String defaultValue, String pageUrl, String frameUrl) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+        this.message = message == null ? "" : message;
+        this.defaultValue = defaultValue == null ? "" : defaultValue;
+        this.pageUrl = pageUrl == null ? "" : pageUrl;
+        this.frameUrl = frameUrl == null ? "" : frameUrl;
+    }
+
+    /** @return the WebView component the prompt originated from; never null. */
+    public WebViewComponent source() { return source; }
+
+    /** @return the prompt message; never null, may be empty. */
+    public String message() { return message; }
+
+    /** @return the prompt's default value; never null, may be empty. */
+    public String defaultValue() { return defaultValue; }
+
+    /** @return the top-level document URL; never null, may be empty. */
+    public String pageUrl() { return pageUrl; }
+
+    /** @return the initiating frame's URL; never null, may be empty. */
+    public String frameUrl() { return frameUrl; }
+
+    @Override
+    public String toString() {
+        String m = message;
+        if (m.length() > 80) m = m.substring(0, 80) + "...";
+        return "WebViewPromptEvent[message=" + m
+            + ", defaultValue=" + defaultValue
+            + ", pageUrl=" + pageUrl + "]";
+    }
+}

--- a/src/ca/weblite/webview/swing/WebViewComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewComponent.java
@@ -7,8 +7,10 @@ package ca.weblite.webview.swing;
 
 import ca.weblite.webview.ConsoleDispatcher;
 import ca.weblite.webview.ConsoleListener;
+import ca.weblite.webview.DialogDispatcher;
 import ca.weblite.webview.JavaScriptEvalException;
 import ca.weblite.webview.WebView;
+import ca.weblite.webview.WebViewDialogHandler;
 import ca.weblite.webview.WebViewMouseDispatcher;
 import ca.weblite.webview.WebViewMouseListener;
 
@@ -65,6 +67,14 @@ public abstract class WebViewComponent extends JComponent {
      *  registered before display are remembered and start receiving events
      *  once the native peer attaches and the JS shim is installed. */
     protected final WebViewMouseDispatcher mouseDispatcher = new WebViewMouseDispatcher(this);
+
+    /** Per-component browser-dialog fan-out hub.  Holds the active
+     *  {@link WebViewDialogHandler} and marshals each native-side
+     *  alert / confirm / prompt / file-picker request onto the Swing
+     *  EDT.  Subclasses install a {@link ca.weblite.webview.WebViewDialogCallback}
+     *  on their native peer at peer-attach time that delegates to this
+     *  dispatcher's {@code dispatch*} methods. */
+    protected final DialogDispatcher dialogDispatcher = new DialogDispatcher(this);
 
     /** Implementation mode for {@link #create(Mode)}. */
     public enum Mode {
@@ -403,5 +413,64 @@ public abstract class WebViewComponent extends JComponent {
      */
     public final boolean isDefaultContextMenuEnabled() {
         return mouseDispatcher.isDefaultEnabled();
+    }
+
+    // ---------------------------------------------------------------------
+    // Browser-initiated UI dialog handler API.
+    //
+    // The handler covers `window.alert`, `window.confirm`,
+    // `window.prompt`, and `<input type="file">` clicks.  Default
+    // behaviour shows Swing dialogs anchored on the host JFrame.
+    // Callers replace it wholesale via setDialogHandler; passing null
+    // installs an internal drop handler that suppresses all dialogs
+    // without UI (useful for headless tests).  See WebViewDialogHandler
+    // for the full contract.
+    //
+    // Concrete (not abstract) on the base class — the dispatcher does
+    // not depend on subclass state.  Subclasses install a
+    // WebViewDialogCallback adapter on their native peer at
+    // peer-attach time that bridges native dialog events into this
+    // dispatcher's dispatch* methods.
+    //
+    // Platform coverage (this iteration):
+    //   - macOS heavyweight (WKWebView): wired in this story.
+    //   - Linux WebKitGTK and Windows WebView2: handler reference is
+    //     stored but the native callback is not yet bridged; the
+    //     embedded engine continues to use its built-in dialogs.
+    //     STORY-004-002 and STORY-004-003 complete the coverage.
+    // ---------------------------------------------------------------------
+
+    /**
+     * Install (or replace) the {@link WebViewDialogHandler} that
+     * receives JS-initiated alert / confirm / prompt / file-picker
+     * events.  Passing {@code null} does NOT reset to the framework
+     * default — it installs an internal drop handler that returns the
+     * JS-spec cancel values without UI ({@code alert} no-op,
+     * {@code confirm} false, {@code prompt} null, file picker empty
+     * list).  To reset to the stock Swing-dialog default, pass
+     * {@link WebViewDialogHandler#DEFAULT} explicitly.
+     *
+     * <p>Safe to call before the component is displayed.  Safe to
+     * call from any thread.  Replacement is atomic; the next
+     * dispatch picks up the new handler.
+     *
+     * <p>See {@link WebViewDialogHandler} for the full contract,
+     * including the Swing EDT threading rules and the
+     * {@code evalAsync(...).get()} self-deadlock hazard.
+     */
+    public final WebViewComponent setDialogHandler(WebViewDialogHandler handler) {
+        dialogDispatcher.setHandler(handler);
+        return this;
+    }
+
+    /**
+     * @return the active {@link WebViewDialogHandler}.  Never returns
+     * {@code null} — returns {@link WebViewDialogHandler#DEFAULT} when
+     * no caller has installed one, and returns the internal drop
+     * singleton when caller passed {@code null} to
+     * {@link #setDialogHandler}.
+     */
+    public final WebViewDialogHandler getDialogHandler() {
+        return dialogDispatcher.getHandler();
     }
 }

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -10,6 +10,7 @@ import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.EmbeddedWebView;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewClickCallback;
+import ca.weblite.webview.WebViewDialogCallback;
 import ca.weblite.webview.WebViewFocusCallback;
 import ca.weblite.webview.WebViewMouseDispatcher;
 import java.awt.AWTEvent;
@@ -193,6 +194,12 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
 
     @Override
     public void dispose() {
+        // Flip the dispatcher's disposed flag BEFORE tearing down the
+        // native peer so any in-flight dialog event arriving from the
+        // native side mid-teardown returns the safe fallback (void /
+        // false / null / empty) without invoking the handler against
+        // a half-disposed component.
+        dialogDispatcher.disposeAll();
         if (embedded != null) {
             EmbeddedWebView e = embedded;
             embedded = null;
@@ -497,6 +504,37 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
                         handleNativeClick();
                     }
                 });
+            }
+        });
+        // Install the dialog bridge so JS alert/confirm/prompt and
+        // <input type=file> route to the per-component
+        // WebViewDialogHandler.  Anchored in EmbeddedWebView.heap by
+        // setDialogCallback so the JVM does not collect the lambda
+        // while the native side holds a global ref.  Each method
+        // delegates to dialogDispatcher.dispatch*, which does the
+        // EDT hop via SwingUtilities.invokeAndWait and returns the
+        // handler's answer to the native completion handler.
+        embedded.setDialogCallback(new WebViewDialogCallback() {
+            @Override
+            public void onAlert(String message, String pageUrl, String frameUrl) {
+                dialogDispatcher.dispatchAlert(message, pageUrl, frameUrl);
+            }
+            @Override
+            public boolean onConfirm(String message, String pageUrl, String frameUrl) {
+                return dialogDispatcher.dispatchConfirm(message, pageUrl, frameUrl);
+            }
+            @Override
+            public String onPrompt(String message, String defaultValue,
+                                   String pageUrl, String frameUrl) {
+                return dialogDispatcher.dispatchPrompt(
+                    message, defaultValue, pageUrl, frameUrl);
+            }
+            @Override
+            public String[] onFilePicker(boolean multiple, String[] mimeTypes,
+                                         String[] extensions, String pageUrl,
+                                         String frameUrl) {
+                return dialogDispatcher.dispatchFilePicker(
+                    multiple, mimeTypes, extensions, pageUrl, frameUrl);
             }
         });
     }

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -10,6 +10,7 @@ import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.GdkInput;
 import ca.weblite.webview.OffscreenWebView;
 import ca.weblite.webview.WebView;
+import ca.weblite.webview.WebViewDialogCallback;
 import ca.weblite.webview.WebViewMouseDispatcher;
 
 import java.awt.Color;
@@ -241,6 +242,36 @@ public class WebViewLightweightComponent extends WebViewComponent {
                 try { e.addOnBeforeLoad(js); } catch (IllegalStateException ignored) {}
             }
         });
+        // Install the dialog bridge so JS alert/confirm/prompt and
+        // <input type=file> route to the per-component
+        // WebViewDialogHandler.  Anchored in OffscreenWebView.heap by
+        // setDialogCallback.  STORY-004-002 wires the native
+        // WebKitGTK signal handlers on Linux; on macOS / Windows the
+        // offscreen engine is a stub and this setDialogCallback call
+        // is a native-side no-op.
+        engine.setDialogCallback(new WebViewDialogCallback() {
+            @Override
+            public void onAlert(String message, String pageUrl, String frameUrl) {
+                dialogDispatcher.dispatchAlert(message, pageUrl, frameUrl);
+            }
+            @Override
+            public boolean onConfirm(String message, String pageUrl, String frameUrl) {
+                return dialogDispatcher.dispatchConfirm(message, pageUrl, frameUrl);
+            }
+            @Override
+            public String onPrompt(String message, String defaultValue,
+                                   String pageUrl, String frameUrl) {
+                return dialogDispatcher.dispatchPrompt(
+                    message, defaultValue, pageUrl, frameUrl);
+            }
+            @Override
+            public String[] onFilePicker(boolean multiple, String[] mimeTypes,
+                                         String[] extensions, String pageUrl,
+                                         String frameUrl) {
+                return dialogDispatcher.dispatchFilePicker(
+                    multiple, mimeTypes, extensions, pageUrl, frameUrl);
+            }
+        });
         for (String js : pendingInit) {
             engine.addOnBeforeLoad(js);
         }
@@ -267,6 +298,11 @@ public class WebViewLightweightComponent extends WebViewComponent {
             repaintTimer.stop();
             repaintTimer = null;
         }
+        // Flip the dispatcher's disposed flag BEFORE tearing down the
+        // native peer so any in-flight dialog event arriving from the
+        // native side mid-teardown returns the safe fallback without
+        // invoking the handler against a half-disposed component.
+        dialogDispatcher.disposeAll();
         if (engine != null) {
             OffscreenWebView ow = engine;
             engine = null;

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -2420,6 +2420,55 @@ static jstring frame_url_jstring(JNIEnv *env, id frame, id webView) {
     return page_url_jstring(env, webView);
 }
 
+// UTF-8 std::string variants of the three helpers above.  Used by the
+// WKUIDelegate IMPs to capture string inputs synchronously on AppKit
+// main BEFORE launching the worker thread that does the JNI hop --
+// std::string captures are thread-safe and don't require us to retain
+// NSString instances across thread boundaries.
+static std::string ns_string_to_utf8(id ns) {
+    if (!ns) return std::string();
+    const char *cstr = msg<const char *>(ns, sel("UTF8String"));
+    return cstr ? std::string(cstr) : std::string();
+}
+
+static std::string page_url_utf8(id webView) {
+    if (!webView) return std::string();
+    id url = msg(webView, sel("URL"));
+    if (!url) return std::string();
+    id abs = msg(url, sel("absoluteString"));
+    return ns_string_to_utf8(abs);
+}
+
+static std::string frame_url_utf8(id frame, id webView) {
+    if (frame) {
+        id req = msg(frame, sel("request"));
+        if (req) {
+            id url = msg(req, sel("URL"));
+            if (url) {
+                id abs = msg(url, sel("absoluteString"));
+                std::string s = ns_string_to_utf8(abs);
+                if (!s.empty()) return s;
+            }
+        }
+    }
+    return page_url_utf8(webView);
+}
+
+// Read an NSArray<NSString*> (or nil) into a std::vector<std::string>.
+// Used by impl_run_open_panel to snapshot the mime / extension arrays
+// on AppKit main before handing off to the worker thread.
+static std::vector<std::string> ns_array_to_utf8_vector(id nsArray) {
+    std::vector<std::string> out;
+    if (!nsArray) return out;
+    long count = msg<long>(nsArray, sel("count"));
+    out.reserve((size_t)count);
+    for (long i = 0; i < count; i++) {
+        id ns = msg<id, long>(nsArray, sel("objectAtIndex:"), i);
+        out.push_back(ns_string_to_utf8(ns));
+    }
+    return out;
+}
+
 // Helper: convert an NSArray<NSString*> (or nil) to a fresh
 // jobjectArray of UTF-8 jstrings.  Returns an empty array for nil
 // input -- never returns nullptr -- so the Java side can assume
@@ -2467,46 +2516,101 @@ static JNIEnv *ensure_jni_env(JavaVM *jvm, bool *attached) {
 
 // IMP: -[WebviewEmbedUIDelegate webView:runJavaScriptAlertPanelWithMessage:
 //                               initiatedByFrame:completionHandler:]
+// ----- Deferral pattern (canvas-11 + bug-fix for the synchronous
+// AppKit-main / EDT deadlock) -----------------------------------------
+//
+// WKUIDelegate selectors are invoked on the AppKit main thread.  Doing
+// SwingUtilities.invokeAndWait directly from here deadlocks: the EDT
+// shows a modal JOptionPane, which creates an NSWindow under the hood,
+// which requires AppKit main thread work -- and AppKit main is blocked
+// in invokeAndWait waiting for the EDT to return.  Classic.
+//
+// Fix: copy the completion handler block, return from the selector
+// immediately, and run the JNI hop on a worker thread.  When Java
+// returns the answer, dispatch_async back onto AppKit main to invoke
+// the completion handler (WKWebView requires its completion handlers
+// to fire on the thread they were delivered on -- AppKit main).  Page's
+// JS thread stays suspended for the duration (the completion handler
+// hasn't fired yet), which is exactly the JS-contract behaviour we want.
+//
+// Same deferral pattern Windows uses via GetDeferral + dispatch_to_thread
+// (canvas-13).  Linux doesn't need it because the GTK pump thread is
+// already decoupled from AWT's EDT thread.
+//
+// Block lifetime: blocks passed as ObjC method arguments are stack-
+// allocated and become invalid once the selector returns.  Calling
+// -copy moves the block to the heap and retains it; we balance with
+// -release after we invoke (or skip invoking) it.
 static void impl_run_alert(id self, SEL, id webView, id message,
                            id frame, id completionHandler) {
     Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
-    auto run_completion = [&] {
-        // void(^)(void)
-        ((void (^)(void))completionHandler)();
-    };
+
+    // Copy the completion handler block so it survives past selector
+    // return.  See block-lifetime note above.
+    id ch = msg(completionHandler, sel("copy"));
+
+    // Capture string inputs synchronously while still on AppKit main;
+    // std::string captures cross thread boundaries trivially without
+    // having to retain NSStrings.
+    std::string msg_utf8 = ns_string_to_utf8(message);
+    std::string page_url = page_url_utf8(webView);
+    std::string frame_url = frame_url_utf8(frame, webView);
+
     if (!e || !e->dialog_callback) {
-        run_completion();
+        // No Java handler wired (yet, or after disposal).  Fire
+        // completion synchronously with the safe default -- we're
+        // already on AppKit main, no need for dispatch_async.
+        ((void (^)(void))ch)();
+        msg(ch, sel("release"));
         return;
     }
-    bool attached = false;
-    JNIEnv *env = ensure_jni_env(e->jvm, &attached);
-    if (!env) {
-        run_completion();
-        return;
-    }
-    jstring jmsg = ns_to_jstring(env, message);
-    jstring jpage = page_url_jstring(env, webView);
-    jstring jframe = frame_url_jstring(env, frame, webView);
-    jclass cls = env->GetObjectClass(e->dialog_callback);
-    if (cls) {
-        jmethodID mid = env->GetMethodID(
-            cls, "onAlert",
-            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
-        if (mid) {
-            env->CallVoidMethod(e->dialog_callback, mid,
-                                jmsg, jpage, jframe);
-            if (env->ExceptionCheck()) {
-                env->ExceptionDescribe();
-                env->ExceptionClear();
-            }
+
+    JavaVM *jvm = e->jvm;
+    jobject cb = e->dialog_callback;
+
+    // Hand off to a worker thread.  AppKit main returns immediately
+    // so the EDT can use AppKit for the modal Swing dialog without
+    // contention.  Detached thread because we never need to join.
+    std::thread([jvm, cb, msg_utf8, page_url, frame_url, ch]() {
+        JNIEnv *env = nullptr;
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            // JVM attach failed; can't call Java.  Still must fire
+            // the completion handler so the page's JS thread resumes.
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ((void (^)(void))ch)();
+                msg(ch, sel("release"));
+            });
+            return;
         }
-        env->DeleteLocalRef(cls);
-    }
-    if (jmsg) env->DeleteLocalRef(jmsg);
-    if (jpage) env->DeleteLocalRef(jpage);
-    if (jframe) env->DeleteLocalRef(jframe);
-    if (attached) e->jvm->DetachCurrentThread();
-    run_completion();
+        jstring jmsg = env->NewStringUTF(msg_utf8.c_str());
+        jstring jpage = env->NewStringUTF(page_url.c_str());
+        jstring jframe = env->NewStringUTF(frame_url.c_str());
+        jclass cls = env->GetObjectClass(cb);
+        if (cls) {
+            jmethodID mid = env->GetMethodID(cls, "onAlert",
+                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+            if (mid) {
+                env->CallVoidMethod(cb, mid, jmsg, jpage, jframe);
+                if (env->ExceptionCheck()) {
+                    env->ExceptionDescribe();
+                    env->ExceptionClear();
+                }
+            }
+            env->DeleteLocalRef(cls);
+        }
+        if (jmsg) env->DeleteLocalRef(jmsg);
+        if (jpage) env->DeleteLocalRef(jpage);
+        if (jframe) env->DeleteLocalRef(jframe);
+        jvm->DetachCurrentThread();
+
+        // Java returned.  Fire the completion handler on AppKit main
+        // (WKWebView requires it) and release our copy of the block.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ((void (^)(void))ch)();
+            msg(ch, sel("release"));
+        });
+    }).detach();
 }
 
 // IMP: -[WebviewEmbedUIDelegate webView:runJavaScriptConfirmPanelWithMessage:
@@ -2514,44 +2618,59 @@ static void impl_run_alert(id self, SEL, id webView, id message,
 static void impl_run_confirm(id self, SEL, id webView, id message,
                              id frame, id completionHandler) {
     Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
-    auto run_completion = [&](BOOL result) {
-        ((void (^)(BOOL))completionHandler)(result);
-    };
+    id ch = msg(completionHandler, sel("copy"));
+    std::string msg_utf8 = ns_string_to_utf8(message);
+    std::string page_url = page_url_utf8(webView);
+    std::string frame_url = frame_url_utf8(frame, webView);
+
     if (!e || !e->dialog_callback) {
-        run_completion(NO);
+        ((void (^)(BOOL))ch)(NO);
+        msg(ch, sel("release"));
         return;
     }
-    bool attached = false;
-    JNIEnv *env = ensure_jni_env(e->jvm, &attached);
-    if (!env) {
-        run_completion(NO);
-        return;
-    }
-    jboolean result = JNI_FALSE;
-    jstring jmsg = ns_to_jstring(env, message);
-    jstring jpage = page_url_jstring(env, webView);
-    jstring jframe = frame_url_jstring(env, frame, webView);
-    jclass cls = env->GetObjectClass(e->dialog_callback);
-    if (cls) {
-        jmethodID mid = env->GetMethodID(
-            cls, "onConfirm",
-            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z");
-        if (mid) {
-            result = env->CallBooleanMethod(
-                e->dialog_callback, mid, jmsg, jpage, jframe);
-            if (env->ExceptionCheck()) {
-                env->ExceptionDescribe();
-                env->ExceptionClear();
-                result = JNI_FALSE;
-            }
+    JavaVM *jvm = e->jvm;
+    jobject cb = e->dialog_callback;
+
+    std::thread([jvm, cb, msg_utf8, page_url, frame_url, ch]() {
+        JNIEnv *env = nullptr;
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ((void (^)(BOOL))ch)(NO);
+                msg(ch, sel("release"));
+            });
+            return;
         }
-        env->DeleteLocalRef(cls);
-    }
-    if (jmsg) env->DeleteLocalRef(jmsg);
-    if (jpage) env->DeleteLocalRef(jpage);
-    if (jframe) env->DeleteLocalRef(jframe);
-    if (attached) e->jvm->DetachCurrentThread();
-    run_completion(result == JNI_TRUE ? YES : NO);
+        jboolean result = JNI_FALSE;
+        jstring jmsg = env->NewStringUTF(msg_utf8.c_str());
+        jstring jpage = env->NewStringUTF(page_url.c_str());
+        jstring jframe = env->NewStringUTF(frame_url.c_str());
+        jclass cls = env->GetObjectClass(cb);
+        if (cls) {
+            jmethodID mid = env->GetMethodID(cls, "onConfirm",
+                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z");
+            if (mid) {
+                result = env->CallBooleanMethod(
+                    cb, mid, jmsg, jpage, jframe);
+                if (env->ExceptionCheck()) {
+                    env->ExceptionDescribe();
+                    env->ExceptionClear();
+                    result = JNI_FALSE;
+                }
+            }
+            env->DeleteLocalRef(cls);
+        }
+        if (jmsg) env->DeleteLocalRef(jmsg);
+        if (jpage) env->DeleteLocalRef(jpage);
+        if (jframe) env->DeleteLocalRef(jframe);
+        jvm->DetachCurrentThread();
+
+        BOOL outcome = (result == JNI_TRUE ? YES : NO);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ((void (^)(BOOL))ch)(outcome);
+            msg(ch, sel("release"));
+        });
+    }).detach();
 }
 
 // IMP: -[WebviewEmbedUIDelegate webView:runJavaScriptTextInputPanelWithPrompt:
@@ -2560,59 +2679,81 @@ static void impl_run_prompt(id self, SEL, id webView, id prompt,
                             id defaultText, id frame,
                             id completionHandler) {
     Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
-    auto run_completion = [&](id text) {
-        // void(^)(NSString *)
-        ((void (^)(id))completionHandler)(text);
-    };
+    id ch = msg(completionHandler, sel("copy"));
+    std::string msg_utf8 = ns_string_to_utf8(prompt);
+    std::string default_utf8 = ns_string_to_utf8(defaultText);
+    std::string page_url = page_url_utf8(webView);
+    std::string frame_url = frame_url_utf8(frame, webView);
+
     if (!e || !e->dialog_callback) {
-        run_completion(nil);
+        ((void (^)(id))ch)(nil);
+        msg(ch, sel("release"));
         return;
     }
-    bool attached = false;
-    JNIEnv *env = ensure_jni_env(e->jvm, &attached);
-    if (!env) {
-        run_completion(nil);
-        return;
-    }
-    id result_ns = nil;
-    jstring jmsg = ns_to_jstring(env, prompt);
-    jstring jdefault = ns_to_jstring(env, defaultText);
-    jstring jpage = page_url_jstring(env, webView);
-    jstring jframe = frame_url_jstring(env, frame, webView);
-    jclass cls = env->GetObjectClass(e->dialog_callback);
-    if (cls) {
-        jmethodID mid = env->GetMethodID(
-            cls, "onPrompt",
-            "(Ljava/lang/String;Ljava/lang/String;"
-            "Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
-        if (mid) {
-            jstring jresult = (jstring)env->CallObjectMethod(
-                e->dialog_callback, mid,
-                jmsg, jdefault, jpage, jframe);
-            if (env->ExceptionCheck()) {
-                env->ExceptionDescribe();
-                env->ExceptionClear();
-                jresult = nullptr;
-            }
-            if (jresult) {
-                const char *cstr = env->GetStringUTFChars(jresult, nullptr);
-                if (cstr) {
-                    result_ns = ns_str(cstr);
-                    env->ReleaseStringUTFChars(jresult, cstr);
-                }
-                env->DeleteLocalRef(jresult);
-            }
+    JavaVM *jvm = e->jvm;
+    jobject cb = e->dialog_callback;
+
+    std::thread([jvm, cb, msg_utf8, default_utf8, page_url,
+                 frame_url, ch]() {
+        JNIEnv *env = nullptr;
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ((void (^)(id))ch)(nil);
+                msg(ch, sel("release"));
+            });
+            return;
         }
-        env->DeleteLocalRef(cls);
-    }
-    if (jmsg) env->DeleteLocalRef(jmsg);
-    if (jdefault) env->DeleteLocalRef(jdefault);
-    if (jpage) env->DeleteLocalRef(jpage);
-    if (jframe) env->DeleteLocalRef(jframe);
-    if (attached) e->jvm->DetachCurrentThread();
-    // result_ns is nil → cancel (page sees prompt() return null per
-    // the JS contract); non-nil NSString → page sees the entered text.
-    run_completion(result_ns);
+        // Capture the result as a std::string with a "cancelled" flag
+        // we send to the main-thread block.  std::string can't
+        // distinguish "" from null, so use a separate bool.
+        std::string result_utf8;
+        bool cancelled = true;
+        jstring jmsg = env->NewStringUTF(msg_utf8.c_str());
+        jstring jdefault = env->NewStringUTF(default_utf8.c_str());
+        jstring jpage = env->NewStringUTF(page_url.c_str());
+        jstring jframe = env->NewStringUTF(frame_url.c_str());
+        jclass cls = env->GetObjectClass(cb);
+        if (cls) {
+            jmethodID mid = env->GetMethodID(cls, "onPrompt",
+                "(Ljava/lang/String;Ljava/lang/String;"
+                "Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+            if (mid) {
+                jstring jresult = (jstring)env->CallObjectMethod(
+                    cb, mid, jmsg, jdefault, jpage, jframe);
+                if (env->ExceptionCheck()) {
+                    env->ExceptionDescribe();
+                    env->ExceptionClear();
+                    jresult = nullptr;
+                }
+                if (jresult) {
+                    const char *cstr =
+                        env->GetStringUTFChars(jresult, nullptr);
+                    if (cstr) {
+                        result_utf8 = cstr;
+                        cancelled = false;
+                        env->ReleaseStringUTFChars(jresult, cstr);
+                    }
+                    env->DeleteLocalRef(jresult);
+                }
+            }
+            env->DeleteLocalRef(cls);
+        }
+        if (jmsg) env->DeleteLocalRef(jmsg);
+        if (jdefault) env->DeleteLocalRef(jdefault);
+        if (jpage) env->DeleteLocalRef(jpage);
+        if (jframe) env->DeleteLocalRef(jframe);
+        jvm->DetachCurrentThread();
+
+        // Build the NSString result on AppKit main before invoking
+        // the completion handler -- nil means cancel (page sees null
+        // per the JS contract), non-nil means the entered text.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            id text = cancelled ? nil : ns_str(result_utf8.c_str());
+            ((void (^)(id))ch)(text);
+            msg(ch, sel("release"));
+        });
+    }).detach();
 }
 
 // IMP: -[WebviewEmbedUIDelegate webView:runOpenPanelWithParameters:
@@ -2630,116 +2771,158 @@ static void impl_run_prompt(id self, SEL, id webView, id prompt,
 static void impl_run_open_panel(id self, SEL, id webView, id parameters,
                                 id frame, id completionHandler) {
     Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
-    auto run_completion = [&](id urls) {
-        // void(^)(NSArray<NSURL *> *)
-        ((void (^)(id))completionHandler)(urls);
-    };
-    if (!e || !e->dialog_callback) {
-        run_completion(nil);
-        return;
-    }
-    bool attached = false;
-    JNIEnv *env = ensure_jni_env(e->jvm, &attached);
-    if (!env) {
-        run_completion(nil);
-        return;
-    }
+    id ch = msg(completionHandler, sel("copy"));
 
+    // Snapshot parameters on AppKit main.  WKOpenPanelParameters and
+    // its private _acceptedMIMETypes / _acceptedFileExtensions
+    // accessors must be invoked here, not from a worker thread, since
+    // WKWebView's object graph isn't guaranteed thread-safe.
     BOOL multiple = NO;
+    std::vector<std::string> mime_types;
+    std::vector<std::string> ext_types;
     if (parameters) {
         multiple = msg<BOOL>(parameters, sel("allowsMultipleSelection"));
-    }
-
-    id mime_types = nil;
-    id ext_types = nil;
-    // _acceptedMIMETypes / _acceptedFileExtensions are private
-    // (underscore-prefixed) accessors on WKOpenPanelParameters that have
-    // been stable since macOS 10.12.  Probe respondsToSelector: rather
-    // than blindly invoking them so a hypothetical future macOS that
-    // removes or renames the selectors degrades gracefully (we pass an
-    // empty array to Java and the default JFileChooser shows all files;
-    // the page's own client-side `accept` validation still works).
-    //
-    // Probing via the ObjC runtime keeps this file as plain C++ -- the
-    // Objective-C++ @try/@catch syntax can't be used because
-    // src_c/webview_embed.cpp is compiled with `c++` not `clang++ -x
-    // objective-c++` (see build-mac.sh and .github/workflows/build.yml).
-    if (parameters) {
+        // _acceptedMIMETypes / _acceptedFileExtensions are private
+        // (underscore-prefixed) accessors on WKOpenPanelParameters that
+        // have been stable since macOS 10.12.  Probe respondsToSelector:
+        // rather than blindly invoking them so a hypothetical future
+        // macOS that removes or renames the selectors degrades
+        // gracefully (we pass an empty array to Java and the default
+        // JFileChooser shows all files; the page's own client-side
+        // `accept` validation still works).
+        //
+        // Probing via the ObjC runtime keeps this file as plain C++ --
+        // the Objective-C++ @try/@catch syntax can't be used because
+        // src_c/webview_embed.cpp is compiled with `c++`, not
+        // `clang++ -x objective-c++`.
         SEL mime_sel = sel("_acceptedMIMETypes");
         if (msg<BOOL, SEL>(parameters, sel("respondsToSelector:"),
                            mime_sel)) {
-            mime_types = msg<id>(parameters, mime_sel);
+            mime_types = ns_array_to_utf8_vector(
+                msg<id>(parameters, mime_sel));
         }
         SEL ext_sel = sel("_acceptedFileExtensions");
         if (msg<BOOL, SEL>(parameters, sel("respondsToSelector:"),
                            ext_sel)) {
-            ext_types = msg<id>(parameters, ext_sel);
+            ext_types = ns_array_to_utf8_vector(
+                msg<id>(parameters, ext_sel));
         }
     }
+    std::string page_url = page_url_utf8(webView);
+    std::string frame_url = frame_url_utf8(frame, webView);
 
-    jobjectArray jmimes = ns_array_to_jstring_array(env, mime_types);
-    jobjectArray jexts = ns_array_to_jstring_array(env, ext_types);
-    jstring jpage = page_url_jstring(env, webView);
-    jstring jframe = frame_url_jstring(env, frame, webView);
+    if (!e || !e->dialog_callback) {
+        ((void (^)(id))ch)(nil);
+        msg(ch, sel("release"));
+        return;
+    }
+    JavaVM *jvm = e->jvm;
+    jobject cb = e->dialog_callback;
 
-    jobjectArray jresult = nullptr;
-    jclass cls = env->GetObjectClass(e->dialog_callback);
-    if (cls) {
-        jmethodID mid = env->GetMethodID(
-            cls, "onFilePicker",
-            "(Z[Ljava/lang/String;[Ljava/lang/String;"
-            "Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;");
-        if (mid) {
-            jresult = (jobjectArray)env->CallObjectMethod(
-                e->dialog_callback, mid,
-                (jboolean)(multiple == YES ? JNI_TRUE : JNI_FALSE),
-                jmimes, jexts, jpage, jframe);
-            if (env->ExceptionCheck()) {
-                env->ExceptionDescribe();
-                env->ExceptionClear();
-                jresult = nullptr;
+    std::thread([jvm, cb, multiple, mime_types, ext_types,
+                 page_url, frame_url, ch]() {
+        JNIEnv *env = nullptr;
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ((void (^)(id))ch)(nil);
+                msg(ch, sel("release"));
+            });
+            return;
+        }
+
+        // Build the input string-arrays in this worker (NewStringUTF
+        // requires a JNIEnv).
+        jclass strCls = env->FindClass("java/lang/String");
+        auto vec_to_jarray = [&](const std::vector<std::string> &v) {
+            jobjectArray a = env->NewObjectArray(
+                (jsize)v.size(), strCls, nullptr);
+            for (size_t i = 0; i < v.size(); i++) {
+                jstring s = env->NewStringUTF(v[i].c_str());
+                if (s) {
+                    env->SetObjectArrayElement(a, (jsize)i, s);
+                    env->DeleteLocalRef(s);
+                }
             }
-        }
-        env->DeleteLocalRef(cls);
-    }
+            return a;
+        };
+        jobjectArray jmimes = vec_to_jarray(mime_types);
+        jobjectArray jexts = vec_to_jarray(ext_types);
+        jstring jpage = env->NewStringUTF(page_url.c_str());
+        jstring jframe = env->NewStringUTF(frame_url.c_str());
 
-    id urls = nil;
-    if (jresult) {
-        jsize n = env->GetArrayLength(jresult);
-        if (n > 0) {
-            id NSURLcls = objc_cls("NSURL");
-            id arr = msg(objc_cls("NSMutableArray"),
-                         sel("arrayWithCapacity:"), (long)n);
-            for (jsize i = 0; i < n; i++) {
-                jstring js = (jstring)env->GetObjectArrayElement(
-                    jresult, i);
-                if (!js) continue;
-                const char *cstr = env->GetStringUTFChars(js, nullptr);
-                if (cstr) {
-                    id path_ns = ns_str(cstr);
+        // Capture chosen file paths as a std::vector<std::string> so
+        // we can build the NSArray<NSURL*> back on AppKit main (NSURL
+        // construction is technically thread-safe but staying on main
+        // keeps the WKWebView completion-handler invocation simple).
+        std::vector<std::string> chosen_paths;
+
+        jclass cls = env->GetObjectClass(cb);
+        if (cls) {
+            jmethodID mid = env->GetMethodID(cls, "onFilePicker",
+                "(Z[Ljava/lang/String;[Ljava/lang/String;"
+                "Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;");
+            if (mid) {
+                jobjectArray jresult = (jobjectArray)env->CallObjectMethod(
+                    cb, mid,
+                    (jboolean)(multiple == YES ? JNI_TRUE : JNI_FALSE),
+                    jmimes, jexts, jpage, jframe);
+                if (env->ExceptionCheck()) {
+                    env->ExceptionDescribe();
+                    env->ExceptionClear();
+                    jresult = nullptr;
+                }
+                if (jresult) {
+                    jsize n = env->GetArrayLength(jresult);
+                    chosen_paths.reserve((size_t)n);
+                    for (jsize i = 0; i < n; i++) {
+                        jstring js = (jstring)env->GetObjectArrayElement(
+                            jresult, i);
+                        if (!js) continue;
+                        const char *cstr =
+                            env->GetStringUTFChars(js, nullptr);
+                        if (cstr) {
+                            chosen_paths.emplace_back(cstr);
+                            env->ReleaseStringUTFChars(js, cstr);
+                        }
+                        env->DeleteLocalRef(js);
+                    }
+                    env->DeleteLocalRef(jresult);
+                }
+            }
+            env->DeleteLocalRef(cls);
+        }
+        if (jmimes) env->DeleteLocalRef(jmimes);
+        if (jexts) env->DeleteLocalRef(jexts);
+        if (jpage) env->DeleteLocalRef(jpage);
+        if (jframe) env->DeleteLocalRef(jframe);
+        if (strCls) env->DeleteLocalRef(strCls);
+        jvm->DetachCurrentThread();
+
+        // Build NSArray<NSURL*> on AppKit main and invoke completion.
+        // Empty paths vector → nil → user cancelled (empty FileList).
+        dispatch_async(dispatch_get_main_queue(), ^{
+            id urls = nil;
+            if (!chosen_paths.empty()) {
+                id NSURLcls = objc_cls("NSURL");
+                id arr = msg(objc_cls("NSMutableArray"),
+                             sel("arrayWithCapacity:"),
+                             (long)chosen_paths.size());
+                for (const std::string &path : chosen_paths) {
+                    id path_ns = ns_str(path.c_str());
                     id url = msg<id, id>(
                         NSURLcls, sel("fileURLWithPath:"), path_ns);
                     if (url) {
                         msg<void, id>(arr, sel("addObject:"), url);
                     }
-                    env->ReleaseStringUTFChars(js, cstr);
                 }
-                env->DeleteLocalRef(js);
+                long count = msg<long>(arr, sel("count"));
+                if (count > 0) urls = arr;
             }
-            long arr_count = msg<long>(arr, sel("count"));
-            if (arr_count > 0) urls = arr;
-        }
-        env->DeleteLocalRef(jresult);
-    }
-
-    if (jmimes) env->DeleteLocalRef(jmimes);
-    if (jexts) env->DeleteLocalRef(jexts);
-    if (jpage) env->DeleteLocalRef(jpage);
-    if (jframe) env->DeleteLocalRef(jframe);
-    if (attached) e->jvm->DetachCurrentThread();
-    // urls nil → user cancelled (page receives an empty FileList);
-    // non-nil NSArray<NSURL*> → page receives the chosen files.
-    run_completion(urls);
+            ((void (^)(id))ch)(urls);
+            msg(ch, sel("release"));
+        });
+    }).detach();
 }
 
 static Class get_webview_embed_ui_delegate_cls() {

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -422,6 +422,402 @@ static void fire_click_callback(Engine *e) {
     if (detach) jvm->DetachCurrentThread();
 }
 
+// ---------------------------------------------------------------------------
+// JS-initiated UI dialog bridge for WebKitGTK.
+//
+// Connects to the `script-dialog` and `run-file-chooser` signals on each
+// WebKitWebView (both heavyweight gtk_create_engine and lightweight
+// gtk_off_create_engine).  Returning TRUE from each handler suppresses the
+// default GTK dialog; the application drives the response by invoking
+// WebViewDialogCallback methods on the per-engine dialog_callback global ref
+// and feeding the answer back via webkit_script_dialog_*_set_* /
+// webkit_file_chooser_request_select_files / _cancel.
+//
+// All four `fire_dialog_*` helpers mirror fire_click_callback's shape:
+// defensive AttachCurrentThread + detach-only-if-we-attached, resolve method
+// id per call (no caching), ExceptionCheck/Clear after every Call*Method.
+// Strings returned from fire_dialog_prompt are g_strdup'd (caller g_free's);
+// arrays returned from fire_dialog_file_picker are g_new0+g_strdup'd (caller
+// g_strfreev's).  WebKitGTK copies both internally per its docs.
+// ---------------------------------------------------------------------------
+
+static void fire_dialog_alert(JavaVM *jvm, jobject callback,
+                              const char *message,
+                              const char *pageUrl,
+                              const char *frameUrl) {
+    if (!jvm || !callback) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            return;
+        }
+        detach = true;
+    }
+    if (!env) {
+        if (detach) jvm->DetachCurrentThread();
+        return;
+    }
+    jstring jmsg = env->NewStringUTF(message ? message : "");
+    jstring jpage = env->NewStringUTF(pageUrl ? pageUrl : "");
+    jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onAlert",
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+        if (m) {
+            env->CallVoidMethod(callback, m, jmsg, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmsg) env->DeleteLocalRef(jmsg);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+static jboolean fire_dialog_confirm(JavaVM *jvm, jobject callback,
+                                    const char *message,
+                                    const char *pageUrl,
+                                    const char *frameUrl) {
+    if (!jvm || !callback) return JNI_FALSE;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            return JNI_FALSE;
+        }
+        detach = true;
+    }
+    if (!env) {
+        if (detach) jvm->DetachCurrentThread();
+        return JNI_FALSE;
+    }
+    jboolean result = JNI_FALSE;
+    jstring jmsg = env->NewStringUTF(message ? message : "");
+    jstring jpage = env->NewStringUTF(pageUrl ? pageUrl : "");
+    jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onConfirm",
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z");
+        if (m) {
+            result = env->CallBooleanMethod(callback, m, jmsg, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                result = JNI_FALSE;
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmsg) env->DeleteLocalRef(jmsg);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (detach) jvm->DetachCurrentThread();
+    return result;
+}
+
+static char *fire_dialog_prompt(JavaVM *jvm, jobject callback,
+                                const char *message,
+                                const char *defaultValue,
+                                const char *pageUrl,
+                                const char *frameUrl) {
+    if (!jvm || !callback) return nullptr;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            return nullptr;
+        }
+        detach = true;
+    }
+    if (!env) {
+        if (detach) jvm->DetachCurrentThread();
+        return nullptr;
+    }
+    char *result = nullptr;
+    jstring jmsg = env->NewStringUTF(message ? message : "");
+    jstring jdefault = env->NewStringUTF(defaultValue ? defaultValue : "");
+    jstring jpage = env->NewStringUTF(pageUrl ? pageUrl : "");
+    jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onPrompt",
+            "(Ljava/lang/String;Ljava/lang/String;"
+            "Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+        if (m) {
+            jstring jresult = (jstring)env->CallObjectMethod(
+                callback, m, jmsg, jdefault, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                jresult = nullptr;
+            }
+            if (jresult) {
+                const char *cstr = env->GetStringUTFChars(jresult, nullptr);
+                if (cstr) {
+                    result = g_strdup(cstr);
+                    env->ReleaseStringUTFChars(jresult, cstr);
+                }
+                env->DeleteLocalRef(jresult);
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmsg) env->DeleteLocalRef(jmsg);
+    if (jdefault) env->DeleteLocalRef(jdefault);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (detach) jvm->DetachCurrentThread();
+    return result;  // caller owns; free with g_free
+}
+
+// Build a jobjectArray of UTF-8 jstrings from a NULL-terminated
+// const gchar*const* (may be NULL).  Returns a freshly-allocated
+// local ref; the caller is responsible for DeleteLocalRef on the
+// outer array.  Element local refs are released inside this helper.
+static jobjectArray nullterm_array_to_jstring_array(
+        JNIEnv *env, jclass stringCls, const gchar *const *arr) {
+    jsize n = 0;
+    if (arr) {
+        while (arr[n] != nullptr) n++;
+    }
+    jobjectArray ja = env->NewObjectArray(n, stringCls, nullptr);
+    if (!ja) return nullptr;
+    for (jsize i = 0; i < n; i++) {
+        jstring js = env->NewStringUTF(arr[i]);
+        if (js) {
+            env->SetObjectArrayElement(ja, i, js);
+            env->DeleteLocalRef(js);
+        }
+    }
+    return ja;
+}
+
+static gchar **fire_dialog_file_picker(JavaVM *jvm, jobject callback,
+                                       gboolean multiple,
+                                       const gchar *const *mimeTypes,
+                                       const gchar *const *extensions,
+                                       const char *pageUrl,
+                                       const char *frameUrl) {
+    if (!jvm || !callback) return nullptr;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            return nullptr;
+        }
+        detach = true;
+    }
+    if (!env) {
+        if (detach) jvm->DetachCurrentThread();
+        return nullptr;
+    }
+    gchar **result = nullptr;
+    jclass stringCls = env->FindClass("java/lang/String");
+    if (!stringCls) {
+        if (detach) jvm->DetachCurrentThread();
+        return nullptr;
+    }
+    jobjectArray jmimes = nullterm_array_to_jstring_array(
+        env, stringCls, mimeTypes);
+    jobjectArray jexts = nullterm_array_to_jstring_array(
+        env, stringCls, extensions);
+    jstring jpage = env->NewStringUTF(pageUrl ? pageUrl : "");
+    jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onFilePicker",
+            "(Z[Ljava/lang/String;[Ljava/lang/String;"
+            "Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;");
+        if (m) {
+            jobjectArray jresult = (jobjectArray)env->CallObjectMethod(
+                callback, m,
+                (jboolean)(multiple ? JNI_TRUE : JNI_FALSE),
+                jmimes, jexts, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                jresult = nullptr;
+            }
+            if (jresult) {
+                jsize len = env->GetArrayLength(jresult);
+                if (len > 0) {
+                    result = g_new0(gchar *, (gsize)len + 1);
+                    gsize idx = 0;
+                    for (jsize i = 0; i < len; i++) {
+                        jstring js = (jstring)env->GetObjectArrayElement(
+                            jresult, i);
+                        if (!js) continue;
+                        const char *cstr = env->GetStringUTFChars(js, nullptr);
+                        if (cstr) {
+                            result[idx++] = g_strdup(cstr);
+                            env->ReleaseStringUTFChars(js, cstr);
+                        }
+                        env->DeleteLocalRef(js);
+                    }
+                    if (idx == 0) {
+                        // Defensive: every entry was null / unreadable.
+                        g_strfreev(result);
+                        result = nullptr;
+                    }
+                }
+                env->DeleteLocalRef(jresult);
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmimes) env->DeleteLocalRef(jmimes);
+    if (jexts) env->DeleteLocalRef(jexts);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    env->DeleteLocalRef(stringCls);
+    if (detach) jvm->DetachCurrentThread();
+    return result;  // caller owns; free with g_strfreev
+}
+
+// Shared inner dispatcher for the `script-dialog` signal.  Engine-agnostic;
+// the per-engine wrappers (on_script_dialog_engine /
+// on_script_dialog_off_engine) pull jvm + dialog_callback + page URL out
+// of their respective Engine / OffEngine struct and call into this
+// function.  Always returns TRUE — the GTK default dialog is permanently
+// suppressed for any WebViewComponent-managed engine.  Even on the
+// null-callback / JNI-attach-failure path, every branch resolves the
+// dialog (via the engine-specific set_* APIs or by not calling them) so
+// the page's JS thread always resumes within bounded time.
+static gboolean handle_script_dialog(JavaVM *jvm, jobject dialog_callback,
+                                     const gchar *page_url,
+                                     WebKitScriptDialog *dialog) {
+    if (!dialog) return TRUE;
+    WebKitScriptDialogType type = webkit_script_dialog_get_dialog_type(dialog);
+    const gchar *message = webkit_script_dialog_get_message(dialog);
+    const char *frame_url = page_url ? page_url : "";
+    switch (type) {
+        case WEBKIT_SCRIPT_DIALOG_ALERT:
+            if (dialog_callback) {
+                fire_dialog_alert(jvm, dialog_callback,
+                                  message, page_url, frame_url);
+            }
+            // No set_* call needed for alert.
+            break;
+        case WEBKIT_SCRIPT_DIALOG_CONFIRM:
+        case WEBKIT_SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM: {
+            jboolean ok = JNI_FALSE;
+            if (dialog_callback) {
+                ok = fire_dialog_confirm(jvm, dialog_callback,
+                                         message, page_url, frame_url);
+            }
+            webkit_script_dialog_confirm_set_confirmed(
+                dialog, ok == JNI_TRUE);
+            break;
+        }
+        case WEBKIT_SCRIPT_DIALOG_PROMPT: {
+            const gchar *def =
+                webkit_script_dialog_prompt_get_default_text(dialog);
+            char *answer = nullptr;
+            if (dialog_callback) {
+                answer = fire_dialog_prompt(jvm, dialog_callback,
+                                            message, def ? def : "",
+                                            page_url, frame_url);
+            }
+            if (answer) {
+                webkit_script_dialog_prompt_set_text(dialog, answer);
+                g_free(answer);
+            }
+            // If answer is null: do NOT call _set_text.  WebKitGTK treats
+            // the absence of a _set_text call as "user cancelled" and the
+            // page sees prompt() return null — exactly the JS-spec cancel
+            // semantic.
+            break;
+        }
+        default:
+            // Unknown dialog kind: suppress the GTK default but don't
+            // forward to Java.  Conservative — future WebKitGTK versions
+            // may add new dialog types we haven't taught the handler
+            // about yet.
+            break;
+    }
+    return TRUE;
+}
+
+// Shared inner dispatcher for the `run-file-chooser` signal.  Same
+// engine-agnostic shape as handle_script_dialog.  Always returns TRUE so
+// the GTK default file picker never fires; always resolves the request
+// via either _select_files (accept) or _cancel (cancel / null callback /
+// empty result) so the page's JS `change` event fires within bounded
+// time.
+static gboolean handle_run_file_chooser(JavaVM *jvm, jobject dialog_callback,
+                                        const gchar *page_url,
+                                        WebKitFileChooserRequest *request) {
+    if (!request) return TRUE;
+    if (!dialog_callback) {
+        webkit_file_chooser_request_cancel(request);
+        return TRUE;
+    }
+    gboolean multiple =
+        webkit_file_chooser_request_get_select_multiple(request);
+    const gchar *const *mime_types =
+        webkit_file_chooser_request_get_mime_types(request);
+    const char *frame_url = page_url ? page_url : "";
+
+    // WebKitGTK's file-chooser API does not expose the original `.ext`
+    // strings the page wrote (only the opaque GtkFileFilter via
+    // _get_mime_types_filter), so we pass an empty extensions array.
+    // The Java-side DialogDispatcher.normaliseExtensions handles the
+    // empty case correctly; the default JFileChooser falls through to
+    // "show all files".  Documented Linux limitation per the canvas.
+    gchar **paths = fire_dialog_file_picker(
+        jvm, dialog_callback, multiple, mime_types,
+        /* extensions */ nullptr, page_url, frame_url);
+
+    if (!paths) {
+        webkit_file_chooser_request_cancel(request);
+    } else {
+        webkit_file_chooser_request_select_files(
+            request, (const gchar *const *)paths);
+        // WebKitGTK copies the paths internally per its docs, so free
+        // our array immediately.
+        g_strfreev(paths);
+    }
+    return TRUE;
+}
+
+// Per-Engine wrapper for the `script-dialog` signal.  Reads page URL,
+// jvm, and dialog_callback from the heavyweight Engine struct and
+// delegates to handle_script_dialog.  The OffEngine counterpart is
+// defined alongside the OffEngine struct further down so its forward
+// dependency is satisfied.
+static gboolean on_script_dialog_engine(WebKitWebView *web,
+                                        WebKitScriptDialog *dialog,
+                                        gpointer user_data) {
+    Engine *e = static_cast<Engine *>(user_data);
+    if (!e) return TRUE;
+    const gchar *uri = webkit_web_view_get_uri(web);
+    return handle_script_dialog(e->jvm, e->dialog_callback, uri, dialog);
+}
+
+static gboolean on_run_file_chooser_engine(WebKitWebView *web,
+                                           WebKitFileChooserRequest *request,
+                                           gpointer user_data) {
+    Engine *e = static_cast<Engine *>(user_data);
+    if (!e) return TRUE;
+    const gchar *uri = webkit_web_view_get_uri(web);
+    return handle_run_file_chooser(e->jvm, e->dialog_callback, uri, request);
+}
+
 static void engine_on_message(Engine *e, const char *msg) {
     if (msg == nullptr) return;
     // The message is JSON: {name, seq, args}.  We mirror the bind format used
@@ -592,6 +988,21 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug) {
                          (GCallback)on_load_changed, nullptr);
         g_signal_connect(WEBKIT_WEB_VIEW(e->web), "load-failed",
                          (GCallback)on_load_failed, nullptr);
+
+        // Wire JS-initiated dialogs (alert / confirm / prompt /
+        // <input type=file>) to the per-engine Java DialogDispatcher via
+        // the dialog_callback global ref.  Returning TRUE from each
+        // handler suppresses the default GTK dialog; the Java side
+        // decides what UI (if any) to show, with default behaviour being
+        // Swing dialogs anchored on the host JFrame.  See
+        // WebViewDialogHandler for the full contract.  Identical
+        // registration site in gtk_off_create_engine — both engines
+        // share the inner handle_script_dialog / handle_run_file_chooser
+        // logic via the per-engine wrappers.
+        g_signal_connect(WEBKIT_WEB_VIEW(e->web), "script-dialog",
+                         (GCallback)on_script_dialog_engine, e);
+        g_signal_connect(WEBKIT_WEB_VIEW(e->web), "run-file-chooser",
+                         (GCallback)on_run_file_chooser_engine, e);
 
         // Wire up the "external" message handler.
         g_signal_connect(
@@ -1017,11 +1428,37 @@ struct OffEngine {
     JavaVM *jvm = nullptr;
 
     // JNI global ref to the registered WebViewDialogCallback, or nullptr.
-    // Storage only in this canvas (STORY-004-001) -- STORY-004-002 wires
-    // the WebKitGTK script-dialog + run-file-chooser signal handlers
-    // that actually invoke this callback on the offscreen WebKitWebView.
+    // Set by gtk_off_set_dialog_callback; cleared in gtk_off_destroy_engine.
+    // Invoked by the script-dialog / run-file-chooser signal handlers
+    // installed in gtk_off_create_engine, which route through the shared
+    // handle_script_dialog / handle_run_file_chooser inner functions
+    // declared in the heavyweight engine block above.
     jobject dialog_callback = nullptr;
 };
+
+// Per-OffEngine wrapper for the `script-dialog` signal.  Reads page URL,
+// jvm, and dialog_callback from the lightweight OffEngine struct and
+// delegates to the shared handle_script_dialog.  Mirrors
+// on_script_dialog_engine — single divergence is the user_data cast type.
+// Per the canvas Safeguards: behaviour MUST be byte-identical to the
+// heavyweight variant, which is achieved by sharing handle_script_dialog.
+static gboolean on_script_dialog_off_engine(WebKitWebView *web,
+                                            WebKitScriptDialog *dialog,
+                                            gpointer user_data) {
+    OffEngine *e = static_cast<OffEngine *>(user_data);
+    if (!e) return TRUE;
+    const gchar *uri = webkit_web_view_get_uri(web);
+    return handle_script_dialog(e->jvm, e->dialog_callback, uri, dialog);
+}
+
+static gboolean on_run_file_chooser_off_engine(
+        WebKitWebView *web, WebKitFileChooserRequest *request,
+        gpointer user_data) {
+    OffEngine *e = static_cast<OffEngine *>(user_data);
+    if (!e) return TRUE;
+    const gchar *uri = webkit_web_view_get_uri(web);
+    return handle_run_file_chooser(e->jvm, e->dialog_callback, uri, request);
+}
 
 // Parallel of engine_on_message for OffEngine: parse the {name, seq, args}
 // envelope produced by window.external.invoke / the bind shim, look the
@@ -1102,6 +1539,17 @@ static OffEngine *gtk_off_create_engine(JNIEnv *env,
             e);
         webkit_user_content_manager_register_script_message_handler(
             e->manager, "external");
+
+        // Wire JS-initiated dialogs to the per-engine Java DialogDispatcher.
+        // Same shape as gtk_create_engine; the offscreen variants of the
+        // signal handlers route through OffEngine instead of Engine but
+        // call the same inner handle_script_dialog /
+        // handle_run_file_chooser logic.
+        g_signal_connect(WEBKIT_WEB_VIEW(e->web), "script-dialog",
+                         (GCallback)on_script_dialog_off_engine, e);
+        g_signal_connect(WEBKIT_WEB_VIEW(e->web), "run-file-chooser",
+                         (GCallback)on_run_file_chooser_off_engine, e);
+
         webkit_user_content_manager_add_script(
             e->manager,
             webkit_user_script_new(
@@ -3809,6 +4257,17 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
 #endif
 }
 
+// The two dialog-callback JNI bridges below are wrapped in `extern "C"`
+// so the symbols emitted match the JVM's JNI lookup expectations
+// (`Java_<classpath>_<method>` with C linkage).  The existing focus /
+// click / release-native-focus / set-attach-callback bridges above get
+// this treatment from `ca_weblite_webview_WebViewNative.h`'s
+// `extern "C" { ... }` wrapper, but the dialog setters were added
+// without regenerating that header so they need the explicit linkage
+// spec.  Regenerating the header is a cosmetic follow-up; the explicit
+// `extern "C"` here keeps the symbols callable from the JVM today.
+extern "C" {
+
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1dialog_1callback
   (JNIEnv *env, jclass, jlong wv, jobject cb) {
     if (wv == 0) return;
@@ -3833,6 +4292,8 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     (void)env; (void)cb;
 #endif
 }
+
+} // extern "C"
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1init
   (JNIEnv *env, jclass, jlong wv, jstring js) {

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -2620,11 +2620,13 @@ static void impl_run_prompt(id self, SEL, id webView, id prompt,
 //
 // _acceptedMIMETypes and _acceptedFileExtensions are documented in
 // WebKit source and have been stable across macOS releases since
-// 10.12, but they are NOT part of the public WKWebKit headers.  Read
-// via KVC and wrap in @try/@catch; a hypothetical future macOS that
-// hides them yields empty arrays here and the default JFileChooser
-// shows all files unfiltered (the page's own client-side accept
-// validation continues to work).
+// 10.12, but they are NOT part of the public WKWebKit headers.  Probe
+// them via the ObjC runtime's respondsToSelector: (see below) rather
+// than blind invocation so a hypothetical future macOS that hides them
+// yields empty arrays here and the default JFileChooser shows all
+// files unfiltered (the page's own client-side accept validation
+// continues to work).  We avoid @try/@catch because this file is
+// compiled as plain C++, not Objective-C++.
 static void impl_run_open_panel(id self, SEL, id webView, id parameters,
                                 id frame, id completionHandler) {
     Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
@@ -2650,20 +2652,30 @@ static void impl_run_open_panel(id self, SEL, id webView, id parameters,
 
     id mime_types = nil;
     id ext_types = nil;
-    @try {
-        if (parameters) {
-            mime_types = msg<id, id>(
-                parameters, sel("valueForKey:"),
-                ns_str("_acceptedMIMETypes"));
+    // _acceptedMIMETypes / _acceptedFileExtensions are private
+    // (underscore-prefixed) accessors on WKOpenPanelParameters that have
+    // been stable since macOS 10.12.  Probe respondsToSelector: rather
+    // than blindly invoking them so a hypothetical future macOS that
+    // removes or renames the selectors degrades gracefully (we pass an
+    // empty array to Java and the default JFileChooser shows all files;
+    // the page's own client-side `accept` validation still works).
+    //
+    // Probing via the ObjC runtime keeps this file as plain C++ -- the
+    // Objective-C++ @try/@catch syntax can't be used because
+    // src_c/webview_embed.cpp is compiled with `c++` not `clang++ -x
+    // objective-c++` (see build-mac.sh and .github/workflows/build.yml).
+    if (parameters) {
+        SEL mime_sel = sel("_acceptedMIMETypes");
+        if (msg<BOOL, SEL>(parameters, sel("respondsToSelector:"),
+                           mime_sel)) {
+            mime_types = msg<id>(parameters, mime_sel);
         }
-    } @catch (id ex) { mime_types = nil; }
-    @try {
-        if (parameters) {
-            ext_types = msg<id, id>(
-                parameters, sel("valueForKey:"),
-                ns_str("_acceptedFileExtensions"));
+        SEL ext_sel = sel("_acceptedFileExtensions");
+        if (msg<BOOL, SEL>(parameters, sel("respondsToSelector:"),
+                           ext_sel)) {
+            ext_types = msg<id>(parameters, ext_sel);
         }
-    } @catch (id ex) { ext_types = nil; }
+    }
 
     jobjectArray jmimes = ns_array_to_jstring_array(env, mime_types);
     jobjectArray jexts = ns_array_to_jstring_array(env, ext_types);

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -382,6 +382,14 @@ struct Engine {
     // destroyed so a late press cannot fire into a freed ref.
     jobject click_callback = nullptr;
 
+    // JNI global ref to the registered WebViewDialogCallback, or nullptr.
+    // Storage only in this canvas (STORY-004-001) -- the signal handler
+    // wiring that actually invokes the callback lands in STORY-004-002
+    // (script-dialog + run-file-chooser on WebKitWebView).  The field
+    // is declared here so the JNI bridge function can store / clear
+    // the global ref without dropping the canvas-004-002 changes.
+    jobject dialog_callback = nullptr;
+
     Engine() {}
     ~Engine() {}
 };
@@ -814,6 +822,21 @@ static void gtk_destroy_engine(Engine *e) {
         e->click_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
+    // Same treatment for the dialog-callback global ref.  Stored only
+    // in this canvas; STORY-004-002 will fire signal handlers off
+    // this field, so symmetric cleanup is required even though
+    // STORY-004-001 itself never invokes the callback on Linux.
+    if (e->dialog_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm && e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->dialog_callback);
+        e->dialog_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     GtkPump::instance().run_sync([&] {
         if (e->redraw_timer_id) {
             g_source_remove(e->redraw_timer_id);
@@ -955,6 +978,24 @@ static void gtk_set_click_callback(Engine *e, JNIEnv *env, jobject cb) {
     }
 }
 
+// Register (or clear, when cb is null) the Java WebViewDialogCallback
+// for this engine.  STORY-004-001 stores the global ref but does NOT
+// install the WebKitWebView script-dialog / run-file-chooser signal
+// handlers that actually invoke it -- those land in STORY-004-002.
+// Implementing the storage lifecycle here keeps the JNI bridge linkable
+// across all three platforms and lets STORY-004-002 ship by only
+// touching the signal-handler wiring.
+static void gtk_set_dialog_callback(Engine *e, JNIEnv *env, jobject cb) {
+    if (!e) return;
+    if (e->dialog_callback) {
+        env->DeleteGlobalRef(e->dialog_callback);
+        e->dialog_callback = nullptr;
+    }
+    if (cb) {
+        e->dialog_callback = env->NewGlobalRef(cb);
+    }
+}
+
 // ===========================================================================
 // Linux / GTK lightweight (offscreen) engine
 //
@@ -974,6 +1015,12 @@ struct OffEngine {
     bool debug = false;
     std::map<std::string, Binding *> bindings;
     JavaVM *jvm = nullptr;
+
+    // JNI global ref to the registered WebViewDialogCallback, or nullptr.
+    // Storage only in this canvas (STORY-004-001) -- STORY-004-002 wires
+    // the WebKitGTK script-dialog + run-file-chooser signal handlers
+    // that actually invoke this callback on the offscreen WebKitWebView.
+    jobject dialog_callback = nullptr;
 };
 
 // Parallel of engine_on_message for OffEngine: parse the {name, seq, args}
@@ -1154,6 +1201,17 @@ static void gtk_off_destroy_engine(OffEngine *e) {
             e->web = nullptr;
         }
     });
+    if (e->dialog_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->dialog_callback);
+        e->dialog_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     for (auto &kv : e->bindings) {
         Binding *b = kv.second;
         JNIEnv *env = nullptr;
@@ -1171,6 +1229,23 @@ static void gtk_off_destroy_engine(OffEngine *e) {
     }
     e->bindings.clear();
     delete e;
+}
+
+// Register (or clear, when cb is null) the Java WebViewDialogCallback
+// for this offscreen engine.  STORY-004-001 stores the global ref but
+// does NOT install the WebKitGTK signal handlers; STORY-004-002 wires
+// the script-dialog + run-file-chooser handlers on the offscreen
+// WebKitWebView.
+static void gtk_off_set_dialog_callback(OffEngine *e, JNIEnv *env,
+                                        jobject cb) {
+    if (!e) return;
+    if (e->dialog_callback) {
+        env->DeleteGlobalRef(e->dialog_callback);
+        e->dialog_callback = nullptr;
+    }
+    if (cb) {
+        e->dialog_callback = env->NewGlobalRef(cb);
+    }
 }
 
 static void gtk_off_init_script(OffEngine *e, std::string js) {
@@ -1631,6 +1706,23 @@ struct Engine {
     std::string attach_failure_message;
     jobject attach_callback = nullptr;
     jclass attach_callback_cls = nullptr;
+
+    // JNI global ref to the registered WebViewDialogCallback, or
+    // nullptr.  Invoked by the WKUIDelegate selectors below for each
+    // JS-initiated alert / confirm / prompt and for <input type=file>
+    // clicks.  The selector waits for the Java side's return value
+    // (via DialogDispatcher's invokeAndWait EDT hop) before invoking
+    // the platform's completion handler, which is what releases the
+    // page's JS thread.  Cleared in cocoa_destroy_engine BEFORE the
+    // ui_delegate is released so any in-flight selector reads a null
+    // field instead of a freed ref.
+    jobject dialog_callback = nullptr;
+
+    // Per-engine WKUIDelegate instance assigned to e->webview via
+    // setUIDelegate:.  Retained by us (we hold the only strong ref);
+    // released in cocoa_destroy_engine after we clear the WKWebView's
+    // uiDelegate property.
+    id ui_delegate = nullptr;
 };
 
 // Process-global map from WKWebView (id) to its owning Engine*.  Populated
@@ -1814,6 +1906,428 @@ static Class get_webview_embed_delegate_cls() {
         g_webview_embed_delegate_cls = c;
     });
     return g_webview_embed_delegate_cls;
+}
+
+// ---------------------------------------------------------------------------
+// WKUIDelegate hook for JS-initiated dialogs.
+//
+// WKWebView consults its uiDelegate to know what to do for
+// runJavaScriptAlertPanelWithMessage: / runJavaScriptConfirmPanel: /
+// runJavaScriptTextInputPanel: / runOpenPanelWithParameters:.  If the
+// uiDelegate is nil -- which is the default -- WKWebView SILENTLY DROPS
+// these requests: alert() returns immediately, confirm() returns false,
+// prompt() returns null, and <input type=file> clicks open no picker.
+// Installing a uiDelegate that implements these selectors restores the
+// expected JS behaviour and lets the host customise it via
+// WebViewDialogHandler.
+//
+// Selectors are invoked on the AppKit main thread.  Each selector takes
+// a completionHandler block that MUST be invoked exactly once to release
+// the page's JavaScript thread; the dispatcher's invokeAndWait hop to
+// the Swing EDT happens between selector entry and completion-handler
+// invocation, so AppKit main is parked during the modal Swing dialog.
+// That is the correct JS-contract behaviour: the page is frozen while
+// the dialog is open.
+//
+// Class registration mirrors get_webview_embed_delegate_cls above
+// (once-per-JVM call_once + objc_allocateClassPair + class_addMethod +
+// objc_registerClassPair).
+// ---------------------------------------------------------------------------
+static std::once_flag g_webview_embed_ui_delegate_once;
+static Class g_webview_embed_ui_delegate_cls = nil;
+
+// Helper: convert an NSString (or nil) to a fresh jstring via UTF-8.
+// Returns nullptr for nil input.  Caller is responsible for releasing
+// the local ref via DeleteLocalRef when done.
+static jstring ns_to_jstring(JNIEnv *env, id ns) {
+    if (!ns) return nullptr;
+    const char *cstr = msg<const char *>(ns, sel("UTF8String"));
+    if (!cstr) return nullptr;
+    return env->NewStringUTF(cstr);
+}
+
+// Helper: read the top-level page URL from the WKWebView.
+static jstring page_url_jstring(JNIEnv *env, id webView) {
+    if (!webView) return nullptr;
+    id url = msg(webView, sel("URL"));
+    if (!url) return nullptr;
+    id abs = msg(url, sel("absoluteString"));
+    return ns_to_jstring(env, abs);
+}
+
+// Helper: read the URL of the frame that initiated the dialog.  When
+// frame is nil or its request has no URL, fall back to the page URL.
+static jstring frame_url_jstring(JNIEnv *env, id frame, id webView) {
+    if (frame) {
+        id req = msg(frame, sel("request"));
+        if (req) {
+            id url = msg(req, sel("URL"));
+            if (url) {
+                id abs = msg(url, sel("absoluteString"));
+                jstring js = ns_to_jstring(env, abs);
+                if (js) return js;
+            }
+        }
+    }
+    return page_url_jstring(env, webView);
+}
+
+// Helper: convert an NSArray<NSString*> (or nil) to a fresh
+// jobjectArray of UTF-8 jstrings.  Returns an empty array for nil
+// input -- never returns nullptr -- so the Java side can assume
+// non-null arrays.  Caller is responsible for releasing the local ref.
+static jobjectArray ns_array_to_jstring_array(JNIEnv *env, id nsArray) {
+    jclass strCls = env->FindClass("java/lang/String");
+    if (!strCls) return nullptr;
+    if (!nsArray) {
+        jobjectArray empty = env->NewObjectArray(0, strCls, nullptr);
+        env->DeleteLocalRef(strCls);
+        return empty;
+    }
+    long count = msg<long>(nsArray, sel("count"));
+    jobjectArray arr = env->NewObjectArray(
+        (jsize)count, strCls, nullptr);
+    for (long i = 0; i < count; i++) {
+        id ns = msg<id, long>(nsArray, sel("objectAtIndex:"), i);
+        jstring js = ns_to_jstring(env, ns);
+        if (js) {
+            env->SetObjectArrayElement(arr, (jsize)i, js);
+            env->DeleteLocalRef(js);
+        }
+    }
+    env->DeleteLocalRef(strCls);
+    return arr;
+}
+
+// Ensure the current AppKit thread is attached to the JVM and return
+// the JNIEnv.  Sets *attached to true when this call attached (the
+// caller must detach before returning to AppKit).  Returns nullptr on
+// failure -- caller must invoke the platform completion handler with
+// the safe default.
+static JNIEnv *ensure_jni_env(JavaVM *jvm, bool *attached) {
+    *attached = false;
+    if (!jvm) return nullptr;
+    JNIEnv *env = nullptr;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK) {
+            return nullptr;
+        }
+        *attached = true;
+    }
+    return env;
+}
+
+// IMP: -[WebviewEmbedUIDelegate webView:runJavaScriptAlertPanelWithMessage:
+//                               initiatedByFrame:completionHandler:]
+static void impl_run_alert(id self, SEL, id webView, id message,
+                           id frame, id completionHandler) {
+    Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
+    auto run_completion = [&] {
+        // void(^)(void)
+        ((void (^)(void))completionHandler)();
+    };
+    if (!e || !e->dialog_callback) {
+        run_completion();
+        return;
+    }
+    bool attached = false;
+    JNIEnv *env = ensure_jni_env(e->jvm, &attached);
+    if (!env) {
+        run_completion();
+        return;
+    }
+    jstring jmsg = ns_to_jstring(env, message);
+    jstring jpage = page_url_jstring(env, webView);
+    jstring jframe = frame_url_jstring(env, frame, webView);
+    jclass cls = env->GetObjectClass(e->dialog_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(
+            cls, "onAlert",
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+        if (mid) {
+            env->CallVoidMethod(e->dialog_callback, mid,
+                                jmsg, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmsg) env->DeleteLocalRef(jmsg);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (attached) e->jvm->DetachCurrentThread();
+    run_completion();
+}
+
+// IMP: -[WebviewEmbedUIDelegate webView:runJavaScriptConfirmPanelWithMessage:
+//                               initiatedByFrame:completionHandler:]
+static void impl_run_confirm(id self, SEL, id webView, id message,
+                             id frame, id completionHandler) {
+    Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
+    auto run_completion = [&](BOOL result) {
+        ((void (^)(BOOL))completionHandler)(result);
+    };
+    if (!e || !e->dialog_callback) {
+        run_completion(NO);
+        return;
+    }
+    bool attached = false;
+    JNIEnv *env = ensure_jni_env(e->jvm, &attached);
+    if (!env) {
+        run_completion(NO);
+        return;
+    }
+    jboolean result = JNI_FALSE;
+    jstring jmsg = ns_to_jstring(env, message);
+    jstring jpage = page_url_jstring(env, webView);
+    jstring jframe = frame_url_jstring(env, frame, webView);
+    jclass cls = env->GetObjectClass(e->dialog_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(
+            cls, "onConfirm",
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z");
+        if (mid) {
+            result = env->CallBooleanMethod(
+                e->dialog_callback, mid, jmsg, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                result = JNI_FALSE;
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmsg) env->DeleteLocalRef(jmsg);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (attached) e->jvm->DetachCurrentThread();
+    run_completion(result == JNI_TRUE ? YES : NO);
+}
+
+// IMP: -[WebviewEmbedUIDelegate webView:runJavaScriptTextInputPanelWithPrompt:
+//                               defaultText:initiatedByFrame:completionHandler:]
+static void impl_run_prompt(id self, SEL, id webView, id prompt,
+                            id defaultText, id frame,
+                            id completionHandler) {
+    Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
+    auto run_completion = [&](id text) {
+        // void(^)(NSString *)
+        ((void (^)(id))completionHandler)(text);
+    };
+    if (!e || !e->dialog_callback) {
+        run_completion(nil);
+        return;
+    }
+    bool attached = false;
+    JNIEnv *env = ensure_jni_env(e->jvm, &attached);
+    if (!env) {
+        run_completion(nil);
+        return;
+    }
+    id result_ns = nil;
+    jstring jmsg = ns_to_jstring(env, prompt);
+    jstring jdefault = ns_to_jstring(env, defaultText);
+    jstring jpage = page_url_jstring(env, webView);
+    jstring jframe = frame_url_jstring(env, frame, webView);
+    jclass cls = env->GetObjectClass(e->dialog_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(
+            cls, "onPrompt",
+            "(Ljava/lang/String;Ljava/lang/String;"
+            "Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+        if (mid) {
+            jstring jresult = (jstring)env->CallObjectMethod(
+                e->dialog_callback, mid,
+                jmsg, jdefault, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                jresult = nullptr;
+            }
+            if (jresult) {
+                const char *cstr = env->GetStringUTFChars(jresult, nullptr);
+                if (cstr) {
+                    result_ns = ns_str(cstr);
+                    env->ReleaseStringUTFChars(jresult, cstr);
+                }
+                env->DeleteLocalRef(jresult);
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmsg) env->DeleteLocalRef(jmsg);
+    if (jdefault) env->DeleteLocalRef(jdefault);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (attached) e->jvm->DetachCurrentThread();
+    // result_ns is nil → cancel (page sees prompt() return null per
+    // the JS contract); non-nil NSString → page sees the entered text.
+    run_completion(result_ns);
+}
+
+// IMP: -[WebviewEmbedUIDelegate webView:runOpenPanelWithParameters:
+//                               initiatedByFrame:completionHandler:]
+//
+// _acceptedMIMETypes and _acceptedFileExtensions are documented in
+// WebKit source and have been stable across macOS releases since
+// 10.12, but they are NOT part of the public WKWebKit headers.  Read
+// via KVC and wrap in @try/@catch; a hypothetical future macOS that
+// hides them yields empty arrays here and the default JFileChooser
+// shows all files unfiltered (the page's own client-side accept
+// validation continues to work).
+static void impl_run_open_panel(id self, SEL, id webView, id parameters,
+                                id frame, id completionHandler) {
+    Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
+    auto run_completion = [&](id urls) {
+        // void(^)(NSArray<NSURL *> *)
+        ((void (^)(id))completionHandler)(urls);
+    };
+    if (!e || !e->dialog_callback) {
+        run_completion(nil);
+        return;
+    }
+    bool attached = false;
+    JNIEnv *env = ensure_jni_env(e->jvm, &attached);
+    if (!env) {
+        run_completion(nil);
+        return;
+    }
+
+    BOOL multiple = NO;
+    if (parameters) {
+        multiple = msg<BOOL>(parameters, sel("allowsMultipleSelection"));
+    }
+
+    id mime_types = nil;
+    id ext_types = nil;
+    @try {
+        if (parameters) {
+            mime_types = msg<id, id>(
+                parameters, sel("valueForKey:"),
+                ns_str("_acceptedMIMETypes"));
+        }
+    } @catch (id ex) { mime_types = nil; }
+    @try {
+        if (parameters) {
+            ext_types = msg<id, id>(
+                parameters, sel("valueForKey:"),
+                ns_str("_acceptedFileExtensions"));
+        }
+    } @catch (id ex) { ext_types = nil; }
+
+    jobjectArray jmimes = ns_array_to_jstring_array(env, mime_types);
+    jobjectArray jexts = ns_array_to_jstring_array(env, ext_types);
+    jstring jpage = page_url_jstring(env, webView);
+    jstring jframe = frame_url_jstring(env, frame, webView);
+
+    jobjectArray jresult = nullptr;
+    jclass cls = env->GetObjectClass(e->dialog_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(
+            cls, "onFilePicker",
+            "(Z[Ljava/lang/String;[Ljava/lang/String;"
+            "Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;");
+        if (mid) {
+            jresult = (jobjectArray)env->CallObjectMethod(
+                e->dialog_callback, mid,
+                (jboolean)(multiple == YES ? JNI_TRUE : JNI_FALSE),
+                jmimes, jexts, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                jresult = nullptr;
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+
+    id urls = nil;
+    if (jresult) {
+        jsize n = env->GetArrayLength(jresult);
+        if (n > 0) {
+            id NSURLcls = objc_cls("NSURL");
+            id arr = msg(objc_cls("NSMutableArray"),
+                         sel("arrayWithCapacity:"), (long)n);
+            for (jsize i = 0; i < n; i++) {
+                jstring js = (jstring)env->GetObjectArrayElement(
+                    jresult, i);
+                if (!js) continue;
+                const char *cstr = env->GetStringUTFChars(js, nullptr);
+                if (cstr) {
+                    id path_ns = ns_str(cstr);
+                    id url = msg<id, id>(
+                        NSURLcls, sel("fileURLWithPath:"), path_ns);
+                    if (url) {
+                        msg<void, id>(arr, sel("addObject:"), url);
+                    }
+                    env->ReleaseStringUTFChars(js, cstr);
+                }
+                env->DeleteLocalRef(js);
+            }
+            long arr_count = msg<long>(arr, sel("count"));
+            if (arr_count > 0) urls = arr;
+        }
+        env->DeleteLocalRef(jresult);
+    }
+
+    if (jmimes) env->DeleteLocalRef(jmimes);
+    if (jexts) env->DeleteLocalRef(jexts);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (attached) e->jvm->DetachCurrentThread();
+    // urls nil → user cancelled (page receives an empty FileList);
+    // non-nil NSArray<NSURL*> → page receives the chosen files.
+    run_completion(urls);
+}
+
+static Class get_webview_embed_ui_delegate_cls() {
+    std::call_once(g_webview_embed_ui_delegate_once, [] {
+        Class c = objc_allocateClassPair((Class)objc_cls("NSObject"),
+                                         "WebviewEmbedUIDelegate", 0);
+        class_addProtocol(c, objc_getProtocol("WKUIDelegate"));
+        class_addMethod(
+            c,
+            sel("webView:runJavaScriptAlertPanelWithMessage:"
+                "initiatedByFrame:completionHandler:"),
+            (IMP)impl_run_alert, "v@:@@@@");
+        class_addMethod(
+            c,
+            sel("webView:runJavaScriptConfirmPanelWithMessage:"
+                "initiatedByFrame:completionHandler:"),
+            (IMP)impl_run_confirm, "v@:@@@@");
+        class_addMethod(
+            c,
+            sel("webView:runJavaScriptTextInputPanelWithPrompt:"
+                "defaultText:initiatedByFrame:completionHandler:"),
+            (IMP)impl_run_prompt, "v@:@@@@@");
+        class_addMethod(
+            c,
+            sel("webView:runOpenPanelWithParameters:"
+                "initiatedByFrame:completionHandler:"),
+            (IMP)impl_run_open_panel, "v@:@@@@");
+        objc_registerClassPair(c);
+        g_webview_embed_ui_delegate_cls = c;
+    });
+    return g_webview_embed_ui_delegate_cls;
+}
+
+// Register (or clear, when cb is null) the Java WebViewDialogCallback
+// for this engine.  Mirrors cocoa_set_focus_callback /
+// cocoa_set_click_callback.  The WKUIDelegate IMPs above read
+// e->dialog_callback on every dispatch, so installing the global ref
+// here is the single place that wires Java handler into the selector
+// hot path.
+static void cocoa_set_dialog_callback(Engine *e, JNIEnv *env, jobject cb) {
+    if (!e) return;
+    if (e->dialog_callback) {
+        env->DeleteGlobalRef(e->dialog_callback);
+        e->dialog_callback = nullptr;
+    }
+    if (cb) {
+        e->dialog_callback = env->NewGlobalRef(cb);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2463,6 +2977,24 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
         msg<void, id, id>(e->manager,
                           sel("addScriptMessageHandler:name:"), delegate,
                           ns_str("external"));
+
+        // Browser-dialog bridge: install a WKUIDelegate so JS-initiated
+        // alert / confirm / prompt and <input type=file> requests flow
+        // through Java (DialogDispatcher → WebViewDialogHandler) instead
+        // of being silently dropped (default behaviour when uiDelegate
+        // is nil).  Each engine constructs a fresh delegate object from
+        // the cached Class so the per-engine Engine pointer can be
+        // stashed via objc_setAssociatedObject for the selector IMPs to
+        // recover.
+        Class ui_delegate_cls = get_webview_embed_ui_delegate_cls();
+        id ui_delegate = msg((id)ui_delegate_cls, sel("new"));
+        objc_setAssociatedObject(
+            ui_delegate, "eng", (id)e, OBJC_ASSOCIATION_ASSIGN);
+        msg<void, id>(e->webview, sel("setUIDelegate:"), ui_delegate);
+        // We hold the only strong ref to the delegate (the WKWebView's
+        // uiDelegate is a weak reference per WebKit convention).  Stash
+        // it on the engine so cocoa_destroy_engine can release it.
+        e->ui_delegate = ui_delegate;
         // Install the external.invoke shim.
         id script = msg(objc_cls("WKUserScript"), sel("alloc"));
         script = msg<id, id, long, BOOL>(
@@ -2581,6 +3113,24 @@ static void cocoa_destroy_engine(Engine *e) {
         e->click_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
+    // Drop the dialog-callback global ref BEFORE the async teardown
+    // lambda runs, so any in-flight WKUIDelegate selector observes a
+    // null callback field and invokes its completion handler with the
+    // safe default (returning the WebKit JS thread cleanly).  Released
+    // here -- outside the async lambda -- because the lambda runs on
+    // the AppKit main thread later and we still have the EDT JNIEnv
+    // available right now (matches the click_callback cleanup above).
+    if (e->dialog_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->dialog_callback);
+        e->dialog_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     cocoa_run_on_main_async([e] {
         // Mark destroyed FIRST.  Any LATER-firing lambdas that read this
         // flag short-circuit; FIFO ordering on the main queue makes
@@ -2593,10 +3143,20 @@ static void cocoa_destroy_engine(Engine *e) {
         // is released with observers still attached.
         cocoa_kvo_teardown(e);
 
+
         if (e->webview) {
+            // Clear the WKWebView's uiDelegate BEFORE releasing the
+            // WKWebView so any in-flight delegate selector observes
+            // the cleared field (WKWebView holds a weak reference to
+            // uiDelegate per Apple's convention).
+            msg<void, id>(e->webview, sel("setUIDelegate:"), (id)nullptr);
             // If we added the WKWebView as a subview, remove it before
             // releasing so AppKit unwinds the view hierarchy cleanly.
             msg<void>(e->webview, sel("removeFromSuperview"));
+        }
+        if (e->ui_delegate) {
+            msg<void>(e->ui_delegate, sel("release"));
+            e->ui_delegate = nullptr;
         }
         if (e->host_view) {
             msg<void>(e->host_view, sel("release"));
@@ -3246,6 +3806,31 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
         env->CallVoidMethod(cb, m, (jboolean)JNI_TRUE, (jstring)nullptr);
     }
     env->DeleteLocalRef(cls);
+#endif
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1dialog_1callback
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+    if (wv == 0) return;
+#ifdef WEBVIEW_GTK
+    embed::gtk_set_dialog_callback((embed::Engine *)wv, env, cb);
+#elif defined(WEBVIEW_COCOA)
+    embed::cocoa_set_dialog_callback((embed::Engine *)wv, env, cb);
+#else
+    (void)env; (void)cb;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1dialog_1callback
+  (JNIEnv *env, jclass, jlong peer, jobject cb) {
+    if (peer == 0) return;
+#ifdef WEBVIEW_GTK
+    embed::gtk_off_set_dialog_callback((embed::OffEngine *)peer, env, cb);
+#else
+    // macOS / Windows have no offscreen engine; the Java
+    // OffscreenWebView.setDialogCallback never gets here because
+    // OffscreenWebView.create returns null on those platforms.
+    (void)env; (void)cb;
 #endif
 }
 

--- a/test/ca/weblite/webview/DialogDispatcherTest.java
+++ b/test/ca/weblite/webview/DialogDispatcherTest.java
@@ -1,0 +1,474 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.SwingUtilities;
+
+/**
+ * Unit tests for {@link DialogDispatcher} — exercise the Java contract
+ * (handler registration, EDT marshaling, drop semantics, exception
+ * isolation, accept-attribute normalisation, dispose semantics) without
+ * a live native engine.  GUI integration is verified by
+ * {@code WebViewDialogDemo}; this file covers the dispatcher's logic.
+ */
+public class DialogDispatcherTest {
+
+    /** Minimal {@link WebViewComponent} subclass usable as a
+     *  dispatcher source — every abstract method returns {@code this}
+     *  or a sentinel.  Never actually attaches to a native peer. */
+    private static final class StubComponent extends WebViewComponent {
+        @Override public WebViewComponent setUrl(String url) { return this; }
+        @Override public String getUrl() { return ""; }
+        @Override public WebViewComponent setDebug(boolean debug) { return this; }
+        @Override public WebViewComponent addOnBeforeLoad(String js) { return this; }
+        @Override public WebViewComponent eval(String js) { return this; }
+        @Override public CompletableFuture<String> evalAsync(String js) {
+            CompletableFuture<String> f = new CompletableFuture<String>();
+            f.completeExceptionally(new IllegalStateException("stub"));
+            return f;
+        }
+        @Override public WebViewComponent addJavascriptCallback(
+                String name, WebView.JavascriptCallback cb) { return this; }
+        @Override public WebViewComponent dispatch(Runnable r) { return this; }
+        @Override public void dispose() { }
+    }
+
+    private StubComponent source;
+    private DialogDispatcher dispatcher;
+    private Thread.UncaughtExceptionHandler priorHandler;
+    private AtomicReference<Throwable> uncaught;
+
+    @Before
+    public void setUp() {
+        source = new StubComponent();
+        dispatcher = new DialogDispatcher(source);
+        priorHandler = Thread.getDefaultUncaughtExceptionHandler();
+        uncaught = new AtomicReference<Throwable>();
+        Thread.setDefaultUncaughtExceptionHandler(
+            new Thread.UncaughtExceptionHandler() {
+                @Override
+                public void uncaughtException(Thread t, Throwable e) {
+                    uncaught.compareAndSet(null, e);
+                }
+            });
+    }
+
+    @After
+    public void tearDown() {
+        Thread.setDefaultUncaughtExceptionHandler(priorHandler);
+    }
+
+    // -----------------------------------------------------------------
+    // Handler-reference lifecycle.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testDefaultHandlerIsDEFAULT() {
+        assertSame(WebViewDialogHandler.DEFAULT, dispatcher.getHandler());
+    }
+
+    @Test
+    public void testGetHandlerNeverReturnsNull() {
+        assertNotNull(dispatcher.getHandler());
+        dispatcher.setHandler(null);
+        assertNotNull(dispatcher.getHandler());
+        dispatcher.setHandler(WebViewDialogHandler.DEFAULT);
+        assertNotNull(dispatcher.getHandler());
+    }
+
+    @Test
+    public void testSetHandlerNullInstallsDrop() {
+        dispatcher.setHandler(null);
+        WebViewDialogHandler h = dispatcher.getHandler();
+        assertNotNull(h);
+        assertNotSame("DROP must not be identity-equal to DEFAULT",
+            WebViewDialogHandler.DEFAULT, h);
+    }
+
+    @Test
+    public void testSetHandlerCustomIsReturnedByGetter() {
+        WebViewDialogHandler custom = new WebViewDialogHandler() {};
+        dispatcher.setHandler(custom);
+        assertSame(custom, dispatcher.getHandler());
+    }
+
+    @Test
+    public void testSetHandlerDefaultAfterNullResets() {
+        dispatcher.setHandler(null);
+        assertNotSame(WebViewDialogHandler.DEFAULT, dispatcher.getHandler());
+        dispatcher.setHandler(WebViewDialogHandler.DEFAULT);
+        assertSame(WebViewDialogHandler.DEFAULT, dispatcher.getHandler());
+    }
+
+    // -----------------------------------------------------------------
+    // Drop-handler semantics (setHandler(null)).
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testDropAlertIsNoOp() {
+        dispatcher.setHandler(null);
+        // Should return normally without showing anything.
+        dispatcher.dispatchAlert("ping", "u", "f");
+    }
+
+    @Test
+    public void testDropConfirmReturnsFalse() {
+        dispatcher.setHandler(null);
+        assertFalse(dispatcher.dispatchConfirm("?", "u", "f"));
+    }
+
+    @Test
+    public void testDropPromptReturnsNull() {
+        dispatcher.setHandler(null);
+        assertNull(dispatcher.dispatchPrompt("?", "x", "u", "f"));
+    }
+
+    @Test
+    public void testDropFilePickerReturnsEmpty() {
+        dispatcher.setHandler(null);
+        String[] r = dispatcher.dispatchFilePicker(
+            false, null, null, "u", "f");
+        assertNotNull(r);
+        assertEquals(0, r.length);
+    }
+
+    // -----------------------------------------------------------------
+    // Custom handler invocation and event-field plumbing.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testDispatchAlertInvokesHandlerOnEdt() {
+        final AtomicReference<Boolean> onEdt = new AtomicReference<Boolean>();
+        final AtomicReference<WebViewAlertEvent> received =
+            new AtomicReference<WebViewAlertEvent>();
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public void alertOpened(WebViewAlertEvent e) {
+                onEdt.set(SwingUtilities.isEventDispatchThread());
+                received.set(e);
+            }
+        });
+        dispatcher.dispatchAlert("msg", "http://a", "http://b");
+        assertEquals(Boolean.TRUE, onEdt.get());
+        assertNotNull(received.get());
+        assertEquals("msg", received.get().message());
+        assertEquals("http://a", received.get().pageUrl());
+        assertEquals("http://b", received.get().frameUrl());
+        assertSame(source, received.get().source());
+    }
+
+    @Test
+    public void testDispatchConfirmReturnsHandlerValue() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public boolean confirmOpened(WebViewConfirmEvent e) { return true; }
+        });
+        assertTrue(dispatcher.dispatchConfirm("?", "u", "f"));
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public boolean confirmOpened(WebViewConfirmEvent e) { return false; }
+        });
+        assertFalse(dispatcher.dispatchConfirm("?", "u", "f"));
+    }
+
+    @Test
+    public void testDispatchPromptReturnsHandlerValue() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public String promptOpened(WebViewPromptEvent e) {
+                return "answer:" + e.defaultValue();
+            }
+        });
+        assertEquals("answer:x",
+            dispatcher.dispatchPrompt("msg", "x", "u", "f"));
+    }
+
+    @Test
+    public void testDispatchPromptHandlerReturningNullReturnsNull() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public String promptOpened(WebViewPromptEvent e) { return null; }
+        });
+        assertNull(dispatcher.dispatchPrompt("?", "", "u", "f"));
+    }
+
+    @Test
+    public void testDispatchFilePickerReturnsHandlerPaths() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+                return Arrays.asList(
+                    new File("/tmp/a.png"), new File("/tmp/b.png"));
+            }
+        });
+        String[] r = dispatcher.dispatchFilePicker(
+            true, new String[0], new String[]{"png"}, "u", "f");
+        assertArrayEquals(
+            new String[]{"/tmp/a.png", "/tmp/b.png"}, r);
+    }
+
+    @Test
+    public void testDispatchFilePickerHandlerEmptyReturnsEmpty() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+                return Collections.emptyList();
+            }
+        });
+        String[] r = dispatcher.dispatchFilePicker(
+            false, null, null, "u", "f");
+        assertNotNull(r);
+        assertEquals(0, r.length);
+    }
+
+    @Test
+    public void testDispatchFilePickerHandlerNullReturnsEmpty() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+                return null;
+            }
+        });
+        String[] r = dispatcher.dispatchFilePicker(
+            false, null, null, "u", "f");
+        assertNotNull(r);
+        assertEquals(0, r.length);
+    }
+
+    // -----------------------------------------------------------------
+    // Accept-attribute normalisation.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testNormaliseExtensionsLowercaseStripDotDedupe() {
+        final AtomicReference<List<String>> seen =
+            new AtomicReference<List<String>>();
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+                seen.set(new ArrayList<String>(e.acceptedExtensions()));
+                return Collections.emptyList();
+            }
+        });
+        dispatcher.dispatchFilePicker(false, null,
+            new String[]{".PNG", "JPG", ".png", "", null, "JPEG"},
+            "u", "f");
+        assertEquals(Arrays.asList("png", "jpg", "jpeg"), seen.get());
+    }
+
+    @Test
+    public void testNormaliseMimeTypesLowercaseDedupe() {
+        final AtomicReference<List<String>> seen =
+            new AtomicReference<List<String>>();
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+                seen.set(new ArrayList<String>(e.acceptedMimeTypes()));
+                return Collections.emptyList();
+            }
+        });
+        dispatcher.dispatchFilePicker(true,
+            new String[]{"Image/PNG", "image/png", "image/*"},
+            null, "u", "f");
+        assertEquals(Arrays.asList("image/png", "image/*"), seen.get());
+    }
+
+    @Test
+    public void testNormaliseAcceptHandlesNullArrays() {
+        final AtomicReference<WebViewFilePickerEvent> seen =
+            new AtomicReference<WebViewFilePickerEvent>();
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+                seen.set(e);
+                return Collections.emptyList();
+            }
+        });
+        dispatcher.dispatchFilePicker(false, null, null, "u", "f");
+        assertNotNull(seen.get());
+        assertTrue(seen.get().acceptedExtensions().isEmpty());
+        assertTrue(seen.get().acceptedMimeTypes().isEmpty());
+    }
+
+    // -----------------------------------------------------------------
+    // Exception isolation.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testHandlerExceptionAlertIsolated() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public void alertOpened(WebViewAlertEvent e) {
+                throw new RuntimeException("boom-alert");
+            }
+        });
+        dispatcher.dispatchAlert("x", "u", "f"); // must not throw
+        waitForUncaught();
+        assertNotNull("uncaught handler should have received the exception",
+            uncaught.get());
+        assertEquals("boom-alert", uncaught.get().getMessage());
+    }
+
+    @Test
+    public void testHandlerExceptionConfirmReturnsFalse() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public boolean confirmOpened(WebViewConfirmEvent e) {
+                throw new RuntimeException("boom-confirm");
+            }
+        });
+        assertFalse(dispatcher.dispatchConfirm("?", "u", "f"));
+        waitForUncaught();
+        assertNotNull(uncaught.get());
+    }
+
+    @Test
+    public void testHandlerExceptionPromptReturnsNull() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public String promptOpened(WebViewPromptEvent e) {
+                throw new RuntimeException("boom-prompt");
+            }
+        });
+        assertNull(dispatcher.dispatchPrompt("?", "", "u", "f"));
+        waitForUncaught();
+        assertNotNull(uncaught.get());
+    }
+
+    @Test
+    public void testHandlerExceptionFilePickerReturnsEmpty() {
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+                throw new RuntimeException("boom-file");
+            }
+        });
+        String[] r = dispatcher.dispatchFilePicker(
+            false, null, null, "u", "f");
+        assertNotNull(r);
+        assertEquals(0, r.length);
+        waitForUncaught();
+        assertNotNull(uncaught.get());
+    }
+
+    // -----------------------------------------------------------------
+    // Disposal semantics.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testDisposedDispatcherReturnsFallbacks() {
+        // Install a handler that would throw if invoked — the dispatcher
+        // must NOT invoke it after dispose.
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override public void alertOpened(WebViewAlertEvent e) {
+                throw new AssertionError("handler invoked after dispose");
+            }
+            @Override public boolean confirmOpened(WebViewConfirmEvent e) {
+                throw new AssertionError("handler invoked after dispose");
+            }
+            @Override public String promptOpened(WebViewPromptEvent e) {
+                throw new AssertionError("handler invoked after dispose");
+            }
+            @Override public List<File> filePickerOpened(WebViewFilePickerEvent e) {
+                throw new AssertionError("handler invoked after dispose");
+            }
+        });
+        dispatcher.disposeAll();
+        assertTrue(dispatcher.isDisposed());
+        dispatcher.dispatchAlert("x", "u", "f");
+        assertFalse(dispatcher.dispatchConfirm("?", "u", "f"));
+        assertNull(dispatcher.dispatchPrompt("?", "", "u", "f"));
+        String[] r = dispatcher.dispatchFilePicker(false, null, null, "u", "f");
+        assertNotNull(r);
+        assertEquals(0, r.length);
+    }
+
+    @Test
+    public void testDisposeAllIsIdempotent() {
+        dispatcher.disposeAll();
+        dispatcher.disposeAll();
+        assertTrue(dispatcher.isDisposed());
+    }
+
+    // -----------------------------------------------------------------
+    // EDT short-circuit.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testDispatchFromEdtShortCircuits() throws Exception {
+        final AtomicReference<Boolean> onEdt = new AtomicReference<Boolean>();
+        dispatcher.setHandler(new WebViewDialogHandler() {
+            @Override
+            public boolean confirmOpened(WebViewConfirmEvent e) {
+                onEdt.set(SwingUtilities.isEventDispatchThread());
+                return true;
+            }
+        });
+        // Dispatch from the EDT itself — must not deadlock and must
+        // still report EDT execution.
+        final boolean[] result = new boolean[1];
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override public void run() {
+                result[0] = dispatcher.dispatchConfirm("?", "u", "f");
+            }
+        });
+        assertTrue(result[0]);
+        assertEquals(Boolean.TRUE, onEdt.get());
+    }
+
+    // -----------------------------------------------------------------
+    // Constructor null-checks.
+    // -----------------------------------------------------------------
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructorRejectsNullSource() {
+        new DialogDispatcher(null);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers.
+    // -----------------------------------------------------------------
+
+    /** Spin briefly waiting for the uncaught-exception handler to be
+     *  invoked.  The dispatcher's exception forwarding is synchronous
+     *  from the EDT path, so this should always observe the exception
+     *  almost immediately; we still allow a tiny grace window in case
+     *  a JVM schedules the uncaught-handler asynchronously. */
+    private void waitForUncaught() {
+        long deadline = System.currentTimeMillis() + 500;
+        while (uncaught.get() == null
+            && System.currentTimeMillis() < deadline) {
+            try { Thread.sleep(5); } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+}

--- a/windows/script/build.bat
+++ b/windows/script/build.bat
@@ -33,6 +33,7 @@ call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x86 -host_arch=x64
 echo Building webview.dll (x86)
 mkdir "%src_dir%\dll\x86"
 cl /D "WEBVIEW_API=__declspec(dllexport)" ^
+	/D "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" ^
 	/I "%JAVA_HOME%\include" /I "%JAVA_HOME%\include\win32" ^
 	/I "%src_dir%\script\Microsoft.Web.WebView2.0.8.355\build\native\include" ^
 	"%src_dir%\script\Microsoft.Web.WebView2.0.8.355\build\native\x86\WebView2Loader.dll.lib" ^
@@ -47,6 +48,7 @@ call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
 echo Building webview.dll (x64)
 mkdir "%src_dir%\dll\x64"
 cl /D "WEBVIEW_API=__declspec(dllexport)" ^
+    /D "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" ^
     /I "%JAVA_HOME%\include" /I "%JAVA_HOME%\include\win32" ^
 	/I "%src_dir%\script\Microsoft.Web.WebView2.0.8.355\build\native\include" ^
 	"%src_dir%\script\Microsoft.Web.WebView2.0.8.355\build\native\x64\WebView2Loader.dll.lib" ^

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -21,6 +21,8 @@
 
 #include <atomic>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <functional>
 #include <map>
 #include <memory>
@@ -107,6 +109,12 @@ struct Engine {
     EventRegistrationToken message_token{};
     EventRegistrationToken got_focus_token{};
     EventRegistrationToken lost_focus_token{};
+    // EventRegistrationToken for the ScriptDialogOpening handler
+    // registered in create_engine.  Not explicitly removed in
+    // destroy_engine -- the controller / webview Release calls
+    // there detach all event handlers transitively (same as
+    // message_token / got_focus_token / lost_focus_token).
+    EventRegistrationToken script_dialog_token{};
     std::map<std::string, Binding *> bindings;
     JavaVM *jvm = nullptr;
     bool debug = false;
@@ -183,6 +191,171 @@ static void fire_click_callback(Engine *e) {
     if (detach) jvm->DetachCurrentThread();
 }
 
+// ---------------------------------------------------------------------------
+// JS-initiated UI dialog bridge for WebView2.
+//
+// Three helpers mirroring the Linux fire_dialog_* shape (canvas-12 /
+// STORY-004-002), used by ScriptDialogHandler::Invoke below.  Each helper
+// attaches the spawned worker thread to the JVM, calls one of the three
+// WebViewDialogCallback methods, sanitises any pending Java exception, and
+// detaches.  Method names / signatures are byte-identical across all three
+// platform binaries -- the same Java WebViewDialogCallback interface is the
+// target.
+//
+// No fire_dialog_file_picker on Windows: WebView2 exposes no public hook
+// for <input type=file>, so the file picker continues to use the OS-native
+// Common Item Dialog and WebViewFilePickerEvent never fires on Windows.
+// Documented platform limitation per canvas-11 / STORY-004-003 AC4.
+// ---------------------------------------------------------------------------
+
+static void fire_dialog_alert(JavaVM *jvm, jobject callback,
+                              const char *message,
+                              const char *pageUrl,
+                              const char *frameUrl) {
+    if (!jvm || !callback) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            return;
+        }
+        detach = true;
+    }
+    if (!env) {
+        if (detach) jvm->DetachCurrentThread();
+        return;
+    }
+    jstring jmsg = env->NewStringUTF(message ? message : "");
+    jstring jpage = env->NewStringUTF(pageUrl ? pageUrl : "");
+    jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onAlert",
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+        if (m) {
+            env->CallVoidMethod(callback, m, jmsg, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmsg) env->DeleteLocalRef(jmsg);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+static jboolean fire_dialog_confirm(JavaVM *jvm, jobject callback,
+                                    const char *message,
+                                    const char *pageUrl,
+                                    const char *frameUrl) {
+    if (!jvm || !callback) return JNI_FALSE;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            return JNI_FALSE;
+        }
+        detach = true;
+    }
+    if (!env) {
+        if (detach) jvm->DetachCurrentThread();
+        return JNI_FALSE;
+    }
+    jboolean result = JNI_FALSE;
+    jstring jmsg = env->NewStringUTF(message ? message : "");
+    jstring jpage = env->NewStringUTF(pageUrl ? pageUrl : "");
+    jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onConfirm",
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z");
+        if (m) {
+            result = env->CallBooleanMethod(callback, m, jmsg, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                result = JNI_FALSE;
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmsg) env->DeleteLocalRef(jmsg);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (detach) jvm->DetachCurrentThread();
+    return result;
+}
+
+// Caller MUST free() the returned string when done.  Returns nullptr
+// for cancel (Java returned null) or any error path -- the completion
+// lambda treats nullptr as cancel and skips the put_ResultText / Accept
+// calls so WebView2 reports null to the page.
+static char *fire_dialog_prompt(JavaVM *jvm, jobject callback,
+                                const char *message,
+                                const char *defaultValue,
+                                const char *pageUrl,
+                                const char *frameUrl) {
+    if (!jvm || !callback) return nullptr;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            return nullptr;
+        }
+        detach = true;
+    }
+    if (!env) {
+        if (detach) jvm->DetachCurrentThread();
+        return nullptr;
+    }
+    char *result = nullptr;
+    jstring jmsg = env->NewStringUTF(message ? message : "");
+    jstring jdefault = env->NewStringUTF(defaultValue ? defaultValue : "");
+    jstring jpage = env->NewStringUTF(pageUrl ? pageUrl : "");
+    jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onPrompt",
+            "(Ljava/lang/String;Ljava/lang/String;"
+            "Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+        if (m) {
+            jstring jresult = (jstring)env->CallObjectMethod(
+                callback, m, jmsg, jdefault, jpage, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                jresult = nullptr;
+            }
+            if (jresult) {
+                const char *cstr = env->GetStringUTFChars(jresult, nullptr);
+                if (cstr) {
+                    size_t n = strlen(cstr);
+                    result = (char *)malloc(n + 1);
+                    if (result) memcpy(result, cstr, n + 1);
+                    env->ReleaseStringUTFChars(jresult, cstr);
+                }
+                env->DeleteLocalRef(jresult);
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jmsg) env->DeleteLocalRef(jmsg);
+    if (jdefault) env->DeleteLocalRef(jdefault);
+    if (jpage) env->DeleteLocalRef(jpage);
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (detach) jvm->DetachCurrentThread();
+    return result;  // caller owns; free with free()
+}
+
 // IUnknown helper -- gives each WebView2 callback proper refcounting and
 // QueryInterface support.  The interfaces we implement are all single-
 // inheritance (Iface : IUnknown), so a templated base keeps boilerplate low.
@@ -242,6 +415,8 @@ private:
 // Forward declarations.
 static void engine_on_message(Engine *e, LPCWSTR msg);
 static std::wstring utf8_to_wide(const char *s);
+static std::string wide_to_utf8(LPCWSTR w);
+static void dispatch_to_thread(Engine *e, DispatchFn fn);
 
 class FocusHandler : public CallbackBase<
     ICoreWebView2FocusChangedEventHandler> {
@@ -274,6 +449,136 @@ public:
             engine_on_message(m_engine, msg);
             CoTaskMemFree(msg);
         }
+        return S_OK;
+    }
+private:
+    Engine *m_engine;
+};
+
+// ScriptDialogHandler -- bridges WebView2's ScriptDialogOpening event to the
+// per-engine Java DialogDispatcher (canvas-13 / STORY-004-003).  Invoke runs
+// on the WebView2 worker thread per Microsoft's threading model; we must NOT
+// block it synchronously waiting for the EDT (the completion-side
+// dispatch_to_thread would self-deadlock).  Instead we GetDeferral, spawn a
+// short-lived std::thread for the JNI hop into DialogDispatcher (which does
+// SwingUtilities.invokeAndWait), and once the answer is in hand we
+// dispatch_to_thread back onto the WebView2 worker to call
+// Accept / put_ResultText / Complete in the right COM apartment.
+//
+// `args` and `deferral` are AddRef'd before the worker thread launches and
+// Release'd inside the completion lambda -- WebView2 would otherwise release
+// the args between the S_OK return and the completion.
+//
+// On null dialog_callback the safe-default path runs (alert: Accept; confirm:
+// don't Accept -> page sees false; prompt: don't put_ResultText / Accept ->
+// page sees null) so the page's JS thread always resumes.  before-unload
+// routes to fire_dialog_confirm, matching Linux behaviour.  File picker is
+// NOT intercepted -- WebView2 has no public hook.
+class ScriptDialogHandler : public CallbackBase<
+    ICoreWebView2ScriptDialogOpeningEventHandler> {
+public:
+    explicit ScriptDialogHandler(Engine *e) : m_engine(e) {}
+    HRESULT STDMETHODCALLTYPE Invoke(
+        ICoreWebView2 *,
+        ICoreWebView2ScriptDialogOpeningEventArgs *args) override {
+        if (!args || !m_engine) return S_OK;
+
+        COREWEBVIEW2_SCRIPT_DIALOG_KIND kind =
+            COREWEBVIEW2_SCRIPT_DIALOG_KIND_ALERT;
+        args->get_Kind(&kind);
+
+        LPWSTR uri_w = nullptr;
+        LPWSTR msg_w = nullptr;
+        LPWSTR def_w = nullptr;
+        args->get_Uri(&uri_w);
+        args->get_Message(&msg_w);
+        if (kind == COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT) {
+            args->get_DefaultText(&def_w);
+        }
+        std::string uri = wide_to_utf8(uri_w);
+        std::string msg = wide_to_utf8(msg_w);
+        std::string def = wide_to_utf8(def_w);
+        if (uri_w) CoTaskMemFree(uri_w);
+        if (msg_w) CoTaskMemFree(msg_w);
+        if (def_w) CoTaskMemFree(def_w);
+
+        ICoreWebView2Deferral *deferral = nullptr;
+        HRESULT hr = args->GetDeferral(&deferral);
+        if (FAILED(hr) || !deferral) {
+            // Can't defer -- the SDK refused to hand us a deferral.  Rare;
+            // log and let WebView2's default-suppressed flow take its
+            // course (page receives the JS-spec default for each kind).
+            WV_LOG("GetDeferral failed: HRESULT=0x%08lx",
+                   (unsigned long)hr);
+            return S_OK;
+        }
+        args->AddRef();
+
+        Engine *e = m_engine;
+        std::thread([e, args, deferral, kind, uri, msg, def] {
+            jobject cb = e ? e->dialog_callback : nullptr;
+            JavaVM *jvm = e ? e->jvm : nullptr;
+            jboolean confirmed = JNI_FALSE;
+            char *prompt_answer = nullptr;
+            switch (kind) {
+                case COREWEBVIEW2_SCRIPT_DIALOG_KIND_ALERT:
+                    if (cb) fire_dialog_alert(
+                        jvm, cb, msg.c_str(),
+                        uri.c_str(), uri.c_str());
+                    break;
+                case COREWEBVIEW2_SCRIPT_DIALOG_KIND_CONFIRM:
+                case COREWEBVIEW2_SCRIPT_DIALOG_KIND_BEFOREUNLOAD:
+                    if (cb) confirmed = fire_dialog_confirm(
+                        jvm, cb, msg.c_str(),
+                        uri.c_str(), uri.c_str());
+                    break;
+                case COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT:
+                    if (cb) prompt_answer = fire_dialog_prompt(
+                        jvm, cb, msg.c_str(), def.c_str(),
+                        uri.c_str(), uri.c_str());
+                    break;
+                default:
+                    break;
+            }
+
+            // Marshal back onto the WebView2 worker thread; ICoreWebView2*
+            // methods are apartment-bound to the engine's worker, so
+            // Accept / put_ResultText / Complete must NOT run on the Java
+            // worker thread we're currently in.
+            dispatch_to_thread(e, [args, deferral, kind, confirmed,
+                                   prompt_answer] {
+                switch (kind) {
+                    case COREWEBVIEW2_SCRIPT_DIALOG_KIND_ALERT:
+                        args->Accept();
+                        break;
+                    case COREWEBVIEW2_SCRIPT_DIALOG_KIND_CONFIRM:
+                    case COREWEBVIEW2_SCRIPT_DIALOG_KIND_BEFOREUNLOAD:
+                        if (confirmed == JNI_TRUE) args->Accept();
+                        // else: don't Accept -- WebView2 returns false to
+                        // the page.
+                        break;
+                    case COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT:
+                        if (prompt_answer != nullptr) {
+                            std::wstring wtxt = utf8_to_wide(prompt_answer);
+                            args->put_ResultText(wtxt.c_str());
+                            args->Accept();
+                            free(prompt_answer);
+                        }
+                        // else: don't put_ResultText, don't Accept --
+                        // WebView2 returns null to the page.
+                        break;
+                    default:
+                        // Unknown future SDK kind: just Complete the
+                        // deferral without Accept; the page sees the
+                        // JS-spec default.
+                        break;
+                }
+                deferral->Complete();
+                deferral->Release();
+                args->Release();
+            });
+        }).detach();
+
         return S_OK;
     }
 private:
@@ -433,6 +738,11 @@ static void engine_thread(Engine *e, HWND /*parent*/, int width, int height,
                         settings->put_AreDevToolsEnabled(
                             e->debug ? TRUE : FALSE);
                         settings->put_AreDefaultContextMenusEnabled(TRUE);
+                        // Suppress WebView2's built-in alert / confirm /
+                        // prompt dialogs.  Java drives the response via
+                        // the ScriptDialogHandler registered below.
+                        // STORY-004-003.
+                        settings->put_AreDefaultScriptDialogsEnabled(FALSE);
                         settings->Release();
                     }
 
@@ -447,6 +757,20 @@ static void engine_thread(Engine *e, HWND /*parent*/, int width, int height,
                     auto *mh = new MsgHandler(e);
                     e->webview->add_WebMessageReceived(mh, &e->message_token);
                     mh->Release();
+
+                    // Wire JS-initiated dialogs (alert / confirm / prompt
+                    // / before-unload) to the per-engine Java
+                    // DialogDispatcher via the dialog_callback global ref.
+                    // WebView2's built-in dialogs are suppressed by
+                    // put_AreDefaultScriptDialogsEnabled(FALSE) above.
+                    // File picker (<input type=file>) is NOT intercepted
+                    // -- WebView2 exposes no public hook; the OS-native
+                    // Common Item Dialog continues to appear as before.
+                    // STORY-004-003.
+                    auto *sdh = new ScriptDialogHandler(e);
+                    e->webview->add_ScriptDialogOpening(
+                        sdh, &e->script_dialog_token);
+                    sdh->Release();
 
                     // Hook GotFocus / LostFocus on the controller so the
                     // Java side can suppress and restore the previously-
@@ -658,6 +982,23 @@ static std::wstring utf8_to_wide(const char *s) {
     MultiByteToWideChar(CP_UTF8, 0, s, -1, &w[0], n);
     if (!w.empty() && w.back() == L'\0') w.pop_back();
     return w;
+}
+
+// Convert a (possibly null) UTF-16 LPWSTR to a UTF-8 std::string.
+// Returns the empty string for null / empty input or on WideCharToMultiByte
+// failure.  Used by ScriptDialogHandler::Invoke to copy the COM-allocated
+// args strings into UTF-8 std::strings BEFORE the JNI worker thread runs,
+// so we can CoTaskMemFree the LPWSTRs while still on the WebView2 worker
+// (mirrors the inline pattern already used in engine_on_message).
+static std::string wide_to_utf8(LPCWSTR w) {
+    if (!w || *w == L'\0') return std::string();
+    int n = WideCharToMultiByte(CP_UTF8, 0, w, -1, nullptr, 0,
+                                nullptr, nullptr);
+    if (n <= 0) return std::string();
+    std::string s(n, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, w, -1, &s[0], n, nullptr, nullptr);
+    if (!s.empty() && s.back() == '\0') s.pop_back();
+    return s;
 }
 
 } // namespace embed_win

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -122,6 +122,14 @@ struct Engine {
     // into the WebView (AWT's MouseGrabber AWTEventListener never sees
     // those clicks because they reach the WebView2 HWND directly).
     jobject click_callback = nullptr;
+    // JNI global ref to the registered WebViewDialogCallback, or nullptr.
+    // Storage only in this canvas (STORY-004-001) -- STORY-004-003 wires
+    // ICoreWebView2::add_ScriptDialogOpening + AreDefaultScriptDialogsEnabled(FALSE)
+    // to actually invoke this callback for JS alert / confirm / prompt.
+    // The Windows file picker remains OS-native (WebView2 exposes no
+    // public hook for <input type=file>), so this callback is never
+    // invoked for the file-picker event kind on Windows.
+    jobject dialog_callback = nullptr;
 };
 
 static void fire_focus_callback(Engine *e, bool became) {
@@ -605,6 +613,22 @@ static void destroy_engine(Engine *e) {
         e->click_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
+    // Symmetric cleanup for the dialog callback global ref.  Storage
+    // only in this canvas; STORY-004-003 will fire the ScriptDialogOpening
+    // event handler off this field, so the symmetric cleanup is required
+    // even though STORY-004-001 itself never invokes the callback on
+    // Windows.
+    if (e->dialog_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->dialog_callback);
+        e->dialog_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     {
         std::lock_guard<std::mutex> lk(e->bindings_mutex);
         for (auto &kv : e->bindings) {
@@ -941,6 +965,33 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
     if (cb) {
         e->click_callback = env->NewGlobalRef(cb);
     }
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1dialog_1callback
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+    // Store the Java callback (JNI global ref) on the Engine.
+    // STORY-004-001 only ships storage on Windows -- STORY-004-003
+    // wires the ICoreWebView2::add_ScriptDialogOpening event handler
+    // off this field plus put_AreDefaultScriptDialogsEnabled(FALSE) so
+    // built-in WebView2 dialogs are suppressed and JS alert / confirm /
+    // prompt route through Java instead.  <input type=file> remains
+    // OS-native on Windows -- WebView2 exposes no public hook for it.
+    auto *e = (Engine *)wv;
+    if (!e) return;
+    if (e->dialog_callback) {
+        env->DeleteGlobalRef(e->dialog_callback);
+        e->dialog_callback = nullptr;
+    }
+    if (cb) {
+        e->dialog_callback = env->NewGlobalRef(cb);
+    }
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1dialog_1callback
+  (JNIEnv *, jclass, jlong, jobject) {
+    // Windows has no offscreen engine; OffscreenWebView.create returns
+    // null on Windows so this JNI bridge should never be reached.
+    // Stub it for link-symmetry across all three native binaries.
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1release_1native_1focus


### PR DESCRIPTION
## Summary

Implements the cross-platform browser-initiated UI dialog API for WebViewComponent, allowing JavaScript `alert()`, `confirm()`, `prompt()` calls and `<input type="file">` clicks to surface as Swing dialogs on the host JFrame. Provides a `WebViewDialogHandler` interface for customization and a default implementation using `JOptionPane` and `JFileChooser`.

This PR completes STORY-004-001 (macOS WKWebView coverage) and includes the foundational Java API and dispatcher infrastructure shared by all platforms.

## Key Changes

**Java API & Infrastructure:**
- Added `WebViewDialogHandler` interface with four `default` methods (`alertOpened`, `confirmOpened`, `promptOpened`, `filePickerOpened`) that show standard Swing dialogs modal to the host window
- Added four immutable event POJOs: `WebViewAlertEvent`, `WebViewConfirmEvent`, `WebViewPromptEvent`, `WebViewFilePickerEvent` carrying dialog context (message, default value, page/frame URLs, MIME types, file extensions)
- Added `DialogDispatcher` — internal per-component hub that marshals native dialog callbacks onto the Swing EDT via `SwingUtilities.invokeAndWait`, invokes the active handler, and returns the result to the native layer
- Added `WebViewDialogCallback` — internal JNI bridge interface (four methods: `onAlert`, `onConfirm`, `onPrompt`, `onFilePicker`)
- Extended `WebViewComponent`, `EmbeddedWebView`, `OffscreenWebView` with `setDialogHandler()` / `getDialogHandler()` public API
- Extended `WebViewNative` with native binding declarations for dialog callback registration

**Native Layer (Linux/Windows/macOS preparation):**
- Added `dialog_callback` `jobject` field to both `Engine` (Windows) and `OffEngine` (Linux) structs to hold the JNI global ref
- Added JNI helper functions on Windows (`fire_dialog_alert`, `fire_dialog_confirm`, `fire_dialog_prompt`) mirroring the Linux pattern — attach/detach JVM, invoke callback methods, sanitize exceptions
- Added `script_dialog_token` `EventRegistrationToken` field to Windows `Engine` struct for future ScriptDialogOpening handler registration

**Testing & Documentation:**
- Added `DialogDispatcherTest` — 474-line unit test suite covering handler registration, EDT marshaling, drop semantics, exception isolation, accept-attribute normalization, and dispose lifecycle
- Added `WebViewDialogDemo` — interactive Swing harness demonstrating three handler modes (default Swing dialogs, custom programmatic answers, drop/suppress)
- Added comprehensive SPDD artifacts:
  - `requirements/[User-story-4]browser-initiated-ui-dialogs.md` — full user story with INVEST analysis and 20+ acceptance criteria
  - `spdd/analysis/GGQPA-XXX-202605181830-[Analysis]-browser-initiated-ui-dialogs.md` — design analysis covering all three platform stories
  - `spdd/prompt/11-*-[Feat]-Browser-Initiated-Ui-Dialogs-And-Macos-Coverage.md` — REASONS Canvas for macOS (STORY-004-001)
  - `spdd/prompt/12-*-[Feat]-Browser-Initiated-Ui-Dialogs-Linux-Coverage.md` — REASONS Canvas for Linux (STORY-004-002)
  - `spdd/prompt/13-*-[Feat]-Browser-Initiated-Ui-Dialogs-Windows-Coverage.md` — REASONS Canvas for Windows (STORY-004-003)
- Updated README with browser-initiated dialogs section and platform-specific notes

**Build:**
- Updated GitHub Actions workflow to run `mvn package` (including unit tests) instead of `mvn verify`

## Implementation Notes

- **Threading model:** Dialog callbacks fire on native UI threads (AppKit main on macOS, GTK main on Linux, WebView2 worker on Windows). `DialogDispatcher` marshals onto Swing EDT via `invokeAndWait` to

https://claude.ai/code/session_01ApsSJzGzQ7Ao71C22MUMfV