### PR TITLE
Fix EDT deadlock in cocoa_run_on_main by using performSelector

### DIFF
--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -1700,6 +1700,39 @@ Files:
   than adding new native hooks per use case. Keep the Java
   handler narrowly scoped so the call cost is bounded for
   every WebView click.
+- macOS sync main-thread dispatch (`embed::cocoa_run_on_main` in
+  `src_c/webview_embed.cpp`) MUST NOT use
+  `dispatch_sync(dispatch_get_main_queue(), …)` from the EDT.
+  AppKit's main thread routinely parks inside
+  `-[LWCToolkit doAWTRunLoopImpl]`'s private CFRunLoop while it
+  waits for the EDT to answer a JNI callback (the AX
+  `accessibilityFocusedUIElement` query during a VoiceOver
+  focus-changed event is the canonical trigger, but any
+  AppKit→Java upcall through `doAWTRunLoopImpl` qualifies —
+  IME callbacks, AWT-EDT round-trips). That private runloop
+  runs only in `@"AWTRunLoopMode"` and does NOT drain the main
+  dispatch queue; combined with the EDT blocking on
+  `dispatch_sync` waiting for the main thread, this is an
+  unconditional EDT-↔-main deadlock. The fix — required for
+  every sync main-thread bridge in this codebase — is to use
+  `-[NSObject performSelectorOnMainThread:withObject:
+  waitUntilDone:YES modes:]` with a mode array that includes
+  `@"AWTRunLoopMode"` alongside the normal AppKit modes
+  (`kCFRunLoopDefaultMode`, `NSEventTrackingRunLoopMode`,
+  `NSModalPanelRunLoopMode`). This matches the JDK's own
+  `sun.lwawt.macosx.ThreadUtilities.javaModes` set and is the
+  canonical "talk to AppKit from a JNI call on the EDT"
+  pattern. The wrapper class
+  (`WebViewAwtMainBridge` / `performWork:`) is registered once
+  per JVM via `std::call_once`, symmetric with the existing
+  swizzle / `WebviewEmbedDelegate` once-only registrations.
+  See the bug report "WebViewHeavyweightComponent deadlocks the
+  EDT when the WebView peer is created during macOS
+  accessibility focus events" for the original trace. The
+  async helper `cocoa_run_on_main_async` is unaffected — it
+  uses `dispatch_async_f` and never blocks the EDT, so a queued
+  block sitting in the main queue while
+  `doAWTRunLoopImpl` runs is latency, not deadlock.
 
 ## S · Safeguards
 - `EmbeddedWebView.attach` validates `parent != null` AND

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -1593,29 +1593,130 @@ struct Engine {
 static std::mutex g_webview_map_mutex;
 static std::map<id, Engine *> g_webview_map;
 
+// Heap-allocated work item passed across the EDT → AppKit main bridge.
+// Lives until the main-thread method runs and deletes it.
+struct AwtBridgeWork {
+    std::function<void()> fn;
+};
+
+// Implementation of -[WebViewAwtMainBridge performWork:].  Runs on the
+// AppKit main thread; receives an NSValue wrapping an AwtBridgeWork *,
+// extracts the function, runs it, and deletes the work item.  The class
+// itself is allocated lazily in ensure_awt_main_bridge.
+static void awt_main_bridge_perform_impl(id /*self*/, SEL /*_cmd*/, id arg) {
+    if (!arg) return;
+    void *p = msg<void *>(arg, sel("pointerValue"));
+    if (!p) return;
+    auto *work = static_cast<AwtBridgeWork *>(p);
+    work->fn();
+    delete work;
+}
+
+// Process-global state for the AWT main-thread bridge.  We allocate one
+// Objective-C class (WebViewAwtMainBridge), one shared instance of it
+// (the target of every performSelectorOnMainThread: call), and one
+// NSArray of run-loop modes.  Initialised exactly once per JVM via
+// std::call_once -- objc_allocateClassPair returns Nil on second call
+// for the same name.
+static Class g_awt_main_bridge_cls = nil;
+static id g_awt_main_bridge_target = nil;
+static id g_awt_main_bridge_modes = nil;
+static std::once_flag g_awt_main_bridge_once;
+
+static void ensure_awt_main_bridge() {
+    std::call_once(g_awt_main_bridge_once, [] {
+        Class c = objc_allocateClassPair((Class)objc_cls("NSObject"),
+                                         "WebViewAwtMainBridge", 0);
+        class_addMethod(c, sel("performWork:"),
+                        (IMP)awt_main_bridge_perform_impl, "v@:@");
+        objc_registerClassPair(c);
+        g_awt_main_bridge_cls = c;
+        // [new] returns a +1-retained instance; keep it forever.
+        g_awt_main_bridge_target = msg((id)c, sel("new"));
+
+        // Build the modes list under which the main thread will service
+        // our performSelector dispatch.  The critical entry here is
+        // "AWTRunLoopMode" -- the private CFRunLoop mode the JDK enters
+        // from -[LWCToolkit doAWTRunLoopImpl] when AppKit calls into
+        // Java from the main thread (accessibility role queries during a
+        // VoiceOver / AX focus-changed event, IME callbacks, etc) and
+        // pumps a nested runloop waiting for the EDT to respond.  In
+        // that mode the main dispatch queue is NOT drained, so the
+        // previous dispatch_sync(main_queue, ...)-based implementation
+        // deadlocked: the EDT was already blocked in
+        // webview_embed_create, so the AX query the main thread was
+        // waiting on never got serviced, and our queued block on the
+        // main queue never got drained either.  Adding AWTRunLoopMode
+        // here lets the main thread service the perform from inside
+        // doAWTRunLoopImpl's nested CFRunLoop, breaking the cycle.
+        //
+        // The other modes mirror what the JDK's own ThreadUtilities
+        // installs (kCFRunLoopDefaultMode, NSEventTrackingRunLoopMode
+        // for live resize / drag, NSModalPanelRunLoopMode for modal
+        // panels) so we keep being serviced through every CFRunLoop
+        // mode AppKit normally runs in.
+        id arr = msg(objc_cls("NSMutableArray"), sel("alloc"));
+        arr = msg(arr, sel("init"));
+        msg<void, id>(arr, sel("addObject:"),
+                      ns_str("kCFRunLoopDefaultMode"));
+        msg<void, id>(arr, sel("addObject:"), ns_str("AWTRunLoopMode"));
+        msg<void, id>(arr, sel("addObject:"),
+                      ns_str("NSEventTrackingRunLoopMode"));
+        msg<void, id>(arr, sel("addObject:"),
+                      ns_str("NSModalPanelRunLoopMode"));
+        g_awt_main_bridge_modes = arr;
+    });
+}
+
+// Wrap `work` in an NSValue (no autorelease -- we hand-manage the +1).
+// Caller owns one ref; release after the perform call returns.
+static id awt_bridge_box(AwtBridgeWork *work) {
+    void *ptr_val = work;
+    id arg = msg(objc_cls("NSValue"), sel("alloc"));
+    arg = msg<id, const void *, const char *>(
+        arg, sel("initWithBytes:objCType:"), &ptr_val, "^v");
+    return arg;
+}
+
 static void cocoa_run_on_main(std::function<void()> f) {
-    // If we're already on the AppKit main thread, just run f inline; otherwise
-    // dispatch_sync to the main queue.  Synchronously dispatching onto your
-    // own queue deadlocks, which is easy to hit when a script-message handler
-    // (which runs on the main thread) ends up calling back into the embed API.
+    // If we're already on the AppKit main thread, just run f inline.
+    // Otherwise route through -[NSObject performSelectorOnMainThread:
+    // withObject:waitUntilDone:modes:] with a mode set that includes
+    // "AWTRunLoopMode", so the call is serviced even when the main
+    // thread is parked inside the JDK's LWCToolkit.doAWTRunLoopImpl
+    // (accessibility-focus callbacks, IME callbacks, AWT-EDT round
+    // trips, etc).
     //
-    // This MUST NOT be called from the EDT during a live AppKit operation
-    // (window resize / drag etc.) -- main's run loop is in
-    // NSEventTrackingRunLoopMode during those and the main dispatch queue is
-    // not reliably drained from sync waiters on other threads, causing the
-    // EDT to block forever.  Use cocoa_run_on_main_async for fire-and-forget
-    // calls (setBounds, navigate, eval, ...).  Reserve the sync version for
-    // attach/detach where we genuinely need to wait for the result.
+    // The previous implementation used dispatch_sync_f to the main
+    // dispatch queue, which deadlocks in that scenario: AppKit's main
+    // thread was inside doAWTRunLoopImpl's nested CFRunLoop in
+    // AWTRunLoopMode (which does NOT drain the main dispatch queue),
+    // waiting for the EDT to answer an accessibility role query; the
+    // EDT meanwhile was here in webview_embed_create waiting for the
+    // main thread to dequeue our sync block.  See the bug report
+    // "WebViewHeavyweightComponent deadlocks the EDT when the WebView
+    // peer is created during macOS accessibility focus events".
+    //
+    // performSelectorOnMainThread:waitUntilDone:YES is the canonical
+    // AWT-on-macOS bridge for "talk to AppKit from a JNI call" and is
+    // the same mechanism the JDK itself uses internally
+    // (sun.lwawt.macosx.ThreadUtilities / JNFRunLoop).
     BOOL is_main = msg<BOOL>(objc_cls("NSThread"), sel("isMainThread"));
     if (is_main) {
         f();
         return;
     }
-    struct Holder { std::function<void()> f; };
-    Holder h{std::move(f)};
-    dispatch_sync_f(dispatch_get_main_queue(), &h, +[](void *p) {
-        static_cast<Holder *>(p)->f();
-    });
+    ensure_awt_main_bridge();
+    auto *work = new AwtBridgeWork{std::move(f)};
+    id arg = awt_bridge_box(work);
+    msg<void, SEL, id, BOOL, id>(
+        g_awt_main_bridge_target,
+        sel("performSelectorOnMainThread:withObject:waitUntilDone:modes:"),
+        sel("performWork:"), arg, YES, g_awt_main_bridge_modes);
+    // performSelectorOnMainThread retains arg for the duration of the
+    // call; releasing our +1 here brings the refcount to 1 (held by
+    // perform) and then 0 after the selector finishes.
+    msg<void>(arg, sel("release"));
 }
 
 static void cocoa_run_on_main_async(std::function<void()> f) {


### PR DESCRIPTION
## Summary

Replace `dispatch_sync` with `-[NSObject performSelectorOnMainThread:withObject:waitUntilDone:modes:]` in `cocoa_run_on_main` to fix an EDT deadlock that occurs when the main thread is parked inside the JDK's `LWCToolkit.doAWTRunLoopImpl` (e.g., during accessibility focus callbacks or IME operations).

## Problem

The previous implementation used `dispatch_sync(dispatch_get_main_queue(), …)` to run work on the AppKit main thread. This deadlocks when:

1. AppKit's main thread is inside `-[LWCToolkit doAWTRunLoopImpl]`'s nested CFRunLoop, waiting for the EDT to answer a JNI callback (e.g., an accessibility role query during a VoiceOver focus-changed event)
2. That private runloop runs only in `@"AWTRunLoopMode"` and does **not** drain the main dispatch queue
3. The EDT is blocked in `webview_embed_create` calling `cocoa_run_on_main`, waiting for the main thread to dequeue the sync block
4. Result: unconditional EDT ↔ main thread deadlock

## Solution

Implement a proper AWT-on-macOS bridge using `performSelectorOnMainThread:withObject:waitUntilDone:modes:` with a mode array that includes `@"AWTRunLoopMode"` alongside standard AppKit modes. This matches the JDK's own `sun.lwawt.macosx.ThreadUtilities` pattern.

## Key Changes

- **New `AwtBridgeWork` struct**: Heap-allocated work item wrapping a `std::function<void()>` passed across the EDT → AppKit main bridge
- **New `WebViewAwtMainBridge` Objective-C class**: Registered once per JVM via `std::call_once`, implements `performWork:` selector that executes the function and cleans up
- **New helper functions**:
  - `awt_main_bridge_perform_impl`: Runs on AppKit main thread, extracts and executes the function, deletes the work item
  - `ensure_awt_main_bridge`: One-time initialization of the bridge class, target instance, and run-loop modes array
  - `awt_bridge_box`: Wraps `AwtBridgeWork*` in an `NSValue` for Objective-C messaging
- **Updated `cocoa_run_on_main`**: Routes sync calls through `performSelectorOnMainThread` with modes including `@"AWTRunLoopMode"`, `kCFRunLoopDefaultMode`, `NSEventTrackingRunLoopMode`, and `NSModalPanelRunLoopMode`
- **Documentation**: Added comprehensive comments explaining the deadlock scenario and why this approach is necessary; updated the Canvas with the same guidance for future sync main-thread bridges

## Notes

- `cocoa_run_on_main_async` is unaffected—it uses `dispatch_async_f` and never blocks the EDT
- The async helper remains the preferred choice for fire-and-forget calls (setBounds, navigate, eval, etc.)
- The sync version is reserved for operations that genuinely need to wait for a result (attach/detach)

https://claude.ai/code/session_01E9XwQz4AvNwuE7zW1meK6B