### PR TITLE
Eliminate EDT↔AppKit sync-bridge deadlock on macOS

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -25,3 +25,4 @@
 #
 java corretto-8.492.09.2
 maven 3.9.9
+ant 1.10.14

--- a/demos/WebViewDeadlockRepro/README.md
+++ b/demos/WebViewDeadlockRepro/README.md
@@ -1,0 +1,53 @@
+# WebView v1.0.5 deadlock repro
+
+Provokes a deterministic-ish EDT ↔ AppKit main-thread mutual-wait
+deadlock against the `cocoa_run_on_main` bridge introduced in v1.0.5
+(PR #30, commit `dcda4cf`). See the top-of-file javadoc in
+`src/ca/weblite/webview/demos/WebViewDeadlockRepro.java` for the full
+timeline.
+
+## What it does
+
+- Loads a page that calls `window.poke()` on `setInterval(1ms)`. The
+  bound Java callback synchronously rendezvous with the EDT via
+  `SwingUtilities.invokeAndWait`, parking the AppKit main thread on a
+  semaphore for the duration.
+- A `javax.swing.Timer` fires synthetic Cmd-C `KeyEvent`s at 10ms
+  cadence into the global `KeyboardFocusManager`. They are picked up by
+  `WebViewHeavyweightComponent`'s editing-shortcut dispatcher, which
+  evaluates `embedded.isNativeFirstResponder()` — the sync v1.0.5
+  bridge call on the EDT side.
+- A daemon watchdog pings the EDT every 100ms; if the EDT goes silent
+  for >5s it dumps every thread's stack trace to stderr and forces
+  `Runtime.halt(1)`.
+
+## Expected behaviour
+
+Within seconds of pressing **Start repro** the app freezes. The watchdog
+fires shortly after and prints:
+
+- The **EDT** parked inside
+  `Java_ca_weblite_webview_WebViewNative_webview_1embed_1is_1native_1first_1responder`
+  → `cocoa_run_on_main` → `performSelectorOnMainThread` semaphore wait,
+  called from `handleEditingShortcut` on a `KeyEvent.KEY_PRESSED`.
+- The **AppKit main thread** parked inside
+  `EventQueue.invokeAndWait` (Java frames visible: the user's
+  `JavascriptCallback.run` calling `invokeAndWait`, called from
+  `engine_on_message` via JNI from the WKScriptMessageHandler).
+
+That mutual-wait shape is the deadlock. The class of bug is broader
+than this exact entry path: any sync EDT→main bridge meeting any sync
+main→EDT callback (including AppKit accessibility, IME, focus events
+on the main side) can close the same cycle.
+
+## Running
+
+```
+ant run
+```
+
+Requires `dist/WebView.jar` and `natives/osx_arm64/libwebview.dylib`
+to exist. Run `./run-mac-demo.sh` once from the repo root to produce
+both, then come back here and `ant run`.
+
+macOS only — the bridge being exercised is macOS-specific.

--- a/demos/WebViewDeadlockRepro/build.xml
+++ b/demos/WebViewDeadlockRepro/build.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="WebViewDeadlockRepro" default="run" basedir=".">
+    <description>Reproduces a v1.0.5 cocoa_run_on_main bridge deadlock.</description>
+
+    <property name="src.dir" value="src"/>
+    <property name="build.dir" value="build"/>
+    <property name="classes.dir" value="${build.dir}/classes"/>
+    <property name="webview.jar" value="../../dist/WebView.jar"/>
+    <property name="main.class" value="ca.weblite.webview.demos.WebViewDeadlockRepro"/>
+
+    <target name="check-webview-jar">
+        <available file="${webview.jar}" property="webview.jar.exists"/>
+        <fail unless="webview.jar.exists">
+WebView.jar not found at ${webview.jar}.
+Build it first from the project root, e.g. ./run-mac-demo.sh once to
+produce dist/WebView.jar and natives/osx_arm64/libwebview.dylib.
+        </fail>
+    </target>
+
+    <target name="compile" depends="check-webview-jar">
+        <mkdir dir="${classes.dir}"/>
+        <javac srcdir="${src.dir}" destdir="${classes.dir}"
+               includeantruntime="false" source="1.8" target="1.8">
+            <classpath>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </javac>
+    </target>
+
+    <target name="run" depends="compile">
+        <java classname="${main.class}" fork="true">
+            <classpath>
+                <pathelement location="${classes.dir}"/>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </java>
+    </target>
+
+    <target name="clean">
+        <delete dir="${build.dir}"/>
+    </target>
+</project>

--- a/demos/WebViewDeadlockRepro/src/ca/weblite/webview/demos/WebViewDeadlockRepro.java
+++ b/demos/WebViewDeadlockRepro/src/ca/weblite/webview/demos/WebViewDeadlockRepro.java
@@ -1,0 +1,221 @@
+/*
+ * MIT License
+ *
+ * Reproduces an EDT <-> AppKit main-thread mutual-wait deadlock that the
+ * v1.0.5 cocoa_run_on_main bridge (PR #30, commit dcda4cf) can exhibit
+ * when a JavaScript callback synchronously rendezvous with the EDT at
+ * the same instant the EDT enters cocoa_run_on_main.
+ *
+ * Mechanism:
+ *
+ *   (1) The page calls a bound JS function on setInterval(1ms). Each
+ *       call runs the WKScriptMessageHandler on the AppKit main thread,
+ *       which JNI-calls into the Java callback "poke". The callback
+ *       does SwingUtilities.invokeAndWait(R) -- posts R to the EDT
+ *       queue and blocks the main thread on a semaphore until R runs.
+ *
+ *   (2) A javax.swing.Timer fires a synthetic Cmd-C KeyEvent at 10ms
+ *       cadence, dispatched via KeyboardFocusManager.dispatchEvent so
+ *       WebViewHeavyweightComponent's editingShortcutDispatcher picks
+ *       it up regardless of who has Swing focus. Focus is parked on a
+ *       JTextField outside the WebView, so handleEditingShortcut
+ *       evaluates embedded.isNativeFirstResponder() -- which fires the
+ *       v1.0.5 sync cocoa_run_on_main bridge.
+ *
+ *   (3) Race window: a Cmd-C event is enqueued on the EDT at a moment
+ *       when poke is mid-flight in invokeAndWait. EDT picks up Cmd-C
+ *       (FIFO, ahead of R since R was posted after Cmd-C was already
+ *       queued), enters performSelectorOnMainThread:waitUntilDone:YES,
+ *       blocks on the perform semaphore. R sits in the EDT queue
+ *       behind the now-blocked Cmd-C handler. Main is blocked in
+ *       invokeAndWait waiting on R. Each side waits for the other ->
+ *       deadlock.
+ *
+ * A daemon watchdog pings the EDT every 100ms and dumps all stack
+ * traces + Runtime.halt(1)s if the EDT goes silent for > 5s.
+ */
+package ca.weblite.webview.demos;
+
+import ca.weblite.webview.WebView;
+import ca.weblite.webview.swing.WebViewHeavyweightComponent;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.KeyboardFocusManager;
+import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
+import java.util.Map;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import javax.swing.ToolTipManager;
+
+public class WebViewDeadlockRepro {
+
+    // setInterval(1) -> page calls poke() every ~1ms, keeping main thread
+    // frequently parked inside invokeAndWait waiting on EDT. Wider blocking
+    // windows make the race resolve faster; browsers clamp setInterval to
+    // 1ms minimum so this is as tight as we can go without rAF chaining.
+    private static final String TEST_PAGE_URL =
+        "data:text/html;charset=utf-8," +
+        "<html><body style='font-family:sans-serif;padding:16px'>" +
+        "<h2>Deadlock repro</h2>" +
+        "<p>Page is firing <code>window.poke()</code> on " +
+        "<code>setInterval(1ms)</code>.</p>" +
+        "<p>Press <b>Start repro</b> below to begin firing synthetic " +
+        "Cmd-C at the EDT every 10ms.</p>" +
+        "<p>Expected: the app freezes within a couple of seconds; the " +
+        "watchdog dumps stack traces and halts the JVM.</p>" +
+        "<script>" +
+        "  setInterval(function(){ if (window.poke) window.poke('tick'); }, 1);" +
+        "</script>" +
+        "</body></html>";
+
+    // EDT liveness watchdog: posts an invokeLater every 100ms that
+    // updates lastEdtTick. If 5s elapse without a tick, the EDT is
+    // wedged -- dump all stack traces and halt.
+    private static volatile long lastEdtTick = System.currentTimeMillis();
+
+    public static void main(String[] args) {
+        // Heavyweight WebView lives above lightweight popups; match
+        // other demos for consistency even though we use no popups.
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+        EventQueue.invokeLater(WebViewDeadlockRepro::run);
+    }
+
+    private static void run() {
+        WebViewHeavyweightComponent wv = new WebViewHeavyweightComponent();
+        wv.setUrl(TEST_PAGE_URL);
+
+        // Java side of the JS bridge. poke fires on the AppKit main
+        // thread (where WKScriptMessageHandler delivers script messages)
+        // and synchronously rendezvous with the EDT via invokeAndWait.
+        // The Runnable is a no-op -- the deadlock-relevant fact is that
+        // main is blocked on the EDT semaphore for the duration.
+        wv.addJavascriptCallback("poke", new WebView.JavascriptCallback() {
+            @Override
+            public void run(String arg) {
+                try {
+                    SwingUtilities.invokeAndWait(new Runnable() {
+                        @Override public void run() { /* no-op */ }
+                    });
+                } catch (Exception ignored) { /* shutdown / interrupt noise */ }
+            }
+        });
+
+        // Non-WebView component to hold Swing focus so the editing-
+        // shortcut handler sees focusInWebView == false and falls
+        // through to isNativeFirstResponder (the sync bridge call).
+        // The handler evaluates isNativeFirstResponder unconditionally
+        // either way -- having focus here just makes the demo's intent
+        // visually obvious.
+        JTextField focusHolder = new JTextField("(focus parking)");
+        focusHolder.setEditable(false);
+
+        // Status label that updates from the EDT via a Swing Timer; it
+        // freezes the instant the EDT wedges, giving the human observer
+        // a live indicator independent of the watchdog.
+        final JLabel status = new JLabel("EDT alive");
+        Timer statusTimer = new Timer(200, ev -> status.setText(
+            "EDT alive  t+" + (System.currentTimeMillis() % 100000)));
+        statusTimer.start();
+
+        // Synthetic Cmd-C dispatcher. SHORTCUT_MASK in
+        // WebViewHeavyweightComponent comes from getMenuShortcutKeyMask
+        // (old-style modifiers), so we use the same source here. The
+        // editingShortcutDispatcher installed by addNotify is a global
+        // KeyEventDispatcher on KeyboardFocusManager; dispatchEvent
+        // routes through it regardless of which component has focus.
+        @SuppressWarnings("deprecation")
+        final int shortcutMask = Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
+        Timer cmdCTimer = new Timer(10, ev -> {
+            KeyEvent ke = new KeyEvent(
+                focusHolder, KeyEvent.KEY_PRESSED,
+                System.currentTimeMillis(), shortcutMask,
+                KeyEvent.VK_C, 'c');
+            KeyboardFocusManager.getCurrentKeyboardFocusManager()
+                .dispatchEvent(ke);
+        });
+
+        JButton startBtn = new JButton("Start repro");
+        JButton stopBtn = new JButton("Stop repro");
+        stopBtn.setEnabled(false);
+        startBtn.addActionListener(ev -> {
+            cmdCTimer.start();
+            startBtn.setEnabled(false);
+            stopBtn.setEnabled(true);
+        });
+        stopBtn.addActionListener(ev -> {
+            cmdCTimer.stop();
+            startBtn.setEnabled(true);
+            stopBtn.setEnabled(false);
+        });
+
+        JPanel buttons = new JPanel();
+        buttons.add(startBtn);
+        buttons.add(stopBtn);
+        buttons.add(status);
+
+        JPanel south = new JPanel(new BorderLayout());
+        south.add(buttons, BorderLayout.CENTER);
+        south.add(focusHolder, BorderLayout.SOUTH);
+
+        JFrame frame = new JFrame("WebView v1.0.5 deadlock repro");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setLayout(new BorderLayout());
+        frame.add(wv, BorderLayout.CENTER);
+        frame.add(south, BorderLayout.SOUTH);
+        frame.setPreferredSize(new Dimension(900, 700));
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        focusHolder.requestFocusInWindow();
+
+        // Start the watchdog after the frame is visible, so initial
+        // EDT-heavy work (peer creation on first paint, etc.) doesn't
+        // trip it.
+        startWatchdog();
+    }
+
+    private static void startWatchdog() {
+        lastEdtTick = System.currentTimeMillis();
+        Thread t = new Thread(() -> {
+            while (true) {
+                try { Thread.sleep(100); } catch (InterruptedException ignored) {}
+                EventQueue.invokeLater(
+                    () -> lastEdtTick = System.currentTimeMillis());
+                long gap = System.currentTimeMillis() - lastEdtTick;
+                if (gap > 5000) {
+                    System.err.println();
+                    System.err.println("======================================================");
+                    System.err.println("DEADLOCK DETECTED -- EDT silent for " + gap + " ms");
+                    System.err.println("======================================================");
+                    dumpThreads();
+                    Runtime.getRuntime().halt(1);
+                }
+            }
+        }, "edt-watchdog");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    private static void dumpThreads() {
+        Map<Thread, StackTraceElement[]> all = Thread.getAllStackTraces();
+        for (Map.Entry<Thread, StackTraceElement[]> e : all.entrySet()) {
+            Thread th = e.getKey();
+            System.err.println();
+            System.err.println("Thread: " + th.getName()
+                + " (id=" + th.getId() + ", state=" + th.getState() + ")");
+            for (StackTraceElement frame : e.getValue()) {
+                System.err.println("    at " + frame);
+            }
+        }
+    }
+}

--- a/requirements/[User-story-4]eliminate-edt-appkit-sync-deadlock-on-macos.md
+++ b/requirements/[User-story-4]eliminate-edt-appkit-sync-deadlock-on-macos.md
@@ -1,0 +1,361 @@
+# Story Decomposition: Eliminate EDT↔AppKit Sync Deadlock Surface on macOS
+
+## INVEST Analysis
+
+### Abstract Task
+
+**Feature**: Eliminate every synchronous EDT→AppKit-main bridge in the macOS heavyweight WebView implementation, closing a class of deadlocks where the EDT and the AppKit main thread mutually wait on each other.
+
+**Analysis Dimensions**:
+
+- **Core Responsibility**: Make the macOS native bridge non-deadlockable by removing the three sync EDT→main call sites in `src_c/webview_embed.cpp` (engine create, first-responder probe, engine destroy) and replacing them with async or cached equivalents.
+- **Primary Operations**:
+  1. Async engine attach with deferred completion listener (replaces sync `cocoa_create_engine`).
+  2. KVO-driven cached first-responder flag (replaces sync `cocoa_is_first_responder`).
+  3. Async engine destroy with safe queued-op handling (replaces sync `cocoa_destroy_engine`).
+- **Key Constraints**:
+  - Java-level `EmbeddedWebView.attach(parent, debug)` must remain a synchronous factory — no API break for existing call sites.
+  - `WebViewHeavyweightComponent`'s pre-paint buffer/replay pattern must keep working unchanged.
+  - Queued async ops on a destroyed engine must never UAF.
+  - The new attach-listener API must be present on Windows and Linux too, even though those platforms attach synchronously.
+  - Repro demo (`demos/WebViewDeadlockRepro`) must run indefinitely without the watchdog firing.
+- **Technical Complexity**: High — touches native concurrency (KVO observers, generation counters, async lifecycle), JNI lifecycle, and cross-platform Java API design.
+- **Business Complexity**: Medium — three logically distinct subgoals, each with its own failure modes and acceptance scenarios, but all in service of one outcome (no hangs).
+
+### INVEST Evaluation
+
+- ❌ **Independent**: As a single story, it has three internal subgoals that can ship independently — splitting clarifies dependencies.
+- ✅ **Negotiable**: Yes — listener shape, KVO mechanism, generation counter vs. destroyed flag are all open to refinement.
+- ✅ **Valuable**: Yes — eliminates user-visible hangs in production.
+- ✅ **Estimable**: Yes — each subgoal is bounded.
+- ❌ **Small**: Combined, the three subgoals exceed 5 days. Each subgoal individually is 1–3 days.
+- ✅ **Testable**: Yes — the repro demo is a deterministic end-to-end test, plus AC-level unit tests on the cache and lifecycle.
+
+**Conclusion**: Needs splitting. Three sub-stories, each independently shippable, each closing one specific sync bridge.
+
+### Split Strategy
+
+**Dimension**: by sync site / technical dependency. Each sub-story removes one of the three sync EDT→main bridge sites. They can land in any order, but the demo will keep deadlocking until all three plus the helper-removal land.
+
+**Recommended sequence** (highest user impact first):
+
+1. **STORY-004-001** — Cached first-responder flag. Closes the sync site that the repro demo actually exercises (Cmd-C path).
+2. **STORY-004-002** — Async engine create with attach-completion listener. Closes the AX-triggered deadlock window during initial attach.
+3. **STORY-004-003** — Async engine destroy with safe queued-op handling, plus removal of the now-unused `cocoa_run_on_main` sync helper. Closes the destroy-side variant and retires the v1.0.5 `performSelectorOnMainThread:modes:` scaffolding.
+
+---
+
+## [STORY-004-001] Cached First-Responder Flag for Editing-Shortcut Routing
+
+### Background
+
+The editing-shortcut dispatcher on the EDT calls `EmbeddedWebView.isNativeFirstResponder` for every `Cmd-C` / `Cmd-V` / `Cmd-X` / `Cmd-A` key event, to decide whether to route the shortcut into the WKWebView or let Swing handle it. On macOS, that check currently hops EDT→main via a synchronous native bridge: it parks the EDT on a semaphore, signals the AppKit main thread to walk the responder chain, and waits for the answer.
+
+When the AppKit main thread is simultaneously parked in `invokeAndWait` waiting for the EDT (a routine condition during accessibility, IME, focus, or other AppKit→Java upcalls), both threads wait forever. The repro demo at `demos/WebViewDeadlockRepro` triggers this within seconds of pressing `Cmd-C` while the WebView is focused.
+
+Because this is the highest-frequency sync bridge call in the library — fired on every editing keystroke — closing it eliminates the most-likely-to-be-hit deadlock window in production.
+
+Key points:
+
+- The fix targets the per-call sync bridge in `cocoa_is_first_responder`, not the broader bridge infrastructure (that's covered by 004-002 and 004-003).
+- Swizzled `becomeFirstResponder` / `resignFirstResponder` hooks on `WKWebView` are not sufficient: focus on inner WebKit content views (e.g. an `<input>` element inside the page) is delegated to a private `WKContentView` and does not fire `WKWebView`'s own responder methods.
+- A KVO observer on the host `NSWindow.firstResponder` property fires on the AppKit main thread for every focus change anywhere in the window's responder hierarchy. Walking the responder chain from the KVO callback and updating an `std::atomic<bool>` on the Engine gives the EDT a sync-free read path.
+
+### Business Value
+
+- End users of any heavyweight WebView application never experience hangs from `Cmd-C` / `Cmd-V` / `Cmd-X` / `Cmd-A` shortcuts.
+- Library users do not need to audit their callback code for the EDT-sync-bridge contract on this specific path.
+- Removes the most frequently-exercised deadlock surface in `src_c/webview_embed.cpp`.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: None. This story is independently shippable.
+- **Data assumptions**: KVO observation on `NSWindow.firstResponder` is supported in every macOS version the library targets (10.13+); responder-chain walking from KVO is a documented AppKit pattern.
+- **Integration points**:
+  - `EmbeddedWebView.isNativeFirstResponder` (Java)
+  - `cocoa_is_first_responder` (C++)
+  - Existing swizzled `WKWebView` becomeFirstResponder / resignFirstResponder hooks (kept as additional update points, not the sole source of truth)
+- **Business constraints**: Existing public API of `EmbeddedWebView` must not change shape.
+
+### Scope In
+
+- `std::atomic<bool>` field on the macOS-side `Engine` struct: `is_first_responder`.
+- KVO observer registered on `[host window] firstResponder` at engine attach; unregistered at engine destroy.
+- On each KVO firing, walk the responder chain to determine whether the WKWebView (or any of its descendants, including the private content view) is the current responder, and update the atomic.
+- `EmbeddedWebView.isNativeFirstResponder` reads the atomic via a JNI call that performs no main-thread hop.
+- Demo verification: `demos/WebViewDeadlockRepro` runs at least 60 seconds with periodic `Cmd-C` without the EDT watchdog firing.
+
+### Scope Out
+
+- Async engine create / attach (STORY-004-002).
+- Async engine destroy (STORY-004-003).
+- Removal of the now-partially-unused `cocoa_run_on_main` sync helper — its other call sites (create, destroy) still exist after this story; cleanup happens in 004-003.
+- Windows / Linux paths.
+
+### Acceptance Criteria
+
+#### AC1: Cmd-C inside the WebView copies selected text to the clipboard
+
+**Given** a heavyweight WebView showing a page with selectable text and the user has clicked into the page so the WebView holds focus
+**When** the user selects text and presses `Cmd-C`
+**Then** the selected text appears on the macOS system clipboard and the editing-shortcut dispatcher determined responder status with no AppKit main-thread hop
+
+#### AC2: Cmd-V inside the WebView pastes from the clipboard
+
+**Given** the WebView holds focus, the system clipboard contains "hello", and an input field on the page has focus
+**When** the user presses `Cmd-V`
+**Then** "hello" appears in the input field
+
+#### AC3: Editing shortcut with focus outside the WebView falls through to Swing
+
+**Given** a `JTextField` sibling holds focus and contains selected text
+**When** the user presses `Cmd-C`
+**Then** Swing's default `Cmd-C` action runs and the editing-shortcut dispatcher does not invoke `EmbeddedWebView.executeEditingCommand`
+
+#### AC4: Focus on an inner DOM element is reported as WebView-is-responder
+
+**Given** the user has clicked into an `<input>` element inside the loaded page, so first-responder is the private WebKit content view
+**When** the editing-shortcut dispatcher queries `isNativeFirstResponder`
+**Then** the result is `true`
+
+#### AC5: Cache reflects focus transfer out of the WebView within one event-loop tick
+
+**Given** the WebView held focus, then the user clicked a `JTextField` sibling
+**When** the editing-shortcut dispatcher queries `isNativeFirstResponder` after the focus transfer
+**Then** the result is `false`
+
+#### AC6: WebViewDeadlockRepro demo runs cleanly for at least 60 seconds
+
+**Given** `demos/WebViewDeadlockRepro` is launched and the simulated `Cmd-C` loop is running
+**When** the demo runs for 60 seconds
+**Then** the EDT-deadlock watchdog never fires and the app remains responsive
+
+#### AC7: KVO observer is released cleanly on engine destroy
+
+**Given** an `EmbeddedWebView` is attached to a parent that is later removed via `removeNotify`
+**When** the engine is destroyed
+**Then** the KVO observer is unregistered from the host window before the engine struct is freed and no AppKit warnings about pending observers appear in the log
+
+### Non-Functional Expectations
+
+- `isNativeFirstResponder` must return in constant time with no perceptible latency increase versus the previous sync implementation under non-deadlock conditions.
+- KVO callback work must be bounded (single responder-chain walk, O(depth) where depth is small).
+
+---
+
+## [STORY-004-002] Async Engine Attach with Completion Listener
+
+### Background
+
+`cocoa_create_engine` in `src_c/webview_embed.cpp` runs the entire AppKit-side setup of the WKWebView synchronously on the main thread, with the EDT parked on a semaphore waiting for it to finish. The setup calls `addSubview:` on the JDK's `AWTView`. `addSubview:` triggers AppKit's accessibility subsystem, which queries the `AWTView` for accessibility metadata; the JDK answers that query by routing back to the EDT via `LWCToolkit.invokeAndWait`. Because the EDT is parked above, both sides deadlock.
+
+The accessibility subsystem is activated by VoiceOver, screen readers, `Cmd-F1` accessibility shortcuts, Spotlight, Stage Manager, and other system-level events the application cannot control. Users have reported the hang occurring within minutes of first launch on machines with no obvious AX consumer running.
+
+This story makes engine attach asynchronous: the C++ Engine struct is allocated immediately, but all AppKit-side setup runs on the main thread via `cocoa_run_on_main_async`. The EDT never parks. A new `WebViewAttachListener` API lets callers observe completion (success or failure). Pre-attach operations buffer and replay, analogous to the existing `WebViewHeavyweightComponent` pre-paint buffer.
+
+Key points:
+
+- `EmbeddedWebView.attach(parent, debug)` remains a synchronous factory at the Java API level — it returns immediately with a non-null `EmbeddedWebView` in a new `PENDING` state.
+- The new listener API ships on all platforms; on Windows and Linux attachment is already synchronous, so listeners fire immediately.
+
+### Business Value
+
+- Engine attach is no longer deadlock-able by external AppKit subsystems (AX, IME, focus tracking) that round-trip through the JDK.
+- Library users gain a documented mechanism (`addOnAttachComplete`) to react to attach success or failure, rather than relying on synchronous exception throw.
+- `WebViewHeavyweightComponent` and other library-internal consumers can layer their pre-paint buffer on top of a uniform pre-attach buffer.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: None — independent of 004-001 and 004-003.
+- **Data assumptions**:
+  - `WebViewHeavyweightComponent`'s buffer/replay pattern (pendingUrl, pendingInit, pendingBindings, debug) for pre-paint configuration is generalizable to pre-attach.
+  - The Engine struct can be allocated synchronously on the calling thread (it has no AppKit dependencies) — only the WKWebView and subview attachment require main-thread execution.
+- **Integration points**:
+  - `EmbeddedWebView` (Java public API)
+  - `WebViewAttachListener` (new Java interface)
+  - `cocoa_create_engine` and the Windows / Linux equivalents
+  - `WebViewHeavyweightComponent`'s pre-paint replay path
+- **Business constraints**: `EmbeddedWebView.attach(parent, debug)` signature is fixed — callers must not need to be rewritten.
+
+### Scope In
+
+- New attach-state enum on `EmbeddedWebView`: `PENDING`, `ATTACHED`, `FAILED`.
+- New public Java interface `WebViewAttachListener` with `onAttached(EmbeddedWebView)` and `onAttachFailed(EmbeddedWebView, Throwable cause)`.
+- New public method `EmbeddedWebView.addOnAttachComplete(WebViewAttachListener)` — fires on the EDT once attach resolves. If already resolved at registration time, fires on the next EDT tick.
+- macOS: `cocoa_create_engine` returns immediately after allocating the C++ Engine struct; WKWebView creation, `setWantsLayer:`, `addSubview:`, and configuration run inside `cocoa_run_on_main_async`. Success or failure is communicated back to Java via a JNI callback on the EDT.
+- Pre-attach `setUrl`, `executeJavaScript`, `evalAsync`, `addBinding`, `setInitScript`, `setUserAgent`, etc. on a `PENDING` `EmbeddedWebView` are buffered and replayed on `ATTACHED` transition in registration order.
+- `attach()` still throws synchronously if the C++ Engine struct allocation itself fails (the rare case — out of memory). Only the AppKit-side phase is async.
+- Cross-platform parity: on Windows and Linux, attach completes synchronously and any registered listener fires immediately on the EDT.
+- `WebViewHeavyweightComponent`'s existing pre-paint buffer keeps working unchanged on top of the new pre-attach mechanism.
+
+### Scope Out
+
+- Async destroy (STORY-004-003).
+- Removal of `cocoa_run_on_main` sync helper (STORY-004-003).
+- Changes to the JS-side `eval` callback dispatch path.
+
+### Acceptance Criteria
+
+#### AC1: attach() returns within 50 ms on macOS regardless of AppKit state
+
+**Given** an AppKit consumer (e.g. VoiceOver enabled or AX query active) is exercising `accessibilityFocusedUIElement` on AWTView
+**When** `EmbeddedWebView.attach(parent, debug)` is called from the EDT
+**Then** the call returns within 50 ms with a non-null `EmbeddedWebView` whose attach state is `PENDING`
+
+#### AC2: Listener fires on the EDT on successful attach
+
+**Given** `attach()` has just returned a `PENDING` `EmbeddedWebView` and a `WebViewAttachListener` is registered
+**When** the async AppKit-side setup completes successfully
+**Then** `onAttached(webView)` is invoked on the EDT and the attach state is `ATTACHED`
+
+#### AC3: Listener fires on the EDT on attach failure
+
+**Given** the async AppKit-side setup fails (e.g. WKWebView allocation returns nil because of a configuration error)
+**When** the async setup resolves with failure
+**Then** `onAttachFailed(webView, cause)` is invoked on the EDT, the attach state is `FAILED`, and `cause` carries an actionable message identifying which setup step failed (e.g. "WKWebView allocation failed" / "host NSView not found")
+
+#### AC4: Pre-attach setUrl is replayed after attach completes
+
+**Given** `attach()` returned a `PENDING` `EmbeddedWebView` and the caller invoked `setUrl("https://example.com")` before any listener fired
+**When** attach completes successfully
+**Then** the WebView begins loading `https://example.com` automatically with no further caller action
+
+#### AC5: Pre-attach addBinding is replayed and callable from JS
+
+**Given** `attach()` returned `PENDING` and the caller invoked `addBinding("myFn", handler)` before attach completed
+**When** attach completes and a page is then loaded
+**Then** `window.myFn(...)` is callable from JavaScript and dispatches to `handler`
+
+#### AC6: Late listener registration fires immediately on the EDT
+
+**Given** attach already resolved (to `ATTACHED` or `FAILED`) before any listener was registered
+**When** `addOnAttachComplete(listener)` is called from the EDT
+**Then** the listener fires on the next EDT event-loop tick with the resolved outcome
+
+#### AC7: WebViewHeavyweightComponent's pre-paint buffer continues to work
+
+**Given** a `WebViewHeavyweightComponent` is constructed and `setUrl(...)` and `addBinding(...)` are called before the component has been painted
+**When** the component is added to a frame and painted for the first time
+**Then** the URL loads and the binding is callable, with no observable behaviour change versus the pre-story implementation
+
+#### AC8: Windows and Linux attach is synchronous and listener fires immediately
+
+**Given** `attach()` is called on Windows or Linux
+**When** the call returns
+**Then** the `EmbeddedWebView`'s attach state is already `ATTACHED` and any subsequently-registered `WebViewAttachListener` fires on the next EDT tick with `onAttached`
+
+#### AC9: attach() throws synchronously only on C++ allocation failure
+
+**Given** the C++ Engine struct allocation itself fails (simulated via test hook)
+**When** `attach()` is called
+**Then** it throws `EmbeddedWebViewException` synchronously with a message identifying the allocation failure, and no `EmbeddedWebView` instance is returned
+
+#### AC10: Attach failure on macOS does not leak the C++ Engine struct
+
+**Given** the async AppKit-side setup fails after the C++ Engine struct was allocated
+**When** the failure is reported back to Java
+**Then** the C++ Engine struct is released as part of the failure path and no native memory leak is observable in a leak-detection harness
+
+### Non-Functional Expectations
+
+- `attach()` return time on macOS must be under 50 ms in all conditions, including under heavy AX activity.
+- Buffered pre-attach operations must replay in registration order.
+
+---
+
+## [STORY-004-003] Async Engine Destroy with Safe Queued-Op Handling
+
+### Background
+
+`cocoa_destroy_engine` in `src_c/webview_embed.cpp` runs `removeFromSuperview` on the AppKit main thread synchronously, with the EDT parked. `removeFromSuperview` can trigger accessibility tree updates and other AppKit→Java upcalls — the same deadlock shape as STORY-004-002, but on the destroy side.
+
+Closing this sync site requires more than moving `delete e` inside `cocoa_run_on_main_async`: the engine has potentially-queued async ops (navigate, eval, addBinding, executeJavaScript) that might fire on the main thread after the destroy lambda has freed the Engine struct, causing a use-after-free. A generation counter or destroyed atomic on the Engine lets each queued lambda check whether it is still safe to touch the struct.
+
+Once destroy is async, the `cocoa_run_on_main` synchronous helper has no remaining callers and can be removed along with the v1.0.5 `WebViewAwtMainBridge` / `performWork:` scaffolding. The Canvas Norm mandating `performSelectorOnMainThread:modes:` for `cocoa_run_on_main` is retired in favour of a new Norm forbidding any sync EDT→main bridge in `webview_embed.cpp`.
+
+Key points:
+
+- This story depends conceptually on 004-002 (the same async-lambda pattern), but ships independently.
+- The helper removal is part of this story because it is the natural cleanup once all three sync sites are gone.
+
+### Business Value
+
+- `removeNotify` / `dispose()` paths on heavyweight WebViews can never hang the EDT, regardless of AppKit state.
+- The library becomes robust to teardown happening while the page is actively running JS or loading.
+- The codebase's deadlock surface is provably zero — there is no remaining sync EDT→main bridge to audit.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: None as a sequencing dependency, but the helper-removal AC presumes 004-001 and 004-002 have also landed (because they remove the other two callers of the sync helper). If 004-003 lands first, the helper-removal AC is deferred to whichever story lands last.
+- **Data assumptions**:
+  - A generation counter (e.g. `std::atomic<uint64_t>`) or destroyed flag (`std::atomic<bool>`) on the Engine is sufficient to short-circuit late async ops.
+  - All async ops in the macOS implementation already capture an `Engine*`; capturing a generation snapshot at queue time and comparing at fire time is straightforward.
+- **Integration points**:
+  - `cocoa_destroy_engine`
+  - Every `cocoa_run_on_main_async` lambda in `src_c/webview_embed.cpp` (navigate, eval, addBinding, setInitScript, etc.)
+  - `WebViewAwtMainBridge` Objective-C class and `performWork:` selector (to be removed)
+  - Canvas 6 Norms section
+- **Business constraints**: No observable behaviour change for callers other than destroy being non-blocking.
+
+### Scope In
+
+- `cocoa_destroy_engine` becomes fully async: `removeFromSuperview`, WKWebView teardown, KVO observer unregistration (from 004-001), and `delete e` all run inside `cocoa_run_on_main_async`. The JNI entry returns immediately.
+- Generation counter (or destroyed atomic) on Engine. Every async lambda for navigate / eval / addBinding / etc. checks the counter before dereferencing the engine and short-circuits cleanly (no crash, no exception) if the engine has been destroyed.
+- `evalAsync` lambdas on a destroyed engine complete the returned `CompletableFuture` exceptionally with an actionable message ("WebView disposed").
+- Removal of `cocoa_run_on_main` sync helper, `WebViewAwtMainBridge` class, and `performWork:` selector.
+- Canvas 6 Norms section updated: the v1.0.5 `performSelectorOnMainThread:modes:` norm is retired and replaced by a norm forbidding any sync EDT→main bridge.
+
+### Scope Out
+
+- Any change to Windows or Linux destroy paths.
+- Any change to the synchronous Java API contract of `dispose()` (it still returns when called; only the underlying native work becomes async).
+
+### Acceptance Criteria
+
+#### AC1: dispose() returns within 50 ms on macOS
+
+**Given** an attached `EmbeddedWebView`
+**When** `dispose()` (or the parent component's `removeNotify`) is invoked from the EDT
+**Then** the JNI call returns within 50 ms
+
+#### AC2: dispose() does not deadlock when AX is active
+
+**Given** VoiceOver is enabled or another AX consumer is querying the AWTView
+**When** `dispose()` is called from the EDT
+**Then** the call returns cleanly within 50 ms and the EDT remains responsive (no watchdog event)
+
+#### AC3: Late navigate on a destroyed engine is a safe no-op
+
+**Given** an `EmbeddedWebView` was disposed while a `setUrl` async lambda was queued on the main thread
+**When** the queued lambda fires
+**Then** no UAF occurs, no exception escapes the native layer, and a debug-level log entry records the no-op
+
+#### AC4: Late evalAsync on a destroyed engine fails the future with a clear message
+
+**Given** an `EmbeddedWebView` was disposed while an `evalAsync(...)` lambda was queued on the main thread
+**When** the queued lambda fires
+**Then** the previously-returned `CompletableFuture` completes exceptionally with a message containing "WebView disposed" and no UAF occurs
+
+#### AC5: cocoa_run_on_main sync helper is removed from the codebase
+
+**Given** the codebase is searched for `cocoa_run_on_main` (without the `_async` suffix)
+**When** the search completes
+**Then** there are zero matches in production source files, and `WebViewAwtMainBridge` / `performWork:` have also been removed
+
+#### AC6: Long-run repro demo passes without deadlock
+
+**Given** `demos/WebViewDeadlockRepro` is extended to run a loop of attach → focus → simulated Cmd-C → dispose for at least 5 minutes
+**When** the demo executes
+**Then** no EDT-watchdog event fires, no native crash occurs, and no UAF is reported by Address Sanitizer (when run under ASan)
+
+#### AC7: Canvas 6 Norms reflect the new contract
+
+**Given** `spdd/prompt/6-*-Swing-Heavyweight-Webview-Embedding.md` is read
+**When** the Norms section is inspected
+**Then** it contains a norm forbidding any sync EDT→main bridge in `src_c/webview_embed.cpp`, and the previous norm mandating `performSelectorOnMainThread:modes:` for `cocoa_run_on_main` has been removed
+
+### Non-Functional Expectations
+
+- `dispose()` return time on macOS must be under 50 ms in all conditions.
+- Late async ops on destroyed engines must complete in O(1) regardless of how many ops were queued.
+- ASan / leak-detection runs of the repro demo must show no native leaks attributable to the destroy path.

--- a/spdd/analysis/GGQPA-XXX-202605201900-[Analysis]-edt-appkit-sync-deadlock-elimination.md
+++ b/spdd/analysis/GGQPA-XXX-202605201900-[Analysis]-edt-appkit-sync-deadlock-elimination.md
@@ -1,0 +1,236 @@
+# SPDD Analysis: Eliminate EDT↔AppKit Sync Deadlock Surface on macOS
+
+## Original Business Requirement
+
+The full story decomposition `[User-story-4]eliminate-edt-appkit-sync-deadlock-on-macos.md` is preserved verbatim in `requirements/[User-story-4]eliminate-edt-appkit-sync-deadlock-on-macos.md` and is incorporated by reference. The headline capability:
+
+> Eliminate every synchronous EDT→AppKit-main bridge in the macOS heavyweight WebView implementation (`src_c/webview_embed.cpp`), closing the class of deadlocks where the EDT and the AppKit main thread mutually wait on each other. Three sync sites must be eliminated:
+>
+> 1. **Cached first-responder flag** (STORY-004-001): replace `cocoa_is_first_responder`'s per-call EDT→main sync probe with an `std::atomic<bool>` on the `Engine`, kept current by a KVO observer registered on the host `NSWindow.firstResponder` property. Existing swizzled `WKWebView` `becomeFirstResponder` / `resignFirstResponder` hooks are insufficient because focus on inner WebKit content views (e.g. an `<input>` inside the page) does not fire `WKWebView`'s own responder methods.
+>
+> 2. **Async engine attach with completion listener** (STORY-004-002): `cocoa_create_engine` returns immediately after allocating the C++ `Engine` struct; WKWebView creation, `addSubview:`, and configuration run via `cocoa_run_on_main_async`. New public Java API `WebViewAttachListener` + `EmbeddedWebView.addOnAttachComplete(listener)` reports the deferred outcome on the EDT. Pre-attach operations buffer and replay. `EmbeddedWebView.attach(parent, debug)` stays a synchronous factory at the Java API level.
+>
+> 3. **Async engine destroy with safe queued-op handling** (STORY-004-003): `cocoa_destroy_engine`'s `removeFromSuperview` and `delete e` move inside `cocoa_run_on_main_async`. A generation counter (or destroyed atomic) on the `Engine` lets queued async ops short-circuit safely. The now-unused `cocoa_run_on_main` sync helper, `WebViewAwtMainBridge` class, and `performWork:` selector are removed. Canvas 6's Norm mandating `performSelectorOnMainThread:modes:` is retired in favour of "no sync EDT→main bridge in `webview_embed.cpp`".
+>
+> Cross-platform: Windows and Linux native paths do not need bridge changes (they have no analogous EDT↔main-thread dispatch primitive). The Java-level attach-listener API is added on all platforms; on Windows / Linux it fires immediately because attachment there is already synchronous. The reproducing demo `demos/WebViewDeadlockRepro` must run indefinitely without the watchdog firing.
+
+All 24 Acceptance Criteria across STORY-004-001 (7 ACs), STORY-004-002 (10 ACs), and STORY-004-003 (7 ACs), plus the per-story Non-Functional Expectations, are in scope of this analysis.
+
+## Domain Concept Identification
+
+### Existing Concepts (from codebase)
+
+- **`EmbeddedWebView`** (`src/ca/weblite/webview/EmbeddedWebView.java`): low-level Java wrapper around the native engine peer. Public surface includes `attach(Component, boolean) [static factory]`, `setBounds`, `setVisible`, `requestFocus`, `navigate`, `addOnBeforeLoad`, `eval`, `evalAsync`, `addJavascriptCallback`, `dispatch`, `pumpEvents`, `openDevTools`, `executeEditingCommand`, `isNativeFirstResponder`, `setFocusCallback`, `setClickCallback`, `releaseNativeFocus`, `dispose`. Holds a `long peer` (zero after dispose), a `heap: List<Object>` GC-anchor list, a `bindings: Map<String, JavascriptCallback>` map, and a per-instance `EvalDispatcher`. `checkAlive()` throws `IllegalStateException` when `peer == 0L`. `dispose()` already orchestrates a careful drain sequence: `evalDispatcher.disposeAllPending()`, then `setFocusCallback(null)` (try/catch), then `setClickCallback(null)` (try/catch), then `peer = 0L`, then `webview_embed_destroy`.
+
+- **`WebViewHeavyweightComponent`** (`src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`): Swing `JComponent` wrapping `EmbeddedWebView`. Holds a private `embedded: EmbeddedWebView` (null until first paint, null after `dispose`), plus the pre-attach buffer fields `pendingUrl`, `pendingInit`, `pendingBindings`, `debug`. `createPeer()` calls `EmbeddedWebView.attach(canvas, debug)` and replays all pending state. `EmbeddedCanvas.peerAttached` (volatile boolean) flips on first `paint()` and back on `removeNotify`. The `editingShortcutDispatcher` (a `KeyEventDispatcher` registered on `KeyboardFocusManager` in `addNotify`) calls `EmbeddedWebView.isNativeFirstResponder()` for every platform-shortcut + C/V/X/A key press — this is the sync-bridge call that the repro demo wedges on.
+
+- **C++ `Engine` struct** (`src_c/webview_embed.cpp:1548-1586`): per-instance native state. Fields: `webview` (WKWebView id), `manager` (WKUserContentController id), `config`, `debug`, `bindings: std::map<std::string, Binding*>`, `jvm`, `surface_layers`, `host_view`, `host_is_awt`, `focus_callback` (JNI global ref), `click_callback` (JNI global ref). Lives until `cocoa_destroy_engine` frees it.
+
+- **`cocoa_run_on_main`** (`src_c/webview_embed.cpp:1681-1720`): the sync EDT→main bridge. Inlines if already on main; otherwise routes through `[g_awt_main_bridge_target performSelectorOnMainThread:withObject:waitUntilDone:YES modes:g_awt_main_bridge_modes]` with `g_awt_main_bridge_modes` including `AWTRunLoopMode`, `kCFRunLoopDefaultMode`, `NSEventTrackingRunLoopMode`, `NSModalPanelRunLoopMode`. Three callers: `cocoa_is_first_responder` (line 1998), `cocoa_create_engine` (line 2077), `cocoa_destroy_engine` (line 2264). **The sync site this story eliminates.**
+
+- **`cocoa_run_on_main_async`** (`src_c/webview_embed.cpp:1722-1735`): the async counterpart. Inlines if already on main; otherwise uses `dispatch_async_f(dispatch_get_main_queue(), …)`. **The replacement substrate.** The macOS `dispatch_get_main_queue()` is FIFO and serial — blocks fire in enqueue order, one at a time, on the AppKit main thread, never concurrently.
+
+- **`WebViewAwtMainBridge` / `performWork:`** (`src_c/webview_embed.cpp:1626-1668`): the Objective-C class and selector that `cocoa_run_on_main` dispatches through. Allocated and registered exactly once per JVM via `std::call_once`. Becomes dead code once all three sync-bridge sites are eliminated; STORY-004-003 removes it.
+
+- **Swizzled responder hooks** (`src_c/webview_embed.cpp:1816-1860`): `swizzled_become_first_responder` and `swizzled_resign_first_responder` are installed via `method_setImplementation` on `WKWebView` once per JVM. They fire whenever the `WKWebView` itself becomes/resigns first responder, look up the engine in `g_webview_map`, and call `fire_focus_callback`. **Key limitation**: they do NOT fire when focus lands on or leaves an inner WebKit content view (`<input>`, etc.) — those transitions don't pass through `WKWebView`'s own responder methods. This is why a KVO observer on `NSWindow.firstResponder` is needed for the cache, not the existing swizzle.
+
+- **`g_webview_map`** (`src_c/webview_embed.cpp:1593-1594`): process-global `std::map<id, Engine*>` keyed by `WKWebView` id. Guarded by `g_webview_map_mutex`. Populated in `cocoa_create_engine` after `WKWebView` alloc; cleared in `cocoa_destroy_engine` before the `cocoa_run_on_main` teardown block. Used by the swizzled responder/mouse hooks (process-wide class swizzle; the map filters to our `WKWebView`s).
+
+- **`cocoa_is_first_responder`** (`src_c/webview_embed.cpp:1995-2022`): the sync responder probe. Walks the responder chain from `[window firstResponder]` upward through `superview` looking for `e->webview`. Returns 1 if found, 0 otherwise. **The sync site eliminated by STORY-004-001.** The walk logic itself (lines 2004-2019) is the right shape — it correctly handles inner content views by walking up — and is reusable inside the KVO callback.
+
+- **`cocoa_create_engine`** (`src_c/webview_embed.cpp:2052-2224`): synchronously allocates the `Engine`, takes a JAWT lock to resolve `surface_layers`, then runs a `cocoa_run_on_main` block that installs swizzles, allocates `WKWebView`, registers in `g_webview_map`, finds a host NSView, calls `[host setWantsLayer:YES]` + `[host addSubview:e->webview]`, installs the script-message-handler delegate, and (if `debug`) sets `developerExtrasEnabled` / `setInspectable:`. The `ok` flag inside the block flips to true on success; outside the block, `!ok → delete e; return nullptr`. **The sync site eliminated by STORY-004-002.**
+
+- **`cocoa_destroy_engine`** (`src_c/webview_embed.cpp:2226-2305`): drops the `WKWebView` from `g_webview_map`, releases `focus_callback` and `click_callback` JNI global refs on the calling thread, runs a `cocoa_run_on_main` block that does `removeFromSuperview`, releases `host_view` / `surface_layers` / `webview` / `config`, then walks `e->bindings` on the calling thread releasing global refs, and finally `delete e`. **The sync site eliminated by STORY-004-003.**
+
+- **`cocoa_navigate` / `cocoa_init_script` / `cocoa_eval` / `cocoa_set_visible` / `cocoa_request_focus` / `cocoa_set_bounds` / `cocoa_execute_editing_command`** (`src_c/webview_embed.cpp:2313-2443`): all already implemented as `cocoa_run_on_main_async` lambdas. Each null-checks `e->webview` or `e->manager` (or `e->host_view`) at the top of the lambda and returns silently if cleared. **The existing async pattern that pre-attach buffering will naturally piggyback on.**
+
+- **`cocoa_bind`** (`src_c/webview_embed.cpp:2383`): currently runs synchronously on the calling thread (`e->bindings[b->name] = b;`). This is the one non-async per-engine op. Inspected by the script-message-handler delegate on the main thread when JS posts a message. Today it works because attach is sync (main thread is the only reader; the EDT writes after attach completes); under async attach it becomes a cross-thread write that must be made safe.
+
+- **`EvalDispatcher`** (`src/ca/weblite/webview/EvalDispatcher.java`, canvas-10): per-engine in-flight `id → CompletableFuture<String>` map with `disposeAllPending()` drain. Owned by `EmbeddedWebView`. `EmbeddedWebView.dispose()` already drains it before `webview_embed_destroy`. **Already async-safe**: new `evalAsync` calls after `peer == 0L` return already-failed futures without touching the dispatcher. Provides the AC4 (story 003) behaviour for free.
+
+- **Pre-paint buffer pattern in `WebViewHeavyweightComponent`** (`src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java:86-103, 111-178, 460-466`): the established convention for "configuration set before the peer exists, replayed when it does". `setUrl`, `addOnBeforeLoad`, `addJavascriptCallback`, `setDebug` all write to `pendingUrl` / `pendingInit` / `pendingBindings` and only delegate to `embedded` when it's non-null. `createPeer()` replays in registration order. **The blueprint for any pre-attach buffer; STORY-004-002 generalises it down to `EmbeddedWebView` level (or, see Strategic Approach below, leverages the existing `dispatch_get_main_queue` FIFO ordering to avoid an explicit Java-level buffer entirely).**
+
+- **Canvas 6 Norm: `cocoa_run_on_main` MUST use `performSelectorOnMainThread:withObject:waitUntilDone:YES modes:` with `AWTRunLoopMode`** (`spdd/prompt/6-*.md` Norms section, lines 1700–1735). The v1.0.5 fix from PR #30 that this work supersedes. **Explicitly retired by STORY-004-003** and replaced by a Norm forbidding any sync EDT→main bridge in `webview_embed.cpp`.
+
+### New Concepts Required
+
+- **`WebViewAttachListener`** (new Java functional interface, `src/ca/weblite/webview/WebViewAttachListener.java`): single-callback observer with `onAttached(EmbeddedWebView)` and `onAttachFailed(EmbeddedWebView, Throwable cause)`. Documented to fire on the Swing EDT. Listeners can be registered before or after attach resolves; resolved-state registration fires the callback on the next EDT tick (never on the calling thread, to prevent re-entrancy bugs in the registering code).
+
+- **Attach state machine on `EmbeddedWebView`**: three-state enum (`PENDING`, `ATTACHED`, `FAILED`) exposed via a getter, plus an internal `Throwable attachFailure` field set on FAILED transition. State transitions are EDT-only — the macOS native side calls back into Java on the EDT to drive transitions, mirroring the existing `WebViewFocusCallback` invokeLater pattern.
+
+- **`is_first_responder: std::atomic<bool>`** on the C++ `Engine` struct (STORY-004-001). Written by the KVO observer callback running on the AppKit main thread; read by `cocoa_is_first_responder` from any thread (typically the EDT). Atomic with default memory_order is sufficient — a stale read by at most one event-loop tick is acceptable, and a single `bool` field admits no torn reads.
+
+- **KVO observer on `NSWindow.firstResponder`** (STORY-004-001). Registered when the WKWebView gains a non-nil window (deferred from `addSubview:` because the window may not be set immediately) and unregistered before the engine is destroyed. Fires on the AppKit main thread. Each firing walks the responder chain (same logic as the current `cocoa_is_first_responder` body) and updates the atomic. **Lifecycle is shared with the engine**, so STORY-004-003 (async destroy) must include observer unregistration in the destroy lambda before any view release.
+
+- **Generation counter (or destroyed atomic) on the C++ `Engine`** (STORY-004-003). `std::atomic<uint64_t>` incremented on destroy, captured by every async lambda at enqueue time, compared at fire time. Used as a belt-and-suspenders short-circuit for late async ops on a destroyed engine. Strictly speaking, FIFO dispatch-queue ordering + EDT-only enqueueing already guarantees no late op fires after destroy — but the counter defends against (a) destroy-from-non-EDT (hypothetical), (b) future code changes that might violate the invariant, and (c) provides a clean signalling path for STORY-004-003 AC4 (evalAsync future fails with "WebView disposed" message from inside the late lambda).
+
+- **Pre-attach buffer for `addJavascriptCallback`** (STORY-004-002, conditional). If we choose to expose `addJavascriptCallback` as a pre-attach operation (and we should, for symmetry with `WebViewHeavyweightComponent`'s `pendingBindings`), `cocoa_bind` must either (a) become an async-on-main lambda (using the FIFO queue to order itself after the attach lambda that creates `e->bindings`), or (b) the Java-side `EmbeddedWebView` must buffer the binding name+callback pair and replay it on the `onAttached` transition. See Strategic Approach for the recommendation.
+
+### Key Business Rules
+
+- **Editing-shortcut routing must remain user-perceptibly identical**: the Cmd-C / Cmd-V / Cmd-X / Cmd-A behaviour described in Canvas 6's Requirements section (the "interacting with the WebView" gating logic in `handleEditingShortcut`) MUST be preserved. The change is purely the mechanism by which `isNativeFirstResponder` returns its answer — sync probe → cached atomic. Edge cases: focus on inner content views, focus on a Swing sibling, focus transferred mid-keystroke.
+
+- **`EmbeddedWebView.attach(parent, debug)` is a synchronous factory at the Java API level on all platforms**: no caller should be required to await a future or pass a listener inline. The PENDING state is the user-observable consequence of macOS-side async setup; Windows / Linux callers see ATTACHED immediately.
+
+- **Pre-attach operations are buffered, not rejected**: a caller who does `EmbeddedWebView ewv = EmbeddedWebView.attach(...); ewv.setUrl("..."); ewv.addBinding(...);` on a single EDT tick MUST get the same end-state as if attach had been fully synchronous. Order is preserved.
+
+- **Pre-attach failure surfaces only through `WebViewAttachListener.onAttachFailed`** (or, if no listener is registered, is captured in the `attachFailure` field and reported to any subsequently-registered listener). It does NOT throw from any post-`attach()` method call — those methods buffer or no-op until the FAILED transition is observed. This avoids the trap where every post-`attach` call site needs try/catch.
+
+- **`dispose()` is non-blocking and idempotent**: returns within 50 ms on macOS (AC1 of story 003) and is safe to call repeatedly. Late ops on a disposed engine are no-ops (navigate) or already-failed futures (evalAsync). Existing dispose() drain order in Java (`evalDispatcher.disposeAllPending` → clear callbacks → `peer = 0L` → JNI destroy) is preserved and remains correct under async destroy.
+
+- **Canvas 6's existing Norms unrelated to the sync bridge must be preserved**: the console-bridge ordering rule, the editing-shortcut consumption rule, the swizzle-once-per-JVM rule, the `webview_embed_open_devtools` non-blocking rule, etc., all stay in force. Only the specific `cocoa_run_on_main` / `performSelectorOnMainThread:modes:` Norm is retired.
+
+- **Listener callbacks never fire on the calling thread**: `addOnAttachComplete` registered after resolution fires on the next EDT tick (`SwingUtilities.invokeLater`), never inline. This prevents re-entrancy when the listener body itself calls `addOnAttachComplete` or other `EmbeddedWebView` methods.
+
+## Strategic Approach
+
+### Solution Direction
+
+**Three coordinated changes to `src_c/webview_embed.cpp` and the macOS-facing Java surface, sequenced (in any order, but recommended 001 → 002 → 003 for user impact) to fully eliminate the sync EDT→main bridge from the heavyweight WebView path.** The three sub-stories share enough infrastructure (KVO observer lifecycle spans 001 + 003; generation counter spans 002 + 003) that a single analysis pass is appropriate even though each ships independently.
+
+**STORY-004-001 — Cached responder via KVO**:
+- Add `is_first_responder: std::atomic<bool>` to the `Engine` struct.
+- On the existing attach path, when the `WKWebView` is added to a host view and the host view has a non-nil window, register a KVO observer on `[window firstResponder]`. If the window is nil at attach time (transient AppKit state), defer registration: observe the WKWebView's `viewDidMoveToWindow` (or a one-shot KVO on the WKWebView's `window` keypath) and register the firstResponder observer on the first non-nil window.
+- KVO callback re-walks the responder chain using the existing `cocoa_is_first_responder` logic and writes the atomic.
+- Refactor `cocoa_is_first_responder` to read the atomic only — no main-thread hop. Keep the body's existing fallback (peer-not-yet-set returns 0) intact.
+- On destroy, unregister the observer before any view release. This is STORY-004-001 scope; the destroy path itself is still sync in 001 (STORY-004-003 makes it async, but observer unregistration is symmetric in both modes).
+
+**STORY-004-002 — Async attach with FIFO-queue replay**:
+- Split `cocoa_create_engine` into a synchronous prologue (allocate `Engine`, take the JAWT lock long enough to retain `surface_layers`, attach the `EvalDispatcher`-related state) and an async-on-main epilogue (`cocoa_run_on_main_async`) that does the WKWebView allocation, host-view discovery, `addSubview:`, configuration, KVO observer registration (from 001), and final state write.
+- The async epilogue captures a JNI global ref to a callback object (provided by the Java side via the new attach-listener wiring). On success or failure, the epilogue posts the result back to the EDT via `SwingUtilities.invokeLater` (or, equivalently, uses `webview_embed_dispatch` style marshalling).
+- **Pre-attach op ordering**: rely on `dispatch_get_main_queue()` FIFO serial ordering. The attach epilogue is the first block enqueued. Subsequent `cocoa_navigate` / `cocoa_eval` / `cocoa_init_script` / `cocoa_set_bounds` / `cocoa_request_focus` / `cocoa_set_visible` / `cocoa_execute_editing_command` calls each enqueue their own async block; they fire in registration order, after the attach block. Each block already null-checks `e->webview` / `e->manager` and silently no-ops if the field is null — so an op enqueued before the attach block creates the WKWebView simply finds it ready by the time it fires. **No Java-level buffer is needed for these ops.**
+- **`cocoa_bind` is the exception**: it currently mutates `e->bindings` synchronously on the calling thread (the EDT). Under async attach, the script-message-handler delegate (running on main) might read `e->bindings` before the calling thread's write is visible. Convert `cocoa_bind` to enqueue an async-on-main lambda that does the map write, OR keep it sync but add a `std::mutex` around `e->bindings`. Recommendation: convert to async — it preserves the "every per-engine native op is async" invariant and trivially serialises against the script-message-handler reads (which also run on main).
+- **Java-side attach-listener wiring**: add `addOnAttachComplete(WebViewAttachListener)` to `EmbeddedWebView`. Internally, `attach()` returns an instance in PENDING state with a JNI global ref to a new callback object. The native attach epilogue calls back into Java with success/failure; the Java side flips the state and fires any registered listeners on the EDT via `SwingUtilities.invokeLater`.
+- **Cross-platform parity**: on Windows / Linux, `webview_embed_create` is synchronous and returns a non-zero peer. The Java side detects this (peer != 0L at constructor entry) and immediately transitions to ATTACHED; any subsequently-registered listener fires on the next EDT tick.
+- **Synchronous failure path**: if the C++ Engine struct allocation itself fails (out of memory, JAWT lock failure), `attach()` throws synchronously as today. Only the AppKit-side phase is moved async. This matches AC9 of story 002.
+
+**STORY-004-003 — Async destroy with generation guard**:
+- Add `generation: std::atomic<uint64_t>` (or `destroyed: std::atomic<bool>`) to the `Engine` struct.
+- Move the existing `cocoa_run_on_main` block in `cocoa_destroy_engine` to `cocoa_run_on_main_async`. The destroy lambda runs `removeFromSuperview`, releases retained AppKit objects, unregisters the KVO observer (from 001), walks `e->bindings` releasing global refs, increments the generation counter (or sets `destroyed = true`), and finally `delete e`.
+- Every other async-on-main lambda captures the generation at enqueue time and compares at fire time. On mismatch (engine destroyed), short-circuit cleanly: navigate / eval / setBounds / setVisible / executeEditingCommand / etc. return without touching the engine. For `cocoa_eval`, on detection inside the late lambda, surface the failure back to the Java-side `EvalDispatcher` so the corresponding `CompletableFuture` completes exceptionally with "WebView disposed". (Note: in practice, the `EvalDispatcher` is already drained by `EmbeddedWebView.dispose()` BEFORE `webview_embed_destroy` is called, so this code path is exercised only in pathological orderings; it remains the right defensive design.)
+- The pre-destroy Java-side cleanup in `cocoa_destroy_engine` (focus_callback / click_callback `DeleteGlobalRef`) happens BEFORE the async destroy lambda is enqueued, on the calling thread (which holds the JNIEnv). This is preserved — the calling thread is the EDT, and these refs must be released before the swizzle hooks could fire on the now-detached `WKWebView`.
+- Once all three sync sites are eliminated, `cocoa_run_on_main`, `WebViewAwtMainBridge`, and `performWork:` have no callers. Delete them. Verify by grep (story 003 AC5).
+- Update Canvas 6's Norms section to retire the `performSelectorOnMainThread:modes:` mandate and add the new prohibition.
+
+### Key Design Decisions
+
+- **Decision: KVO on `NSWindow.firstResponder` vs. swizzle `NSWindow.firstResponder` setter.** KVO is the documented, supported AppKit pattern; swizzle is intrusive and class-wide. The cost of KVO is a single `addObserver:forKeyPath:options:context:` at attach and a `removeObserver:forKeyPath:` at destroy, plus a per-focus-change callback that walks one responder chain. → **KVO chosen.** Rationale: smaller footprint, no risk of conflicting with another library that observes the same key path, and documented forward-compatibility across macOS versions.
+
+- **Decision: Java-level buffer vs. native FIFO-queue replay for pre-attach ops.** Java-level buffer (mirroring `WebViewHeavyweightComponent`'s `pendingUrl` etc.) is explicit but duplicative — `WebViewHeavyweightComponent` already does it at one level up. Native FIFO-queue replay is implicit but leverages an invariant we already depend on (every macOS per-engine op is already an async-on-main block; `dispatch_get_main_queue()` is documented as serial FIFO). → **Native FIFO-queue replay chosen for most ops.** The one exception is `cocoa_bind`, which is currently sync; converting it to async makes the whole picture uniform. **Trade-off**: if a caller observes attach succeed (via the listener) and then immediately reads back state (e.g. eval that depends on a binding being installed), they will see the binding ready because the bind block was enqueued first. The listener fires on the EDT *after* the attach block completes on main, so by the time user code runs in onAttached, all pre-attach blocks have already fired.
+
+- **Decision: Generation counter vs. destroyed flag.** A `std::atomic<bool> destroyed` is simpler; a `std::atomic<uint64_t> generation` is more powerful (lets us tell "is this op still relevant" vs. "did we destroy and recreate"). For this library, engines are never reused; once destroyed, they're gone. → **Destroyed flag is sufficient.** Rationale: simpler. **Trade-off**: if we ever add an engine-reset operation in the future, we'll need the counter. Defer until that requirement exists.
+
+- **Decision: attach() failure error reporting — exception vs. listener.** The story specifies AC9 of 002: synchronous throw only on C++ allocation failure (the rare path). Async AppKit-side failure goes through the listener. → **Two-tier failure reporting accepted.** Rationale: synchronous throw remains for the cases existing callers handle today (out-of-memory, bad parent); the new listener path covers the new failure surface (WKWebView allocation, host NSView discovery) that did not previously exist as a distinct failure mode. **Trade-off**: callers who don't register a listener will silently get a FAILED-state engine; document explicitly and make `getAttachState()` queryable.
+
+- **Decision: dispose() return semantics — true async (fire-and-forget) vs. await-and-return.** Today, `dispose()` returns after the sync destroy block completes on main. Under async destroy, `dispose()` enqueues the destroy lambda and returns immediately. There's no observable difference for callers because Java-side state (`peer = 0L`, evalDispatcher drained, callbacks cleared) is set synchronously before the native call returns. → **True async (fire-and-forget).** Rationale: it's the whole point of the story. **Trade-off**: callers who relied on "after dispose() returns, the WKWebView is fully detached from the view hierarchy" will see the detachment happen up to one main-loop tick later. No current caller relies on this; the demos and `WebViewHeavyweightComponent` don't observe AppKit state from Java after dispose.
+
+- **Decision: pre-attach `setUrl` / `eval` / etc. semantics — buffer-then-replay vs. queue-onto-main-immediately.** As above, native queue-onto-main-immediately works because `dispatch_get_main_queue()` is FIFO serial. **No special-case handling needed in Java**; the existing methods on `EmbeddedWebView` already call straight through to JNI without buffering. **However**, `EmbeddedWebView.checkAlive()` throws when `peer == 0L` — and during PENDING the peer is non-zero (the Engine struct exists). So `checkAlive()` continues to work correctly. **Trade-off**: caller cannot distinguish PENDING from ATTACHED through normal API calls (they all succeed). This is the desired behaviour — the listener is the explicit signal.
+
+- **Decision: editing-shortcut dispatcher continues to call `isNativeFirstResponder` directly vs. push the responder state into Swing.** We could mirror the responder state into a Swing-side `boolean` and have the editing-shortcut dispatcher read that. But that requires an EDT hop on every responder change, which we're trying to avoid. → **Keep the direct call.** The call now reads an atomic, not a sync bridge. The dispatcher's gating logic is unchanged.
+
+### Alternatives Considered
+
+- **Alternative: keep sync bridges but install AWTRunLoopMode-aware locks (the v1.0.5 fix extended).** The current v1.0.5 fix already does this for the inverse-ordering deadlock. But it does not close the cycle where the EDT enters our sync bridge while AppKit-main is parked in `invokeAndWait` waiting for the EDT — adding more modes cannot help because the EDT itself isn't running an event loop. **Rejected** — fundamentally unsolvable with sync bridges.
+
+- **Alternative: timeout-based sync bridge with degraded fallback.** Replace `waitUntilDone:YES` with a manual condition-variable wait + timeout. On timeout, log + degrade (return last-cached value, no-op the op, etc.). **Rejected** — turns a hang into a diagnosable error, but the diagnosable error is still observable to users (Cmd-C "doesn't work for ~5 seconds occasionally") and the fundamental class of bug is not closed. Acceptable as a defense-in-depth layered on top of the async fix, but not as the primary fix.
+
+- **Alternative: move `addSubview:` off the AX-triggering path by attaching only the layer, not the view.** The macOS implementation already has a layer-only fallback path (`src_c/webview_embed.cpp:2166-2176`) when no host NSView is found. We could prefer that path universally, side-stepping AX. **Rejected** — the layer-only fallback is documented as "won't render WKWebView content"; it's a dead-end, not a viable rendering mode. The async fix is the right shape.
+
+- **Alternative: split the C++ Engine struct into "shell" and "peer" — Java holds the shell pointer (eternal until dispose), peer is a separately-managed handle.** Would let the peer be safely destroyed async without touching the shell. **Rejected** — adds complexity without benefit over the generation-counter approach, which achieves the same UAF safety with one atomic.
+
+- **Alternative: separate-thread main pump that drives the WKWebView on a non-AppKit thread.** WKWebView is documented to require the AppKit main thread; cannot run elsewhere. **Rejected** — not technically possible.
+
+- **Alternative: introduce a Java-level pre-attach buffer in `EmbeddedWebView`** (mirroring `WebViewHeavyweightComponent`'s `pendingUrl` etc.). Explicit, easier to reason about, but duplicates the FIFO-queue ordering work already provided by `dispatch_get_main_queue()`. **Rejected as the primary mechanism**, but kept as a fallback if testing reveals queue-ordering edge cases. The `cocoa_bind` async conversion is required regardless.
+
+## Risk & Gap Analysis
+
+### Requirement Ambiguities
+
+- **KVO registration timing**: the story says "register a KVO observer on the host NSWindow's firstResponder". At the moment of `addSubview:`, the WKWebView is in the view hierarchy but the host view's `window` property may transiently be nil (AppKit policy: a view's `window` resolves when the host window is fully constructed and the view is part of its content view's hierarchy). The story implicitly assumes the observer can always be registered immediately. **Clarification**: register lazily on the first `viewDidMoveToWindow:` (or via a one-shot KVO on the WKWebView's own `window` keypath) so we tolerate the transient-nil case. The actual responder chain check still gates on `[e->webview window]` being non-nil — same as the current sync probe.
+
+- **`addOnAttachComplete` re-fire semantics**: the story says listeners registered after resolution fire "immediately" — interpreted as "on the next EDT tick via `invokeLater`", not "inline on the calling thread". This is implied by AC6 of story 002 ("fires on the next EDT event-loop tick"). **Confirmed via AC; documented in Key Business Rules above.**
+
+- **Multiple listeners per attach**: the story uses `addOnAttachComplete` (singular subject, additive verb) implying multiple listeners are supported. **Clarification**: the implementation maintains a `List<WebViewAttachListener>` and fires all of them in registration order. No `removeOnAttachComplete` is required for v1 of this work.
+
+- **Cross-story interaction — story 001 alone leaves attach sync**: if STORY-004-001 ships first (recommended for user impact), `cocoa_create_engine` is still sync. The KVO observer registration happens inside the sync attach block, fine. But the demo (AC6 of 001) still has a create-time AX deadlock surface — it's not a regression, it's that 001 only closes one deadlock. **Clarification**: AC6 of 001 says "runs cleanly for at least 60 seconds" of the Cmd-C loop; this targets the Cmd-C path, not the create path. The demo does not currently exercise creating-during-AX, so AC6 is achievable with just 001. **The demo extension in story 003 AC6 (5-minute attach→focus→Cmd-C→dispose loop) is the test that requires all three.**
+
+- **`WebViewAttachListener.onAttachFailed` `cause` field**: the story says "actionable message identifying the failure step" (e.g. "WKWebView allocation failed" / "host NSView not found"). Implementation question: is the cause a Java exception type with structured fields, or a generic `Throwable` with message? **Recommendation**: a new `WebViewAttachException` extends `IllegalStateException` (matching the existing `attach()` throw type) with a message and (optionally) a fail-stage enum. Defer to canvas-generation phase.
+
+- **`getAttachState()` exposure**: not explicitly listed in the story but implied by AC10 ("...attach state transitions to FAILED"). **Recommendation**: add `AttachState getAttachState()` getter on `EmbeddedWebView` returning the enum. Trivial and useful for tests.
+
+### Edge Cases
+
+- **`addBinding` racing with first JS message**: under async attach, a caller does `attach(); addBinding("foo", cb); setUrl("page-that-calls-foo")`. The `cocoa_bind` async lambda inserts `b` into `e->bindings`; the navigate lambda starts loading the page. If the page calls `foo()` before the bind lambda fires, the script-message-handler looks up `foo` in `e->bindings`, finds nothing, drops the message silently. **Mitigation**: FIFO ordering of the main queue ensures the bind lambda fires before the navigate lambda. But what about the time between navigate enqueue and the page actually loading and calling JS? That's wall-clock time, much longer than the dispatch-queue delta — by the time the page is loading and running its scripts, all enqueued async blocks have fired. **Risk is bounded by the same invariant as today's sync attach; no new edge case.**
+
+- **`dispose()` during pending attach**: a caller does `attach(); dispose();` on the same EDT tick. `dispose()` enqueues a destroy lambda; the attach lambda is already enqueued before it. FIFO ordering means attach completes, then destroy fires. The listener (if registered) fires `onAttached` first, then the engine is destroyed. From the listener's perspective, the engine is briefly valid then gone. **Mitigation**: listener implementations must check the engine's attach state or use `evalAsync` (which is dispose-safe) rather than sync `eval` (which would `checkAlive` and throw). Document the contract.
+
+- **`dispose()` before attach lambda fires + no listener registered**: same as above but no listener. attach lambda fires, internal state goes to ATTACHED, destroy lambda fires, engine is freed. No observer of the brief ATTACHED state. No UAF (destroy lambda is last). **Edge case OK.**
+
+- **KVO observer + window change**: the WKWebView's host window can change at runtime (e.g. user drags the JFrame to a different display, or a re-parenting operation). The KVO observer is registered on a specific NSWindow's firstResponder property; if the WKWebView's `window` changes, the observer must move to the new window. **Mitigation**: observe the WKWebView's own `window` keypath; on change, unregister from the old window's firstResponder and register on the new one. Recompute the atomic immediately after the move.
+
+- **WKWebView never gets a window (degenerate case)**: layer-only fallback path. `cocoa_is_first_responder` already returns 0 in that case (because `e->webview` has no window → no firstResponder → walk never matches). Cache is initialised to false and stays false. **Edge case OK.**
+
+- **JNI thread for the attach-completion callback**: the async epilogue runs on the AppKit main thread. To invoke a Java callback there, it must attach the current thread to the JVM (`AttachCurrentThread`) and detach after. The existing `fire_focus_callback` pattern in `webview_embed.cpp:1793-1814` does exactly this. **Reuse that pattern.**
+
+- **Listener exception propagation**: if a user-supplied `WebViewAttachListener.onAttached(...)` throws, what happens? Currently, the `editingShortcutDispatcher` and similar EDT callbacks let exceptions propagate to AWT's uncaught exception handler. **Recommendation**: same. Document that listener implementations should catch their own exceptions or accept the AWT default behaviour.
+
+- **Engine destroyed during `cocoa_is_first_responder` read**: the read is `return e->is_first_responder.load();`. If `e` itself is freed concurrently, this is a UAF. **Mitigation**: by contract, `EmbeddedWebView.isNativeFirstResponder` returns false when `peer == 0L` without making the JNI call (see `EmbeddedWebView.java:301`). Java-side dispose sets `peer = 0L` before the native destroy. So `isNativeFirstResponder` reads can never race with destroy from a single-EDT-thread perspective. **Edge case OK.**
+
+- **Test hook for AC9 (synchronous C++ allocation failure)**: simulating `new Engine()` failure is hard. **Recommendation**: add a `WEBVIEW_TEST_FAIL_ALLOC=1` env-var hook in cocoa_create_engine prologue (returns nullptr from the prologue). Defer the exact mechanism to canvas-generation phase.
+
+- **macOS version compatibility for KVO on `firstResponder`**: `NSWindow.firstResponder` is observable via KVO on macOS 10.7+ (it's a documented KVO-compliant property). The library targets macOS 10.13+ (per the README), so this is well within bounds. **Edge case OK.**
+
+### Technical Risks
+
+- **Risk: KVO observer + AppKit reentrancy.** KVO callbacks can fire from inside AppKit's responder-change machinery. Walking the responder chain inside the callback is safe (read-only), but the atomic write may need a memory barrier if other CPUs read it without one. **Mitigation**: `std::atomic<bool>` with default memory_order is sequentially consistent — sufficient for our needs.
+
+- **Risk: dispatch queue ordering assumed serial.** `dispatch_get_main_queue()` is documented as serial FIFO; this is the foundation of the no-Java-buffer recommendation. **Mitigation**: this is documented Apple behaviour, not an inference. If it ever changes, the dispatch queue is no longer the macOS main queue and many other things break first.
+
+- **Risk: `addOnBeforeLoad` (init script) ordering vs. attach.** Today's `cocoa_init_script` enqueues an async block; under async attach, the script is added to `e->manager` after the manager is created in the attach lambda. The init script is then injected by `WKWebView` at document-start for every subsequent navigation. If the navigate enqueues a load before the init script is added: race. **Mitigation**: FIFO queue order — addOnBeforeLoad and navigate from the same caller go in registration order, so the init script is added before the navigate fires. From WKWebView's perspective: init scripts added to the controller before the navigation request reaches WebKit are honoured. ✓
+
+- **Risk: `cocoa_bind` async conversion introduces a window where JS messages can arrive before the binding is registered.** As above, FIFO ordering means the bind lambda fires before any navigate-triggered page load that could call the binding. But the page may also be loaded BEFORE attach completes (rare: if the caller does `attach(); setUrl(url); addBinding(name, cb);`). In that case, the navigate lambda fires after the attach lambda but before the bind lambda — the page could call the binding before it's registered. **Mitigation**: this is a caller-ordering issue identical to today's sync attach (where `embedded.addJavascriptCallback` after `embedded.navigate` has the same race). The `WebViewHeavyweightComponent` code conventionally registers bindings before calling navigate (`createPeer()` does exactly this: `pendingBindings` is iterated before `pendingUrl` is navigated). Documented convention; preserved.
+
+- **Risk: removing `cocoa_run_on_main` sync helper might break a non-obvious caller.** The grep at story 003 AC5 should catch all production callers. Demos and test code might still reference it. **Mitigation**: grep in story 003 covers `src/`, `src_c/`, `windows/`, and `demos/`. Update or remove demo references.
+
+- **Risk: Canvas norm retirement may invalidate other documents.** Canvas 6's Norm currently mandates the `performSelectorOnMainThread:modes:` mechanism. Other canvases may reference it (e.g. discussions of how to safely talk to AppKit from JNI). **Mitigation**: grep `spdd/prompt/` for `performSelectorOnMainThread`, `AWTRunLoopMode`, `WebViewAwtMainBridge`. Update or cross-reference as needed during `/spdd-prompt-update`.
+
+- **Risk: cross-platform Java API change for `WebViewAttachListener` affects Windows / Linux consumers.** Adding a public interface and a new method (`addOnAttachComplete`) is API addition, not API breakage. Existing callers ignore it. **Mitigation**: ensure the Windows / Linux implementations of `EmbeddedWebView` (currently a single class with platform-aware JNI calls) correctly transition to ATTACHED at construction and fire the listener on next EDT tick. Single Java class, single code path — low risk.
+
+- **Risk: testing the deadlock fix on CI.** The repro demo requires GUI interaction. **Mitigation**: the existing demo at `demos/WebViewDeadlockRepro` is deterministic (uses synthetic Cmd-C and a setInterval-driven JS callback). Extend it to terminate cleanly after N successful loop iterations and use it as a smoke test. ASan can run locally for story 003 AC6.
+
+- **Risk: pre-existing `WebViewHeavyweightComponent.handleEditingShortcut` calls `isNativeFirstResponder` from inside the KeyEventDispatcher.** Today the call is sync and fast under non-deadlock conditions. After the cache, it's a load of an atomic — even faster. No behavioural risk.
+
+- **Risk: `EmbeddedWebView.dispose()` is called from a non-EDT thread.** Defensive programming: today's dispose flips `peer = 0L` and calls `webview_embed_destroy`. Both work from any thread. Under async destroy, the same continues to work — JNI thread for the native call doesn't matter because the destroy lambda runs on main. **Edge case OK.**
+
+### Acceptance Criteria Coverage
+
+| AC# | Description | Addressable? | Gaps/Notes |
+|-----|-------------|--------------|------------|
+| 001-AC1 | Cmd-C inside WebView copies to clipboard | Yes | Existing `executeEditingCommand` path unchanged; only the responder probe changes |
+| 001-AC2 | Cmd-V inside WebView pastes | Yes | Same as AC1 |
+| 001-AC3 | Cmd-C with focus outside WebView falls through to Swing | Yes | `handleEditingShortcut` already gates on `isNativeFirstResponder`; cached value preserves semantics |
+| 001-AC4 | Focus on inner DOM element reported as WebView-is-responder | Yes | KVO callback walks the responder chain (same logic as today's sync probe); inner content views are visited |
+| 001-AC5 | Cache reflects focus transfer out within one event-loop tick | Yes | KVO fires synchronously inside AppKit's `setFirstResponder:` call; cache updated before any subsequent EDT read |
+| 001-AC6 | WebViewDeadlockRepro runs cleanly for 60 s | Yes | Repro demo wedges specifically on the `isNativeFirstResponder` sync probe; cache eliminates that path |
+| 001-AC7 | KVO observer released cleanly on engine destroy | Yes | Symmetric registration / unregistration in attach / destroy. Need to handle window-change case (see Edge Cases) |
+| 002-AC1 | attach() returns within 50 ms under AX | Yes | Async epilogue returns immediately after `new Engine()` |
+| 002-AC2 | Listener fires on EDT on success | Yes | Native epilogue marshals to EDT via JNI callback + invokeLater |
+| 002-AC3 | Listener fires on EDT on failure | Yes | Failure path symmetric with success path |
+| 002-AC4 | Pre-attach setUrl replayed | Yes | FIFO queue ordering; no Java buffer needed |
+| 002-AC5 | Pre-attach addBinding replayed and callable from JS | Yes | Requires `cocoa_bind` async conversion (see Strategic Approach) |
+| 002-AC6 | Late listener registration fires immediately | Yes | `SwingUtilities.invokeLater` from resolved state |
+| 002-AC7 | WebViewHeavyweightComponent's pre-paint buffer still works | Yes | The component's buffer operates above `EmbeddedWebView`'s; new state machine is transparent to it |
+| 002-AC8 | Windows / Linux attach is synchronous | Yes | No native change on those platforms; constructor immediately transitions to ATTACHED |
+| 002-AC9 | attach() throws synchronously on C++ allocation failure | Yes | Sync prologue retains existing throw paths; only async epilogue is new |
+| 002-AC10 | Attach failure does not leak C++ Engine struct | Yes | Async epilogue must `delete e` on failure; symmetric with existing sync `!ok → delete e` path |
+| 003-AC1 | dispose() returns within 50 ms | Yes | Async destroy enqueues and returns immediately |
+| 003-AC2 | dispose() does not deadlock under AX | Yes | No sync EDT→main bridge in the dispose path |
+| 003-AC3 | Late navigate is safe no-op | Yes | Generation counter + existing `e->webview` null check |
+| 003-AC4 | Late evalAsync fails future with "WebView disposed" | Yes | EvalDispatcher already drained at Java dispose; native generation guard is belt-and-suspenders |
+| 003-AC5 | cocoa_run_on_main helper removed | Yes | After 001 + 002 + 003 land, no callers; mechanical removal |
+| 003-AC6 | Long-run demo (5 min, ASan) passes | Yes | Requires demo extension (in scope of 003 per the story) |
+| 003-AC7 | Canvas 6 Norms updated | Yes | Mechanical Norms-section rewrite during `/spdd-prompt-update` |
+
+**Coverage**: 24 of 24 ACs addressable. No gaps. Two require care during canvas generation: 002-AC5 (cocoa_bind async conversion) and 001-AC7 (KVO observer lifecycle including window-change handling).
+
+**Non-functional**: all five non-functional expectations (50 ms attach, 50 ms dispose, O(1) late-op short-circuit, KVO callback O(depth), ASan-clean) are addressable with the proposed mechanisms.

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -168,10 +168,91 @@ generated_at: 2026-05-16T07:19:13-07:00
   component (`WebViewLightweightComponent`) is unaffected
   because its mouse events flow through AWT and `MouseGrabber`
   sees them naturally.
+- **No sync EDT↔AppKit-main bridge.** `src_c/webview_embed.cpp`
+  MUST NOT contain any synchronous EDT→AppKit-main-thread
+  dispatch primitive. Every per-engine native operation runs
+  via `cocoa_run_on_main_async` (or inlines when already on
+  main); any AppKit-thread state that the EDT needs to read
+  is mirrored into an atomic on the `Engine` struct, updated
+  from the main thread, and read lock-free. Mutual-wait
+  deadlocks of the form "EDT parks waiting for AppKit-main
+  while AppKit-main is parked in `invokeAndWait` waiting for
+  EDT" — including the path through accessibility, IME,
+  focus-change, or any other AppKit→Java upcall via
+  `LWCToolkit.doAWTRunLoopImpl` — are structurally impossible
+  in this codebase as a consequence.
+- **Async engine attach with deferred completion**
+  (macOS-specific behaviour, cross-platform API).
+  `EmbeddedWebView.attach(parent, debug)` is a synchronous
+  factory on every platform — it returns immediately with a
+  non-null `EmbeddedWebView` and MUST return within 50 ms on
+  macOS regardless of AppKit-side activity (accessibility,
+  IME, focus tracking, etc.). On macOS the WKWebView creation,
+  host-NSView discovery, `addSubview:`, and configuration run
+  asynchronously on the AppKit main thread after the C++
+  `Engine` struct is allocated. On Windows and Linux the
+  attach completes synchronously inside the JNI call as
+  today. A new `WebViewAttachListener` API
+  (`addOnAttachComplete`) reports the deferred outcome on the
+  EDT — `onAttached` on success, `onAttachFailed(cause)` on
+  AppKit-side failure. The listener API exists on all
+  platforms; on Windows / Linux the listener fires on the
+  next EDT tick because the engine is already in `ATTACHED`
+  state when the constructor returns. Pre-attach operations
+  (`setUrl`, `addOnBeforeLoad`, `addJavascriptCallback`,
+  `eval`, `setBounds`, `setVisible`, `requestFocus`,
+  `executeEditingCommand`) MUST NOT throw on a `PENDING`
+  engine — they queue and replay automatically. The
+  `EmbeddedWebView.attach(...)` Java signature does not
+  change; existing callers (including
+  `WebViewHeavyweightComponent.createPeer`) MUST continue to
+  work without modification.
+- **Async engine destroy with safe queued-op handling**
+  (macOS-specific behaviour). `EmbeddedWebView.dispose()`
+  MUST return within 50 ms on macOS regardless of AppKit-side
+  activity. On macOS the `removeFromSuperview`, AppKit
+  object releases, and `delete e` move into a
+  `cocoa_run_on_main_async` block. A `destroyed: std::atomic<bool>`
+  flag on the `Engine` lets any queued async op that fires
+  after destroy short-circuit cleanly. `EmbeddedWebView.dispose()`
+  remains idempotent. Late `evalAsync` calls on a disposed
+  engine continue to return an already-failed future carrying
+  `IllegalStateException("EmbeddedWebView has been disposed.")`,
+  as today; the future-completion path does not regress.
+- **Cached first-responder probe via KVO.**
+  `EmbeddedWebView.isNativeFirstResponder()` MUST NOT make a
+  synchronous main-thread hop on any call. On macOS the
+  responder state is mirrored into an
+  `std::atomic<bool> is_first_responder` field on the
+  `Engine`, maintained by a KVO observer on the host
+  `NSWindow`'s `firstResponder` key path; each observation
+  fires on the AppKit main thread, walks the responder chain
+  exactly as the previous synchronous probe did, and writes
+  the atomic. The cache MUST correctly reflect focus on inner
+  WebKit content views (e.g. an `<input>` inside the page) —
+  the existing `WKWebView` `becomeFirstResponder` /
+  `resignFirstResponder` swizzle is insufficient for this
+  alone because those methods do not fire for focus
+  transitions to the private content view. Behaviour visible
+  through the editing-shortcut dispatcher and any other
+  caller of `isNativeFirstResponder` MUST be indistinguishable
+  from the previous synchronous implementation outside of
+  deadlock conditions.
+- **Deadlock-repro demo runs indefinitely.**
+  `demos/WebViewDeadlockRepro` (the reproducer for the v1.0.5
+  sync-bridge deadlock) MUST run for at least 60 seconds with
+  its synthetic `Cmd-C` loop without the EDT watchdog firing.
+  An extended attach → focus → `Cmd-C` → dispose stress loop
+  MUST run for at least 5 minutes without watchdog firing,
+  native crash, or Address-Sanitizer-reported use-after-free
+  attributable to the destroy path.
 - Definition of Done: documented by `README.md ("Heavyweight platform notes" section)` ("Heavyweight
   platform notes") and exercised by the `WebViewHeavyweightDemo`
   (`demos/WebViewHeavyweightDemo/...`). No automated tests cover
-  this — it is GUI integration code.
+  this — it is GUI integration code. The sync-deadlock
+  elimination work additionally MUST keep the
+  `demos/WebViewDeadlockRepro` long-run loop passing on macOS;
+  see Operation 14 below for the test plan.
 
 ## E · Entities
 - **WebViewHeavyweightComponent** (extends `WebViewComponent`,
@@ -300,6 +381,102 @@ generated_at: 2026-05-16T07:19:13-07:00
     avoided. New commands (e.g. `UNDO`, `REDO`) MUST be
     appended with new IDs rather than reusing or shifting
     existing ones.
+- **WebViewAttachListener** (new public functional interface,
+  `src/ca/weblite/webview/WebViewAttachListener.java`). Two
+  methods: `void onAttached(EmbeddedWebView webView)` and
+  `void onAttachFailed(EmbeddedWebView webView, Throwable cause)`.
+  Documented to fire on the Swing EDT. Invariants:
+  - Listeners MAY be registered before or after attach
+    resolves. Registration after resolution fires the
+    corresponding callback on the next EDT tick (via
+    `SwingUtilities.invokeLater`), never inline on the
+    calling thread.
+  - Multiple listeners are supported; they fire in
+    registration order.
+  - The `cause` argument on `onAttachFailed` carries an
+    actionable message identifying the failure step (e.g.
+    "WKWebView allocation failed", "host NSView not found").
+    Implementations MAY downcast to a more specific
+    exception type if a richer contract is exposed in a
+    future revision.
+  - Listener-thrown exceptions propagate to AWT's
+    uncaught-exception handler (same convention as every
+    other EDT-marshalled callback in this canvas);
+    implementations SHOULD catch their own exceptions if
+    they do not want default AWT behaviour.
+- **AttachState** (new public enum,
+  `src/ca/weblite/webview/AttachState.java`). Values:
+  `PENDING`, `ATTACHED`, `FAILED`. Exposed via
+  `EmbeddedWebView.getAttachState(): AttachState`.
+  Invariants:
+  - State transitions occur only on the EDT.
+  - `PENDING → ATTACHED` and `PENDING → FAILED` are the only
+    legal transitions; `ATTACHED` and `FAILED` are terminal.
+  - On Windows and Linux, the engine enters `ATTACHED`
+    synchronously during the `EmbeddedWebView` constructor.
+  - On macOS, the engine enters `ATTACHED` or `FAILED`
+    asynchronously after `cocoa_create_engine`'s async
+    epilogue completes — driven by a JNI callback that
+    marshals onto the EDT before flipping the state.
+- **EmbeddedWebView additions for async attach / destroy and
+  responder cache** (extends the existing entity above).
+  Invariants:
+  - `attachState: AttachState` — initialised based on the
+    platform-specific return shape of `webview_embed_create`
+    (see Operation 1 and Operation 14).
+  - `attachFailure: Throwable` — null until `FAILED`
+    transition.
+  - `attachListeners: List<WebViewAttachListener>` —
+    registered listeners. Cleared after the resolve dispatch
+    fires (no further callbacks once the engine resolves);
+    a fresh list is rebuilt only if a caller registers
+    additional listeners post-resolution (each of which
+    fires immediately on the next EDT tick).
+  - New method `addOnAttachComplete(WebViewAttachListener listener)`:
+    appends to `attachListeners` (when `PENDING`) or
+    schedules an immediate `invokeLater` dispatch (when
+    `ATTACHED` / `FAILED`). MUST be safe to call before or
+    after resolution. Returns `this` for chaining.
+  - New method `getAttachState(): AttachState`: read the
+    current state. Useful for tests and for callers that
+    prefer polling over listeners.
+  - The pre-existing `peer` field is non-zero from the moment
+    `EmbeddedWebView` is constructed (the C++ `Engine` struct
+    allocation is still synchronous on every platform); only
+    the AppKit-side state inside the struct is deferred on
+    macOS. `checkAlive()` keeps its existing
+    `peer == 0L` semantics — it is NOT used to gate
+    pre-attach calls on `PENDING`. Methods that today call
+    `checkAlive()` continue to call it; they remain safe
+    because the native lambdas they enqueue null-check
+    `e->webview` / `e->manager` at fire time.
+- **C++ Engine struct additions for async lifecycle and
+  responder cache** (`src_c/webview_embed.cpp`). Invariants:
+  - `is_first_responder: std::atomic<bool>` — mirrored
+    AppKit-main-thread state. Written by the KVO observer
+    callback only; read by `cocoa_is_first_responder` from
+    any thread. Default-initialised to `false`.
+  - `destroyed: std::atomic<bool>` — set to `true` inside
+    the destroy async lambda before any AppKit teardown
+    runs. Read by every other async-on-main lambda at fire
+    time as a belt-and-suspenders short-circuit; the
+    primary correctness guarantee is dispatch-queue FIFO
+    ordering plus EDT-only enqueueing, but the flag closes
+    any hypothetical non-EDT-enqueue race and provides a
+    clean signal for the `cocoa_eval` late-failure path
+    (see Operation 14).
+  - `kvo_observer: id` — strong reference to the KVO observer
+    target (an `NSObject` subclass owned by this engine).
+    Registered against the host `NSWindow`'s `firstResponder`
+    key path when the WKWebView gains a non-nil window;
+    unregistered before the engine struct is freed. May be
+    re-registered against a new window if the WKWebView's
+    `window` property changes at runtime.
+  - `observed_window: id` — weak/unretained back-reference
+    to the NSWindow the observer is currently registered
+    against. Used by destroy / window-change to call
+    `removeObserver:forKeyPath:` against the right target;
+    never `release`d (it's an unowned back-pointer).
 
 ## A · Approach
 - **Heavyweight peer hosts the native view.** AWT/JAWT exposes a
@@ -505,6 +682,188 @@ generated_at: 2026-05-16T07:19:13-07:00
   The hook is the canonical mechanism for surfacing in-WebView
   user input back to Swing for purposes AWT's event queue would
   normally handle.
+- **No sync EDT→AppKit-main bridge in the macOS path.** The
+  previous design (v1.0.5, PR #30) routed every EDT→main hop
+  through `-[NSObject performSelectorOnMainThread:withObject:
+  waitUntilDone:YES modes:]` with `AWTRunLoopMode` in the
+  modes array, expecting that to break the
+  EDT-parked-while-main-parked-in-AWT-doAWTRunLoopImpl cycle.
+  It does break that one specific ordering, but it does NOT
+  close the inverse cycle: if our `cocoa_run_on_main` block
+  has already begun executing on the main thread and the
+  block's body drives an AppKit primitive (e.g. `addSubview:`)
+  that synchronously rendezvous with the EDT through
+  AppKit accessibility / IME / `LWCToolkit.invokeAndWait`,
+  the EDT is still parked on the original `performSelector`'s
+  semaphore and the cycle closes. The fix is to eliminate
+  the sync EDT→main bridge entirely. Three sync sites
+  (`cocoa_is_first_responder`, `cocoa_create_engine`,
+  `cocoa_destroy_engine`) are converted to async-or-cached
+  equivalents; once all three are gone, the
+  `cocoa_run_on_main` helper, the `WebViewAwtMainBridge`
+  Objective-C class, and the `performWork:` selector are
+  removed. The three conversion strategies are documented
+  in the three following Approach entries.
+- **Cached first-responder via KVO on
+  `NSWindow.firstResponder`.** The previous sync probe
+  walked the responder chain on the AppKit main thread on
+  every call; each call was a deadlock surface for the
+  editing-shortcut dispatcher's hot path. The replacement
+  mirrors the responder state into an `std::atomic<bool>`
+  field on the `Engine`. A KVO observer on the host
+  `NSWindow`'s `firstResponder` key path fires on the main
+  thread for every focus transition anywhere in the
+  window's responder hierarchy; the observer callback walks
+  the responder chain using the same logic the previous
+  sync probe used (which correctly handles inner WebKit
+  content views by walking upward) and writes the atomic.
+  The atomic read in `cocoa_is_first_responder` is now
+  lock-free with no thread hop. Trade-off accepted:
+  swizzling `WKWebView`'s own `becomeFirstResponder` /
+  `resignFirstResponder` (already done elsewhere in this
+  canvas for the focus-callback path) was considered as the
+  sole cache-update mechanism but rejected — focus on
+  inner content views (`<input>`, contentEditable) does not
+  pass through `WKWebView`'s own responder methods, so the
+  cache would be wrong. KVO on the window's firstResponder
+  observes every transition. The KVO observer's lifecycle
+  is tied to the engine and the WKWebView's current window:
+  registered lazily on the first non-nil window (the
+  WKWebView's `window` property is observed in case it is
+  initially nil, which is the AppKit policy during view
+  hierarchy construction), unregistered on destroy, and
+  re-registered against any new window if the WKWebView
+  ever moves between windows at runtime.
+- **Async engine attach with FIFO-queue-ordered pre-attach
+  ops.** The previous design ran all of WKWebView creation,
+  host-view discovery, `addSubview:`, and configuration
+  synchronously on the AppKit main thread with the EDT
+  parked on a semaphore. `addSubview:` triggers AppKit
+  accessibility metadata queries against the AWT host view,
+  which the JDK answers via `LWCToolkit.invokeAndWait` —
+  and the EDT is parked above, so the cycle closes. The
+  fix splits `cocoa_create_engine` into a synchronous
+  prologue (allocate the C++ `Engine` struct, take the JAWT
+  lock long enough to retain `surface_layers`, install the
+  `EvalDispatcher` and the eval-bridge JNI globals on the
+  Java side) and an async epilogue (`cocoa_run_on_main_async`)
+  that does the AppKit-side setup. The JNI entry point
+  returns immediately after the prologue with a valid C++
+  `Engine` pointer; the AppKit-side success/failure resolves
+  later and is posted back to the EDT via a JNI callback
+  that flips `EmbeddedWebView.attachState` and fires any
+  registered `WebViewAttachListener`s. **Pre-attach op
+  ordering is solved by the macOS main dispatch queue
+  itself.** `dispatch_get_main_queue()` is a documented
+  serial FIFO queue — blocks fire one at a time in enqueue
+  order. The attach epilogue is the first block enqueued;
+  every subsequent `cocoa_navigate` / `cocoa_eval` /
+  `cocoa_init_script` / `cocoa_set_bounds` /
+  `cocoa_request_focus` / `cocoa_set_visible` /
+  `cocoa_execute_editing_command` call enqueues its own
+  async block and they fire in registration order, AFTER
+  the attach block, with `e->webview` and `e->manager`
+  populated. Each per-op block already null-checks the
+  field at fire time and silently no-ops if cleared (for
+  the destroy-side race), so the implementation pattern
+  already handles the pre-attach case at zero additional
+  cost. No Java-level pre-attach buffer is introduced in
+  `EmbeddedWebView`; the pre-paint buffer in
+  `WebViewHeavyweightComponent` (its `pendingUrl` /
+  `pendingInit` / `pendingBindings` fields) keeps working
+  exactly as today, layered above this lower-level mechanism.
+  The one operation that previously ran synchronously on the
+  calling thread — `cocoa_bind` (mutates `e->bindings`) —
+  MUST be converted to an async-on-main lambda so it
+  enqueues after the attach block (FIFO) and serialises
+  against the script-message-handler delegate's reads
+  (which also run on main). Alternatives considered:
+  - Java-level pre-attach buffer in `EmbeddedWebView`
+    (mirroring the heavyweight component's pattern).
+    Rejected as the primary mechanism — duplicates the
+    FIFO-queue ordering invariant that the macOS main queue
+    already provides. Kept available as a fallback if
+    testing reveals a queue-ordering edge case.
+  - Keep `cocoa_bind` sync with a `std::mutex` around
+    `e->bindings`. Rejected — converting to async keeps
+    the "every per-engine native op is async" invariant
+    uniform and trivially serialises against the
+    script-message-handler's reads.
+  - Move to a `CompletableFuture<EmbeddedWebView>` attach
+    factory. Rejected — every existing caller would have
+    to be rewritten; the listener API serves the same
+    purpose with no break.
+- **`EmbeddedWebView.attach(...)` stays a synchronous Java
+  factory.** The Java signature is unchanged across all
+  platforms. On Windows / Linux, attach completes
+  synchronously inside the JNI call as today and the
+  returned `EmbeddedWebView` is in `ATTACHED` state by the
+  time it is observable. On macOS, attach returns in
+  `PENDING` state and resolves asynchronously. Pre-attach
+  method calls on a `PENDING` engine MUST NOT throw — they
+  enqueue native async blocks that fire after the attach
+  epilogue, exactly as post-attach calls do. The contract
+  the caller sees is: "after `attach(...)` returns, the
+  `EmbeddedWebView` is fully usable; setUrl / addBinding /
+  eval / etc. all work; if you want a definite signal that
+  the native view is on-screen, register a
+  `WebViewAttachListener`."
+- **Synchronous failure path preserved for C++ allocation
+  failure.** If the C++ `Engine` struct allocation itself
+  fails (out-of-memory, JAWT lock failure, missing JAWT on
+  the platform), `webview_embed_create` returns `0` and
+  `EmbeddedWebView.attach(...)` throws
+  `IllegalStateException` synchronously, exactly as today.
+  Only the AppKit-side phase is moved async. The new
+  listener-driven failure path covers the AppKit-side
+  failures (WKWebView allocation returns nil, no hostable
+  NSView discovered) that did not previously exist as a
+  distinct failure mode.
+- **Async engine destroy with `destroyed` flag belt-and-
+  suspenders.** The previous design ran `removeFromSuperview`
+  and view-hierarchy teardown synchronously on the AppKit
+  main thread with the EDT parked. `removeFromSuperview`
+  triggers the same AppKit accessibility metadata path as
+  `addSubview:`, so the destroy side has the same deadlock
+  surface. The fix moves the entire AppKit teardown
+  (`removeFromSuperview`, host-view release, surface-layers
+  release, webview release, config release, KVO observer
+  unregistration) and the C++ `delete e` call into a
+  `cocoa_run_on_main_async` lambda. The JNI entry returns
+  immediately. The Java-side teardown sequence (drain
+  `evalDispatcher`, clear focus / click callbacks via
+  `setFocusCallback(null)` / `setClickCallback(null)`, set
+  `peer = 0L`, then `webview_embed_destroy`) is preserved
+  unchanged — those steps run on the calling thread (EDT)
+  BEFORE the async destroy lambda is enqueued, exactly as
+  today. **Use-after-free safety**: a `destroyed:
+  std::atomic<bool>` flag on the `Engine` is set to `true`
+  at the top of the destroy lambda before any AppKit
+  teardown runs. Every other async-on-main lambda
+  (navigate / eval / init / setBounds / setVisible /
+  requestFocus / executeEditingCommand) reads the flag at
+  fire time and short-circuits cleanly if `true`. **The
+  primary correctness guarantee is FIFO dispatch-queue
+  ordering plus EDT-only enqueueing** — no async lambda is
+  ever enqueued after destroy is, so no lambda fires after
+  destroy fires. The flag is belt-and-suspenders against
+  (a) destroy being called from a non-EDT thread
+  (hypothetical), (b) future code changes that violate the
+  EDT-only-enqueue invariant, and (c) the `cocoa_eval`
+  late-completion path that needs to report "WebView
+  disposed" back to a `CompletableFuture`. Trade-off:
+  callers who relied on "after `dispose()` returns, the
+  WKWebView is fully detached from the view hierarchy"
+  will see the detachment happen up to one main-loop tick
+  later. No current caller depends on this — the demos
+  and `WebViewHeavyweightComponent` do not observe AppKit
+  state from Java after dispose — but is documented for
+  future readers. Alternative considered: a generation
+  counter (`std::atomic<uint64_t>`) instead of a flag.
+  Rejected as over-engineering — engines in this library
+  are never reused, and the flag is sufficient for the
+  current contract. The counter design can be reintroduced
+  later if an engine-reset operation is ever needed.
 
 ## S · Structure
 - `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
@@ -527,6 +886,19 @@ generated_at: 2026-05-16T07:19:13-07:00
   per-platform native click hook once per mouse-button press
   inside the heavyweight WebView's native surface. Mirrors the
   shape of the existing `WebViewFocusCallback`.
+- `src/ca/weblite/webview/WebViewAttachListener.java` (new) —
+  public functional interface with two methods:
+  `void onAttached(EmbeddedWebView)` and
+  `void onAttachFailed(EmbeddedWebView, Throwable)`. Registered
+  on `EmbeddedWebView` via the new `addOnAttachComplete`
+  method; the callbacks fire on the Swing EDT. On Windows /
+  Linux the listener fires synchronously on the next EDT tick
+  because attach completes inside the constructor; on macOS it
+  fires asynchronously once the AppKit-side setup resolves.
+- `src/ca/weblite/webview/AttachState.java` (new) — public
+  enum with values `PENDING`, `ATTACHED`, `FAILED`. Returned
+  by `EmbeddedWebView.getAttachState()`. State transitions
+  are EDT-only.
 - `src/ca/weblite/webview/ConsoleDispatcher.java` (from
   [[swing-webview-component-mode-selection]]) — owned by the
   component; receives raw payloads from the internal
@@ -566,6 +938,31 @@ generated_at: 2026-05-16T07:19:13-07:00
   `mouseDown:`/`rightMouseDown:`/`otherMouseDown:` swizzle on
   macOS, `WM_PARENTNOTIFY` on Windows) reads that ref and
   invokes the Java callback's `invoke()` method.
+  macOS-specific structural changes for the sync-deadlock
+  elimination work (see Operation 14): the
+  `cocoa_run_on_main` synchronous helper, the
+  `WebViewAwtMainBridge` Objective-C class, the
+  `performWork:` selector, and the `ensure_awt_main_bridge`
+  / `awt_bridge_box` / `awt_main_bridge_perform_impl`
+  scaffolding are removed; the `g_awt_main_bridge_cls` /
+  `g_awt_main_bridge_target` / `g_awt_main_bridge_modes` /
+  `g_awt_main_bridge_once` file-scope statics are removed.
+  `cocoa_create_engine` is split into a synchronous prologue
+  + `cocoa_run_on_main_async` epilogue; `cocoa_destroy_engine`
+  becomes fully async; `cocoa_is_first_responder` reads an
+  atomic on the `Engine` struct. The `Engine` struct gains
+  `is_first_responder: std::atomic<bool>`, `destroyed:
+  std::atomic<bool>`, `kvo_observer: id`, and
+  `observed_window: id` fields. `cocoa_bind` becomes async
+  on main (FIFO-ordered after the attach epilogue) instead
+  of mutating `e->bindings` synchronously on the calling
+  thread. The JNI export for `webview_embed_create` keeps
+  its `jlong`-returning signature on every platform; the
+  macOS side returns the freshly-allocated `Engine*` after
+  the synchronous prologue. A new JNI callback channel
+  (declared on `WebViewNative`) carries the AppKit-side
+  attach success / failure outcome from the async epilogue
+  back to the EDT.
 - `demos/WebViewHeavyweightDemo/...` — interactive demo that
   exercises the trickier scenarios (combo-box popups over the
   WebView, `JTabbedPane` tab visibility, and on-demand
@@ -709,6 +1106,29 @@ File: `src/ca/weblite/webview/EmbeddedWebView.java`
        `WebViewNative.webview_embed_open_devtools(peer)`;
        return `(result == 1)`. Does NOT touch `heap` or
        `bindings` — pure side-effect call.
+   - `addOnAttachComplete(WebViewAttachListener listener): EmbeddedWebView` (new)
+     - Null-check `listener` (throw `NullPointerException`
+       with a message naming the parameter).
+     - If `attachState == PENDING`, append the listener to
+       `attachListeners`.
+     - If `attachState == ATTACHED`, schedule
+       `SwingUtilities.invokeLater` that calls
+       `listener.onAttached(this)`. MUST NOT fire inline on
+       the calling thread.
+     - If `attachState == FAILED`, schedule
+       `SwingUtilities.invokeLater` that calls
+       `listener.onAttachFailed(this, attachFailure)`. MUST
+       NOT fire inline.
+     - Returns `this` for chaining. Pure side-effect; does
+       NOT touch `heap` or `bindings`. Safe to call before
+       or after attach resolves and from the EDT only — the
+       method MAY assume EDT thread (document this) so the
+       state read and the list append do not need explicit
+       synchronisation.
+   - `getAttachState(): AttachState` (new)
+     - Read and return `attachState`. EDT-only. Useful for
+       tests and for callers that prefer polling over
+       listeners.
 4. Constraints / Invariants:
    - `checkAlive` throws `IllegalStateException` after dispose
      (`EmbeddedWebView.java:204`).
@@ -1061,7 +1481,17 @@ Files:
        that the user is interacting with the WebView,
        because AWT's focus owner stays on whichever Swing
        component last had focus while the WKWebView holds
-       native first-responder status.
+       native first-responder status. The macOS native body
+       MUST NOT perform a synchronous main-thread hop on
+       this call — it MUST read the cached
+       `is_first_responder` atomic on the `Engine` struct,
+       maintained by the KVO observer on
+       `NSWindow.firstResponder` (see Operation 14). The
+       dispatcher's hot path on every editing keystroke is
+       therefore a lock-free atomic load with no thread
+       hop; the previous synchronous probe (which is the
+       sync site the `WebViewDeadlockRepro` demo wedges on)
+       is gone.
    - **Default to deferring to Swing.** If both signals are
      false, return `false` so AWT delivers the event to its
      focus owner via the normal dispatch path. This is the
@@ -1627,6 +2057,289 @@ Files:
      currently selected, so the callback can fire on every
      click without worrying about the current popup state.
 
+### 14. Eliminate Sync EDT↔AppKit Bridge (macOS)
+Files:
+- `src/ca/weblite/webview/WebViewAttachListener.java` (new
+  public functional interface)
+- `src/ca/weblite/webview/AttachState.java` (new public
+  enum)
+- `src/ca/weblite/webview/EmbeddedWebView.java` (new
+  `attachState` / `attachFailure` / `attachListeners`
+  fields, `addOnAttachComplete`, `getAttachState`, and the
+  internal JNI callback that resolves the attach state on
+  the EDT; no signature change to the existing `attach`
+  factory)
+- `src/ca/weblite/webview/WebViewNative.java` (one new
+  JNI entry point for the attach-completion callback
+  registration; signature is platform-uniform, native
+  bodies on Windows / Linux fire the callback immediately)
+- `src_c/webview_embed.cpp` (the three sync-site removals
+  plus the helper teardown)
+- `windows/webview_embed.cc` (immediate-fire attach
+  callback)
+- `demos/WebViewDeadlockRepro/...` (extension to drive the
+  long-run attach → focus → Cmd-C → dispose stress loop
+  for the 5-minute test)
+
+1. Responsibility: structurally eliminate the class of
+   EDT↔AppKit-main mutual-wait deadlock from the macOS
+   heavyweight WebView implementation by removing every
+   synchronous EDT→AppKit-main dispatch primitive in
+   `src_c/webview_embed.cpp`. Three concrete sync sites
+   are converted; the synchronous helper plumbing is then
+   removed. The Java-visible API surface is augmented with
+   a deferred-completion listener (`WebViewAttachListener`)
+   that fires on the EDT, but `EmbeddedWebView.attach(...)`
+   remains a synchronous factory so existing callers are
+   unaffected. Cross-platform: the new Java API exists on
+   every platform; on Windows / Linux the listener fires
+   immediately because attach is already synchronous.
+
+2. Cached first-responder via KVO on
+   `NSWindow.firstResponder` (closes
+   `cocoa_is_first_responder` sync site):
+   - Add `is_first_responder: std::atomic<bool>` to the
+     `Engine` struct, default-initialised `false`.
+   - Define a small Objective-C class
+     (`WebViewKvoObserver` or similar) whose
+     `observeValueForKeyPath:ofObject:change:context:`
+     method recomputes the responder state by walking the
+     responder chain from `[window firstResponder]` upward
+     through `superview` looking for `e->webview` (same
+     walk the previous synchronous probe used,
+     `webview_embed.cpp:2004-2019`). The observer holds a
+     back-pointer to its owning `Engine` via
+     `objc_setAssociatedObject` or a direct field; it
+     writes the result into `e->is_first_responder` with
+     `store(value)`.
+   - Observer lifecycle: register lazily on the first
+     non-nil window. Because the WKWebView's `window`
+     property may be transiently nil at the moment of
+     `addSubview:` (AppKit policy during view-hierarchy
+     construction), observe the WKWebView's own `window`
+     key path with a one-shot KVO; on the first non-nil
+     window, register the firstResponder observer on that
+     window and recompute the atomic immediately, then
+     either leave the window observer in place (to handle
+     subsequent window changes — see below) or
+     short-circuit further triggers as appropriate.
+   - Window-change handling: if the WKWebView ever moves
+     between windows (e.g. user drags the JFrame across
+     screens, or a re-parenting operation), the
+     `window`-keypath observer fires again; the
+     implementation unregisters the firstResponder
+     observer from the previous window's
+     `observed_window` (if any) and registers it on the
+     new window, then recomputes the atomic.
+   - Refactor `cocoa_is_first_responder` to a single line:
+     `return e ? e->is_first_responder.load() : 0;`. No
+     thread hop, no responder-chain walk on the EDT side.
+   - Observer registration runs inside the attach epilogue
+     (which is `cocoa_run_on_main_async` after the changes
+     in step 3); observer unregistration runs inside the
+     destroy lambda (step 4) BEFORE any view release. On
+     window-change the unregister/register happens on the
+     main thread within the observer callback itself.
+   - The existing swizzled `becomeFirstResponder` /
+     `resignFirstResponder` hooks on `WKWebView` are NOT
+     repurposed for the cache; they stay scoped to the
+     existing focus-callback delivery (Operation 11).
+     Rationale per Approach: those swizzles do not fire
+     for focus on inner WebKit content views.
+
+3. Async engine attach (closes `cocoa_create_engine` sync
+   site):
+   - Split `cocoa_create_engine` into:
+     - Synchronous prologue (runs on the calling thread,
+       typically EDT): allocate the C++ `Engine` struct
+       with `new Engine()`; record `e->jvm`,
+       `e->debug`. Acquire the JAWT lock long enough to
+       retain `surface_layers` (existing
+       `JawtLock` pattern); on JAWT lock failure return
+       0 (matches today's `delete e; return nullptr;`
+       synchronous-failure path). After the prologue
+       succeeds, `webview_embed_create` returns the
+       `Engine*` cast to `jlong` immediately.
+     - Async epilogue (`cocoa_run_on_main_async`, runs
+       on the AppKit main thread later): install the
+       focus / click / first-responder swizzles
+       (existing `std::call_once` guards apply); alloc
+       and init the WKWebView; register in
+       `g_webview_map`; find the host NSView; call
+       `[host setWantsLayer:YES]`; call
+       `[host addSubview:e->webview]`; install the
+       script-message-handler delegate and the
+       `external.invoke` shim; if `debug`, set
+       `developerExtrasEnabled` / `setInspectable:`;
+       register the KVO observer per step 2; finally
+       post the success outcome back to the EDT (see
+       step 6).
+   - On any AppKit-side failure inside the async
+     epilogue (WKWebView alloc returned nil, no
+     hostable NSView discovered), post a failure
+     outcome to the EDT carrying an actionable message
+     identifying the failure step, then proceed to
+     release whatever AppKit objects were allocated so
+     far, drop the entry from `g_webview_map` (if it
+     was inserted), and `delete e`. The C++ `Engine`
+     struct MUST NOT leak on the async-failure path.
+   - The synchronous return of a non-zero `Engine*`
+     before the async epilogue runs is the macOS
+     behavioural change. Windows and Linux retain their
+     existing synchronous-create semantics inside their
+     own JNI bodies.
+
+4. Async engine destroy (closes `cocoa_destroy_engine`
+   sync site):
+   - Add `destroyed: std::atomic<bool>` to the `Engine`
+     struct, default `false`.
+   - Pre-destroy work on the calling thread (EDT)
+     remains as today and runs BEFORE the async lambda
+     is enqueued: drop `e->webview` from
+     `g_webview_map` under `g_webview_map_mutex`;
+     release the `focus_callback` JNI global ref;
+     release the `click_callback` JNI global ref.
+     Rationale: these refs must be cleared before the
+     swizzled responder / mouse hooks could fire into a
+     freed Java ref.
+   - The remaining teardown moves into a
+     `cocoa_run_on_main_async` lambda:
+     `e->destroyed.store(true)` first; unregister the
+     KVO firstResponder observer from
+     `e->observed_window` (if any) and the
+     `window`-keypath observer from `e->webview`; clear
+     `e->kvo_observer` / `e->observed_window`; call
+     `[e->webview removeFromSuperview]`; release
+     `e->host_view` / `e->surface_layers` /
+     `e->webview` / `e->config`; walk `e->bindings`
+     releasing each Java global ref (the JNI attach /
+     detach pattern existing destroy uses); `delete e`.
+     The JNI entry returns immediately after enqueueing
+     the lambda.
+   - Every other async-on-main lambda
+     (`cocoa_navigate` / `cocoa_eval` /
+     `cocoa_init_script` / `cocoa_set_bounds` /
+     `cocoa_set_visible` / `cocoa_request_focus` /
+     `cocoa_execute_editing_command` / `cocoa_bind`)
+     reads `e->destroyed.load()` at the top of the
+     lambda and short-circuits cleanly if `true`. For
+     `cocoa_eval` specifically, the late-fire short-
+     circuit MUST NOT raise an exception or write to a
+     freed pointer; the corresponding
+     `CompletableFuture<String>` is already drained
+     exceptionally by `EmbeddedWebView.dispose()` via
+     `evalDispatcher.disposeAllPending()` before the
+     JNI destroy call, so the native-side short-circuit
+     is belt-and-suspenders.
+
+5. `cocoa_bind` async conversion (required by step 3):
+   - The existing `cocoa_bind(Engine *e, Binding *b) {
+     e->bindings[b->name] = b; }` mutates `e->bindings`
+     synchronously on the calling thread (EDT). Under
+     async attach the script-message-handler delegate
+     might read `e->bindings` on the main thread before
+     the EDT's write is visible. Wrap the body in
+     `cocoa_run_on_main_async([=] { … })` so the map
+     write runs on main and serialises against the
+     delegate's reads. Pre-attach `addJavascriptCallback`
+     calls thus enqueue after the attach epilogue (FIFO),
+     are picked up by the delegate at JS-call time, and
+     the existing
+     `WebViewHeavyweightComponent.createPeer` replay
+     order (bindings before navigate) is preserved.
+
+6. Attach-completion JNI bridge:
+   - Declare a JNI entry point on `WebViewNative` for
+     registering an attach-completion callback against a
+     peer, with a Java-side signature shaped like
+     `webview_embed_set_attach_callback(long peer, Object
+     callback)`. The Java callback object is a small
+     internal type owned by `EmbeddedWebView`; its
+     `onResolved(boolean ok, String failureMessage)`
+     method is invoked from the native side via JNI.
+   - macOS native body: store a JNI global ref to the
+     callback on the `Engine`. The async attach epilogue,
+     on success, calls the global ref's `onResolved(true,
+     null)`; on failure, calls `onResolved(false,
+     failureMessage)`. The native call attaches the
+     current thread to the JVM if needed (same pattern as
+     `fire_focus_callback`) and detaches after. The
+     callback in turn marshals to the EDT via
+     `SwingUtilities.invokeLater` — either inside the JNI
+     callback's Java body, or by having the C++ side
+     enqueue an `invokeLater` directly. Either is valid;
+     the listener firing rule (Norms) is that
+     `WebViewAttachListener` callbacks fire on the EDT.
+   - Windows / Linux native bodies: fire `onResolved(true,
+     null)` immediately during `webview_embed_create`
+     (the synchronous path), so the Java side observes
+     `ATTACHED` as soon as the constructor returns.
+   - Java side: `EmbeddedWebView` constructor registers
+     the callback BEFORE returning from `attach(...)`.
+     The callback flips `attachState` from `PENDING` to
+     `ATTACHED` or `FAILED`, captures `attachFailure` on
+     failure, and fires every registered listener via
+     `SwingUtilities.invokeLater` in registration order.
+
+7. Helper removal (after steps 2–6 land):
+   - Remove the `cocoa_run_on_main` synchronous helper
+     and the entire `WebViewAwtMainBridge` /
+     `performWork:` / `ensure_awt_main_bridge` /
+     `awt_bridge_box` / `awt_main_bridge_perform_impl`
+     scaffolding from `src_c/webview_embed.cpp`. Remove
+     the file-scope statics
+     `g_awt_main_bridge_cls`,
+     `g_awt_main_bridge_target`, `g_awt_main_bridge_modes`,
+     `g_awt_main_bridge_once`. Grep `src/`, `src_c/`,
+     `windows/`, and `demos/` for `cocoa_run_on_main`
+     (without `_async`) and `WebViewAwtMainBridge` /
+     `performWork:` — there MUST be zero matches in
+     production code after this step.
+
+8. Deadlock-repro long-run test
+   (`demos/WebViewDeadlockRepro/...`):
+   - Extend the demo with a stress mode that runs an
+     attach → wait for `onAttached` → request focus →
+     simulate Cmd-C → dispose loop for at least 5
+     minutes. The existing 5-second EDT watchdog stays
+     in place; the demo MUST exit cleanly with a zero
+     status code after the configured duration without
+     the watchdog firing.
+   - Run locally under Address Sanitizer (`ASAN_OPTIONS`
+     compatible with the existing Mac demo runner); any
+     UAF attributable to the destroy path MUST surface
+     during this test.
+
+9. Constraints / Invariants:
+   - Every per-engine native operation on macOS MUST run
+     via `cocoa_run_on_main_async` (or inline when
+     already on main). No new synchronous EDT→main
+     dispatch primitive may be introduced in
+     `src_c/webview_embed.cpp`.
+   - State that the EDT needs to read about the AppKit
+     main thread MUST be cached in an `std::atomic` on
+     the `Engine` struct, written from the main thread.
+     Direct synchronous reads of AppKit-thread state
+     from the EDT are forbidden.
+   - `dispatch_get_main_queue()` ordering (serial FIFO)
+     is load-bearing for pre-attach op replay. Any change
+     that uses a different queue, multiple queues, or
+     introduces concurrent dispatch breaks the
+     no-Java-buffer invariant and must be redesigned.
+   - The KVO observer MUST be unregistered before any
+     view release in the destroy lambda. AppKit logs a
+     warning (and may crash in some configurations) if
+     an observed object is released while observers are
+     still registered.
+   - The synchronous return shape of `webview_embed_create`
+     is preserved: it returns the C++ `Engine*` as
+     `jlong`, or 0 on synchronous prologue failure. Java
+     callers continue to throw `IllegalStateException`
+     on a zero return.
+   - The Windows and Linux native paths are NOT modified
+     by this Operation, except for the immediate-fire
+     attach-completion callback in step 6.
+
 ## N · Norms
 - All AWT/JAWT interaction must respect the rule that the
   native peer is only valid while the host AWT Component is
@@ -1700,39 +2413,68 @@ Files:
   than adding new native hooks per use case. Keep the Java
   handler narrowly scoped so the call cost is bounded for
   every WebView click.
-- macOS sync main-thread dispatch (`embed::cocoa_run_on_main` in
-  `src_c/webview_embed.cpp`) MUST NOT use
-  `dispatch_sync(dispatch_get_main_queue(), …)` from the EDT.
-  AppKit's main thread routinely parks inside
-  `-[LWCToolkit doAWTRunLoopImpl]`'s private CFRunLoop while it
-  waits for the EDT to answer a JNI callback (the AX
-  `accessibilityFocusedUIElement` query during a VoiceOver
-  focus-changed event is the canonical trigger, but any
-  AppKit→Java upcall through `doAWTRunLoopImpl` qualifies —
-  IME callbacks, AWT-EDT round-trips). That private runloop
-  runs only in `@"AWTRunLoopMode"` and does NOT drain the main
-  dispatch queue; combined with the EDT blocking on
-  `dispatch_sync` waiting for the main thread, this is an
-  unconditional EDT-↔-main deadlock. The fix — required for
-  every sync main-thread bridge in this codebase — is to use
+- macOS sync EDT→AppKit-main bridge in
+  `src_c/webview_embed.cpp` is PROHIBITED. No code path
+  in the macOS portion of `webview_embed.cpp` may block the
+  EDT waiting for the AppKit main thread — not via
+  `dispatch_sync(dispatch_get_main_queue(), …)`, not via
   `-[NSObject performSelectorOnMainThread:withObject:
-  waitUntilDone:YES modes:]` with a mode array that includes
-  `@"AWTRunLoopMode"` alongside the normal AppKit modes
-  (`kCFRunLoopDefaultMode`, `NSEventTrackingRunLoopMode`,
-  `NSModalPanelRunLoopMode`). This matches the JDK's own
-  `sun.lwawt.macosx.ThreadUtilities.javaModes` set and is the
-  canonical "talk to AppKit from a JNI call on the EDT"
-  pattern. The wrapper class
-  (`WebViewAwtMainBridge` / `performWork:`) is registered once
-  per JVM via `std::call_once`, symmetric with the existing
-  swizzle / `WebviewEmbedDelegate` once-only registrations.
-  See the bug report "WebViewHeavyweightComponent deadlocks the
-  EDT when the WebView peer is created during macOS
-  accessibility focus events" for the original trace. The
-  async helper `cocoa_run_on_main_async` is unaffected — it
-  uses `dispatch_async_f` and never blocks the EDT, so a queued
-  block sitting in the main queue while
-  `doAWTRunLoopImpl` runs is latency, not deadlock.
+  waitUntilDone:YES modes:]`, not via any custom semaphore /
+  condition-variable rendezvous, and not via any new
+  helper that has those semantics. The previous Norm (which
+  mandated `performSelectorOnMainThread:modes:` with
+  `AWTRunLoopMode`) is retired by Operation 14 because it
+  only closes one ordering of the deadlock cycle: it does
+  NOT prevent the case where our own main-thread block has
+  already begun executing and its body (e.g.
+  `[host addSubview:e->webview]`) synchronously rendezvous
+  with the EDT through AppKit accessibility / IME /
+  `LWCToolkit.invokeAndWait`, with the EDT still parked on
+  the original `performSelector` semaphore. The structural
+  fix is to eliminate every sync EDT→main hop. Specifically:
+  - Every per-engine native operation MUST run via
+    `cocoa_run_on_main_async` (or inline when already on
+    main), and `cocoa_run_on_main_async` MUST remain
+    asynchronous (`dispatch_async_f` to
+    `dispatch_get_main_queue()`); queued blocks sitting in
+    the main queue while `doAWTRunLoopImpl` runs are
+    latency, not deadlock.
+  - Any AppKit-main-thread state that the EDT needs to
+    read MUST be mirrored into an `std::atomic` on the
+    `Engine` struct, written from the main thread (e.g. by
+    a KVO observer callback, a swizzled responder hook,
+    or the destroy lambda) and read lock-free from the
+    EDT. The cached first-responder flag
+    (`is_first_responder`) is the canonical example.
+  - Pre-attach op ordering is provided by
+    `dispatch_get_main_queue()`'s documented FIFO serial
+    semantics. Any change that uses a different queue,
+    introduces a concurrent dispatch queue, or otherwise
+    breaks the FIFO-after-attach invariant is forbidden
+    by this Norm because it would force the
+    re-introduction of an explicit pre-attach buffer (or
+    worse, a sync bridge).
+  - The synchronous helper `cocoa_run_on_main` and the
+    `WebViewAwtMainBridge` / `performWork:` /
+    `ensure_awt_main_bridge` scaffolding MUST NOT be
+    reintroduced. They were removed by Operation 14 step
+    7; any code-review observation that they are
+    "missing" should be redirected to the documented
+    async pattern.
+  Rationale and history: the v1.0.5 fix from PR #30
+  (commit `dcda4cf`) introduced the
+  `performSelectorOnMainThread:modes:` mechanism to close
+  one specific ordering. The demo at
+  `demos/WebViewDeadlockRepro` reproduces the inverse
+  ordering it does NOT close, where the EDT enters
+  `cocoa_run_on_main` for `cocoa_is_first_responder` while
+  the AppKit main thread is parked in `invokeAndWait`
+  waiting for the EDT to drain a JS callback. The
+  user-story decomposition in
+  `requirements/[User-story-4]eliminate-edt-appkit-sync-deadlock-on-macos.md`
+  and the analysis in
+  `spdd/analysis/GGQPA-XXX-202605201900-[Analysis]-edt-appkit-sync-deadlock-elimination.md`
+  document the full reasoning.
 
 ## S · Safeguards
 - `EmbeddedWebView.attach` validates `parent != null` AND
@@ -1835,3 +2577,107 @@ Files:
   [[in-process-webview-java-api]]; the asymmetry is
   intentional because the standalone surface has no Swing in
   the picture.
+- `WebViewAttachListener` callbacks MUST fire on the Swing
+  EDT and MUST NOT fire inline on the registering thread,
+  even when attach has already resolved at registration time.
+  `addOnAttachComplete` on a `PENDING` engine appends to
+  `attachListeners` and returns; the resolve dispatch fires
+  every listener via `SwingUtilities.invokeLater` in
+  registration order. `addOnAttachComplete` on an `ATTACHED`
+  or `FAILED` engine schedules `SwingUtilities.invokeLater`
+  with the appropriate callback; inline firing on the
+  calling thread would let listener bodies that register
+  further listeners re-enter the dispatch code path with
+  half-initialised state and is a source of subtle bugs.
+- `EmbeddedWebView` state transitions (`PENDING → ATTACHED`,
+  `PENDING → FAILED`) are EDT-only. The macOS native
+  attach-completion callback marshals to the EDT before
+  flipping `attachState`, capturing `attachFailure` (on
+  failure), and firing listeners. State reads
+  (`getAttachState`) are also documented EDT-only; this
+  removes the need to volatile-qualify `attachState` and
+  matches the existing Swing-thread-confinement convention
+  used throughout this canvas.
+- Pre-attach method calls on a `PENDING` engine MUST NOT
+  throw. `setUrl`, `addOnBeforeLoad`, `addJavascriptCallback`,
+  `eval`, `setBounds`, `setVisible`, `requestFocus`,
+  `executeEditingCommand` all enqueue native async-on-main
+  blocks; each block null-checks `e->webview` / `e->manager`
+  at fire time and silently no-ops if cleared (the existing
+  destroy-side race pattern). The `EmbeddedWebView.checkAlive()`
+  guard continues to check `peer == 0L`, which is non-zero
+  during `PENDING` (the C++ struct allocation is synchronous);
+  callers therefore see no behavioural difference from the
+  pre-async-attach contract.
+- The KVO observer for `NSWindow.firstResponder` MUST be
+  registered lazily on the first non-nil window (the
+  WKWebView's `window` property may be transiently nil at
+  `addSubview:` time per AppKit policy) and MUST be
+  unregistered from its current `observed_window` before any
+  view release in the destroy lambda. AppKit logs a warning
+  (and may crash in some configurations) if an observed
+  object is released while observers are still registered.
+  The observer MUST also be moved (unregistered from the old
+  window, registered against the new window) if the
+  WKWebView's `window` property changes at runtime; the atomic
+  cache MUST be recomputed immediately after the move.
+- The `Engine.destroyed: std::atomic<bool>` MUST be set to
+  `true` as the FIRST action inside the destroy lambda,
+  before any AppKit teardown runs. Every other
+  `cocoa_run_on_main_async` lambda (navigate / eval /
+  init_script / set_bounds / set_visible / request_focus /
+  execute_editing_command / bind) MUST read `destroyed` at
+  the top of its body and short-circuit cleanly (no JNI
+  exception, no callback into Java, no AppKit call) if `true`.
+  The primary correctness guarantee is dispatch-queue FIFO
+  ordering plus EDT-only enqueueing; the flag is
+  belt-and-suspenders against (a) destroy-from-non-EDT,
+  (b) future code changes that violate the
+  EDT-only-enqueue invariant, and (c) the `cocoa_eval`
+  late-completion path that needs a clean signalling channel.
+- `EmbeddedWebView.dispose()` ordering (Java-side) MUST be
+  preserved under async destroy: drain the `EvalDispatcher`
+  first, clear focus / click callbacks (try/catch),
+  set `peer = 0L`, then call `webview_embed_destroy`. The
+  drain runs on the EDT and completes every pending
+  `evalAsync` future exceptionally before the native destroy
+  enqueues its lambda; the `peer = 0L` flip ensures
+  subsequent `EmbeddedWebView.evalAsync` calls return an
+  already-failed future without touching the dispatcher.
+  Native-side late `cocoa_eval` short-circuits are therefore
+  exercised only in pathological orderings; they remain
+  the correct defensive design.
+- `EmbeddedWebView.attach(...)` synchronous-throw contract is
+  preserved for C++ allocation failure. If the C++ `Engine`
+  struct allocation itself fails (out-of-memory, JAWT lock
+  failure, or any synchronous-prologue error),
+  `webview_embed_create` returns `0` and the Java factory
+  throws `IllegalStateException` exactly as today — no
+  partial `EmbeddedWebView` instance is observable. Only
+  AppKit-side failures (which by definition only occur on
+  macOS in the async epilogue) route through the
+  `WebViewAttachListener.onAttachFailed` callback. Callers
+  who use `attach(...)` without registering a listener
+  MUST be able to discover async failure via
+  `getAttachState() == FAILED`; documenting this avoids
+  the trap where AppKit-side failures are silently swallowed.
+- The C++ `Engine` struct MUST NOT leak on async-attach
+  failure. If the async epilogue fails after `new Engine()`
+  succeeded (e.g. WKWebView allocation returned nil, no
+  hostable NSView discovered), the failure path MUST
+  release any AppKit objects already allocated, drop the
+  entry from `g_webview_map` if it was inserted, post the
+  failure outcome to the EDT, and finally `delete e`. This
+  is symmetric with the synchronous `!ok → delete e` path
+  the previous design used; the new path just runs in the
+  async lambda instead of inline.
+- `cocoa_bind`'s async conversion MUST preserve the
+  registration-order semantics relied upon by
+  `WebViewHeavyweightComponent.createPeer` (which iterates
+  `pendingBindings` BEFORE calling `navigate(pendingUrl)`).
+  The main dispatch queue's FIFO serial ordering provides
+  this automatically; any change that breaks FIFO order
+  (e.g. routing bind through a different queue) would
+  re-introduce a race between binding registration and
+  page-load JS calls that the existing canvas code already
+  documents around.

--- a/src/ca/weblite/webview/AttachState.java
+++ b/src/ca/weblite/webview/AttachState.java
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Steve Hannah
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction.
+ */
+package ca.weblite.webview;
+
+/**
+ * Lifecycle state of an {@link EmbeddedWebView}'s native peer attachment.
+ *
+ * <p>State transitions are confined to the Swing Event Dispatch Thread. The
+ * only legal transitions are {@code PENDING → ATTACHED} and
+ * {@code PENDING → FAILED}; {@code ATTACHED} and {@code FAILED} are terminal.
+ *
+ * <p>On Windows and Linux, the engine enters {@link #ATTACHED} synchronously
+ * during the {@code EmbeddedWebView} constructor — its native side completes
+ * before {@code webview_embed_create} returns. On macOS, the engine enters
+ * {@link #ATTACHED} or {@link #FAILED} asynchronously after the AppKit-side
+ * setup (WKWebView allocation, host-NSView discovery, {@code addSubview:},
+ * configuration) completes; a JNI callback marshals onto the EDT to drive
+ * the transition.
+ *
+ * <p>Callers that need an explicit signal MUST use
+ * {@link EmbeddedWebView#addOnAttachComplete}; pre-attach method calls
+ * on a {@code PENDING} engine ({@code setUrl}, {@code addOnBeforeLoad},
+ * {@code addJavascriptCallback}, {@code eval}, etc.) are buffered by the
+ * native dispatch queue and replay automatically once the engine reaches
+ * {@code ATTACHED}.
+ */
+public enum AttachState {
+    /** AppKit-side setup is in flight; only macOS observes this state. */
+    PENDING,
+    /** Native peer is fully attached and ready for use. */
+    ATTACHED,
+    /** AppKit-side setup failed; failure cause available via the listener. */
+    FAILED
+}

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import javax.swing.SwingUtilities;
 
 /**
  * Low-level wrapper around an embedded WebView native peer.
@@ -27,6 +28,23 @@ import java.util.concurrent.CompletableFuture;
  *
  * <p>Most callers should not use this class directly; use the Swing components
  * in the {@code ca.weblite.webview.swing} package instead.
+ *
+ * <p><b>Attach lifecycle.</b> The Java factory {@link #attach(Component,
+ * boolean)} is synchronous on every platform — it returns a non-null
+ * {@code EmbeddedWebView} immediately. On macOS the underlying AppKit-side
+ * setup (WKWebView allocation, host-NSView discovery, {@code addSubview:},
+ * configuration) runs asynchronously on the AppKit main thread; the
+ * returned instance is briefly in {@link AttachState#PENDING} state and
+ * transitions to {@link AttachState#ATTACHED} or {@link AttachState#FAILED}
+ * once the AppKit-side phase resolves. Callers that need an explicit
+ * signal may register a {@link WebViewAttachListener} via
+ * {@link #addOnAttachComplete}; pre-attach method calls
+ * ({@link #setBounds}, {@link #setVisible}, {@link #navigate},
+ * {@link #addOnBeforeLoad}, {@link #eval}, {@link #addJavascriptCallback},
+ * etc.) are safe on a {@code PENDING} engine — the macOS dispatch queue
+ * preserves FIFO order, so they replay in registration order after the
+ * AppKit-side setup completes. On Windows and Linux the engine is in
+ * {@link AttachState#ATTACHED} state by the time the factory returns.
  */
 public class EmbeddedWebView {
 
@@ -48,6 +66,39 @@ public class EmbeddedWebView {
      */
     private final EvalDispatcher evalDispatcher;
 
+    /**
+     * Attach lifecycle state.  Reads and writes are confined to the
+     * Swing EDT.  Initialised to {@link AttachState#PENDING}; the
+     * native attach-completion callback drives the transition to
+     * {@link AttachState#ATTACHED} or {@link AttachState#FAILED} via
+     * {@link AttachCallback#onResolved}, which marshals onto the EDT
+     * before flipping the field.
+     */
+    private AttachState attachState = AttachState.PENDING;
+
+    /**
+     * Failure cause set on the {@code PENDING → FAILED} transition.
+     * EDT-only; null in {@code PENDING} and {@code ATTACHED} states.
+     */
+    private Throwable attachFailure;
+
+    /**
+     * Listeners registered via {@link #addOnAttachComplete} while the
+     * engine is in {@link AttachState#PENDING}.  Fired in registration
+     * order on the EDT once the attach resolves and then cleared.
+     * EDT-only.
+     */
+    private final List<WebViewAttachListener> attachListeners =
+            new ArrayList<WebViewAttachListener>();
+
+    /**
+     * Native-callable bridge object that receives the attach-completion
+     * notification from the native side.  Held in {@link #heap} so the
+     * JNI global ref the native side stores stays reachable from Java
+     * until the engine is destroyed.
+     */
+    private final AttachCallback attachCallback = new AttachCallback();
+
     private EmbeddedWebView(long peer) {
         this.peer = peer;
         this.evalDispatcher = new EvalDispatcher(new EvalDispatcher.EvalSink() {
@@ -59,12 +110,28 @@ public class EmbeddedWebView {
                 }
             }
         }, true, "EmbeddedWebView");
+        // Anchor the attach callback against GC for as long as the engine
+        // is alive; the native side holds a JNI global ref but releasing
+        // it via the destroy lambda is the only mechanism that drops the
+        // anchor on the native side.  Java-side anchor matches every other
+        // callback registered through this class.
+        heap.add(attachCallback);
     }
 
     /**
      * Attach a WebView to the displayable parent Component.  The Component
      * must be heavyweight and already displayable (i.e. {@code addNotify()}
      * has been called).
+     *
+     * <p>On macOS the returned {@code EmbeddedWebView} is briefly in
+     * {@link AttachState#PENDING} state while the AppKit-side setup runs
+     * asynchronously on the AppKit main thread; on Windows and Linux it
+     * is in {@link AttachState#ATTACHED} state by the time the call
+     * returns.  In both cases the engine is safe to operate on
+     * immediately — pre-attach calls buffer through the platform's
+     * native dispatch queue and replay in registration order.  Callers
+     * that need an explicit signal may register a
+     * {@link WebViewAttachListener} via {@link #addOnAttachComplete}.
      *
      * @param parent a heavyweight, displayable AWT Component to attach to.
      * @param debug enables developer tools on supported platforms.
@@ -84,6 +151,13 @@ public class EmbeddedWebView {
                 "native window handle or initialize the embedded WebView.");
         }
         final EmbeddedWebView ewv = new EmbeddedWebView(p);
+        // Register the attach-completion callback BEFORE installing the
+        // eval bridge or returning.  The native side either fires the
+        // callback immediately (Windows/Linux, where attach is
+        // synchronous) or stores it for later (macOS, where the AppKit-
+        // side epilogue is still in flight).  Both paths marshal the
+        // ATTACHED / FAILED transition onto the Swing EDT.
+        WebViewNative.webview_embed_set_attach_callback(p, ewv.attachCallback);
         // Install the evalAsync bridge BEFORE returning so the SHIM_JS is
         // in place at document-start for every subsequent navigation, and
         // the __webview_eval_result__ resolver binding is ready before
@@ -347,6 +421,132 @@ public class EmbeddedWebView {
         checkAlive();
         WebViewNative.webview_embed_release_native_focus(peer);
         return this;
+    }
+
+    /**
+     * Read the current attach lifecycle state.  EDT-only.
+     *
+     * @return one of {@link AttachState#PENDING}, {@link AttachState#ATTACHED},
+     *         or {@link AttachState#FAILED}.
+     */
+    public AttachState getAttachState() {
+        return attachState;
+    }
+
+    /**
+     * Register a {@link WebViewAttachListener} to be notified when the
+     * native peer's attach resolves.  May be called at any point during
+     * the engine's lifetime — including after attach has already
+     * resolved, in which case the appropriate callback fires on the
+     * next EDT tick.  Callbacks never fire inline on the calling
+     * thread, even when attach is already resolved.
+     *
+     * <p>Multiple listeners are supported; they fire in registration
+     * order on the EDT.  Listener-thrown exceptions propagate to AWT's
+     * uncaught-exception handler.
+     *
+     * @param listener the listener to register; must not be null.
+     * @return {@code this} for chaining.
+     */
+    public EmbeddedWebView addOnAttachComplete(WebViewAttachListener listener) {
+        if (listener == null) {
+            throw new NullPointerException("listener");
+        }
+        if (attachState == AttachState.PENDING) {
+            attachListeners.add(listener);
+        } else {
+            // Already resolved — schedule the callback on the next EDT
+            // tick so the call does not fire inline on the registering
+            // thread.  Capture state at registration time in case a
+            // subsequent transition somehow occurred (defence in depth;
+            // ATTACHED and FAILED are terminal in normal operation).
+            final WebViewAttachListener captured = listener;
+            final boolean attachedNow = (attachState == AttachState.ATTACHED);
+            final Throwable cause = attachFailure;
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    if (attachedNow) {
+                        captured.onAttached(EmbeddedWebView.this);
+                    } else {
+                        captured.onAttachFailed(EmbeddedWebView.this, cause);
+                    }
+                }
+            });
+        }
+        return this;
+    }
+
+    /**
+     * EDT-only.  Flip the attach state and fire every registered
+     * listener.  Called from {@link AttachCallback#onResolved} after
+     * the native side has notified Java that the AppKit-side setup
+     * has resolved.
+     */
+    private void resolveAttachOnEdt(boolean ok, String failureMessage) {
+        if (attachState != AttachState.PENDING) {
+            // Idempotent: native side should only fire once, but be
+            // defensive against a stray re-fire.
+            return;
+        }
+        if (ok) {
+            attachState = AttachState.ATTACHED;
+            attachFailure = null;
+        } else {
+            attachState = AttachState.FAILED;
+            attachFailure = new IllegalStateException(
+                failureMessage != null ? failureMessage
+                    : "EmbeddedWebView attach failed");
+        }
+        // Snapshot then clear so any callback that itself calls
+        // addOnAttachComplete (which would now hit the resolved
+        // branch) sees a clean PENDING-listener list.
+        List<WebViewAttachListener> snapshot =
+                new ArrayList<WebViewAttachListener>(attachListeners);
+        attachListeners.clear();
+        Throwable cause = attachFailure;
+        boolean attachedNow = ok;
+        for (WebViewAttachListener l : snapshot) {
+            try {
+                if (attachedNow) {
+                    l.onAttached(this);
+                } else {
+                    l.onAttachFailed(this, cause);
+                }
+            } catch (RuntimeException ex) {
+                // Let AWT's uncaught-exception handler observe it;
+                // do not let one listener's throw stop the others
+                // from firing.
+                Thread t = Thread.currentThread();
+                t.getUncaughtExceptionHandler().uncaughtException(t, ex);
+            }
+        }
+    }
+
+    /**
+     * Bridge object the native side calls to signal attach completion.
+     * Held in {@link #heap} (anti-GC) and registered with the native
+     * engine via {@link WebViewNative#webview_embed_set_attach_callback}
+     * inside {@link #attach}.  The native side invokes
+     * {@link #onResolved} from whatever thread completed the AppKit-side
+     * setup; this implementation marshals the work onto the Swing EDT
+     * before mutating any state.
+     */
+    final class AttachCallback {
+        /**
+         * Invoked by the native side; safe to call from any thread.
+         * @param ok true on success, false on failure.
+         * @param failureMessage human-readable failure description;
+         *                       only meaningful when {@code ok} is false.
+         */
+        public void onResolved(final boolean ok, final String failureMessage) {
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    resolveAttachOnEdt(ok, failureMessage);
+                }
+            });
+        }
     }
 
     /**

--- a/src/ca/weblite/webview/WebViewAttachListener.java
+++ b/src/ca/weblite/webview/WebViewAttachListener.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Steve Hannah
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction.
+ */
+package ca.weblite.webview;
+
+/**
+ * Observer for the deferred completion of
+ * {@link EmbeddedWebView#attach(java.awt.Component, boolean)}.
+ *
+ * <p>On macOS the AppKit-side setup of the WKWebView runs asynchronously on
+ * the AppKit main thread after the synchronous Java factory returns. This
+ * listener fires on the Swing EDT once that setup resolves — with
+ * {@link #onAttached} on success or {@link #onAttachFailed} on failure.
+ *
+ * <p>On Windows and Linux the engine is fully attached by the time the
+ * Java factory returns, and any listener registered via
+ * {@link EmbeddedWebView#addOnAttachComplete} fires on the next EDT tick
+ * with {@link #onAttached}.
+ *
+ * <p>Listeners MAY be registered before or after attach resolves; a
+ * registration on an already-resolved engine schedules the corresponding
+ * callback via {@link javax.swing.SwingUtilities#invokeLater}. Callbacks
+ * never fire inline on the calling thread; the implementation always uses
+ * an EDT trip so listener bodies that themselves call back into
+ * {@code EmbeddedWebView} (or register further listeners) cannot re-enter
+ * the dispatch path with half-initialised state.
+ *
+ * <p>Implementations should catch their own exceptions if they do not want
+ * AWT's default uncaught-exception handling to apply.
+ */
+public interface WebViewAttachListener {
+
+    /**
+     * Invoked on the Swing EDT once the native peer's attach completes
+     * successfully.
+     *
+     * @param webView the {@link EmbeddedWebView} whose attach just resolved;
+     *                never null.
+     */
+    void onAttached(EmbeddedWebView webView);
+
+    /**
+     * Invoked on the Swing EDT once the native peer's attach fails.
+     *
+     * <p>Failure surfaces only for AppKit-side errors that occur during
+     * the asynchronous portion of macOS attach (WKWebView allocation
+     * returned nil, no hostable NSView discovered). Synchronous failures
+     * during the C++ engine allocation (out-of-memory, JAWT lock
+     * failure) propagate as an {@link IllegalStateException} from
+     * {@link EmbeddedWebView#attach}, never as a listener callback.
+     *
+     * @param webView the {@link EmbeddedWebView} whose attach just failed;
+     *                never null. The engine is in {@link AttachState#FAILED}
+     *                and is not usable; callers should discard it.
+     * @param cause   the failure cause; carries an actionable message
+     *                identifying the failure step. Never null.
+     */
+    void onAttachFailed(EmbeddedWebView webView, Throwable cause);
+}

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -250,6 +250,22 @@ native static void webview_embed_set_click_callback(long w, WebViewClickCallback
 // adequate on those platforms).  Never throws via JNI.
 native static void webview_embed_release_native_focus(long w);
 
+// Register a one-shot attach-completion callback for the engine.
+// The callback object MUST have a method
+// {@code void onResolved(boolean ok, String failureMessage)} that the
+// native side invokes once the engine's attach resolves — with
+// (true, null) on success, or (false, "<step description>") on
+// failure. macOS attach is asynchronous: the callback fires later,
+// from the AppKit main thread, when the WKWebView setup completes.
+// Windows and Linux attach is synchronous: the callback fires
+// immediately inside this call (still routed through the EDT via
+// SwingUtilities.invokeLater in the Java handler).  Never throws via
+// JNI; null callback clears any prior registration.  Used by
+// {@link EmbeddedWebView} to drive the {@link AttachState} state
+// machine and fire {@link WebViewAttachListener} callbacks on the
+// Swing EDT.
+native static void webview_embed_set_attach_callback(long w, Object cb);
+
 
 // ---------------------------------------------------------------------------
 // Lightweight / offscreen API (currently Linux-only).

--- a/src_c/ca_weblite_webview_WebViewNative.h
+++ b/src_c/ca_weblite_webview_WebViewNative.h
@@ -321,6 +321,14 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1rel
 
 /*
  * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_set_attach_callback
+ * Signature: (JLjava/lang/Object;)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1attach_1callback
+  (JNIEnv *, jclass, jlong, jobject);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
  * Method:    webview_offscreen_init
  * Signature: (JLjava/lang/String;)V
  */

--- a/src_c/webview.h
+++ b/src_c/webview.h
@@ -537,7 +537,32 @@ protected:
 
 #define OBJC_OLD_DISPATCH_PROTOTYPES 1
 #include <CoreGraphics/CoreGraphics.h>
+#include <cstddef>
 #include <objc/objc-runtime.h>
+
+// Typed objc_msgSend shim.
+//
+// Modern macOS SDKs (Xcode 15+) declare objc_msgSend with no parameters
+// even when OBJC_OLD_DISPATCH_PROTOTYPES is defined, and the ARM64
+// calling convention does not match the variadic ABI used by old
+// prototypes anyway.  Every call therefore has to go through a typed
+// function-pointer cast that matches the call site's actual argument
+// types.  msg<>() centralises that cast; the `#define objc_msgSend
+// webview::msg` redirection below makes every objc_msgSend(...) call in
+// this header route through it without touching individual call sites.
+//
+// Identical in shape to the helper of the same name in
+// src_c/webview_embed.cpp; replicated here because webview.h is a
+// header-only single-file include of upstream Serge Zaitsev webview
+// and cannot rely on the embed file's helper.
+namespace webview {
+template <typename Ret = id, typename... Args>
+static inline Ret msg(id receiver, SEL selector, Args... args) {
+  using Fn = Ret (*)(id, SEL, Args...);
+  return reinterpret_cast<Fn>(objc_msgSend)(receiver, selector, args...);
+}
+} // namespace webview
+#define objc_msgSend webview::msg
 
 #define NSBackingStoreBuffered 2
 

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -1583,6 +1583,54 @@ struct Engine {
     // those clicks because the heavyweight peer receives them through
     // the AppKit responder chain rather than AWT's event queue.
     jobject click_callback = nullptr;
+
+    // Mirrored first-responder state.  Written on the AppKit main thread
+    // by the KVO observer callback on NSWindow.firstResponder (see
+    // WebviewEmbedKvoObserver below); read lock-free from any thread by
+    // cocoa_is_first_responder.  A stale read by at most one event-loop
+    // tick is acceptable; a single bool admits no torn reads.
+    std::atomic<bool> is_first_responder{false};
+
+    // Destroyed flag.  Set true as the FIRST action inside the destroy
+    // lambda (cocoa_destroy_engine), before any AppKit teardown runs.
+    // Every other async-on-main lambda (navigate / eval / init_script /
+    // set_bounds / set_visible / request_focus / execute_editing_command
+    // / bind) reads this at fire time and short-circuits cleanly if true.
+    // The primary correctness guarantee is dispatch-queue FIFO ordering +
+    // EDT-only enqueueing; this flag is belt-and-suspenders against
+    // (a) destroy-from-non-EDT, (b) future code changes that violate the
+    // EDT-only-enqueue invariant, and (c) the cocoa_eval late-fire path
+    // that needs to short-circuit if the engine is gone.
+    std::atomic<bool> destroyed{false};
+
+    // KVO observer wired against the host window's firstResponder key
+    // path; lazily registered on the first non-nil window the WKWebView
+    // sees, and re-registered if the WKWebView moves between windows at
+    // runtime.  Owned by the engine (retained); released in the destroy
+    // lambda before the WKWebView itself is released.
+    id kvo_observer = nullptr;
+
+    // Last NSWindow the KVO observer was registered against.  Used to
+    // unregister cleanly during destroy or on window change.  Weak
+    // (unretained) back-reference; AppKit owns the window's lifecycle.
+    id observed_window = nullptr;
+
+    // Attach-completion resolution state.  Coordinated between
+    // (a) the AppKit-main-thread epilogue inside cocoa_create_engine,
+    // which sets attach_resolved+attach_ok+attach_failure_message and
+    // fires the callback if one is registered; and (b) the EDT-thread
+    // cocoa_set_attach_callback, which stores the callback and fires
+    // it immediately if attach is already resolved.  Guarded by
+    // attach_callback_mutex.  The callback is fired exactly once: the
+    // mutex serialises the "store callback + fire if resolved" and
+    // "set resolved + fire if callback present" windows, and the
+    // callback fields are cleared after firing.
+    std::mutex attach_callback_mutex;
+    bool attach_resolved = false;
+    bool attach_ok = false;
+    std::string attach_failure_message;
+    jobject attach_callback = nullptr;
+    jclass attach_callback_cls = nullptr;
 };
 
 // Process-global map from WKWebView (id) to its owning Engine*.  Populated
@@ -1593,131 +1641,19 @@ struct Engine {
 static std::mutex g_webview_map_mutex;
 static std::map<id, Engine *> g_webview_map;
 
-// Heap-allocated work item passed across the EDT → AppKit main bridge.
-// Lives until the main-thread method runs and deletes it.
-struct AwtBridgeWork {
-    std::function<void()> fn;
-};
-
-// Implementation of -[WebViewAwtMainBridge performWork:].  Runs on the
-// AppKit main thread; receives an NSValue wrapping an AwtBridgeWork *,
-// extracts the function, runs it, and deletes the work item.  The class
-// itself is allocated lazily in ensure_awt_main_bridge.
-static void awt_main_bridge_perform_impl(id /*self*/, SEL /*_cmd*/, id arg) {
-    if (!arg) return;
-    void *p = msg<void *>(arg, sel("pointerValue"));
-    if (!p) return;
-    auto *work = static_cast<AwtBridgeWork *>(p);
-    work->fn();
-    delete work;
-}
-
-// Process-global state for the AWT main-thread bridge.  We allocate one
-// Objective-C class (WebViewAwtMainBridge), one shared instance of it
-// (the target of every performSelectorOnMainThread: call), and one
-// NSArray of run-loop modes.  Initialised exactly once per JVM via
-// std::call_once -- objc_allocateClassPair returns Nil on second call
-// for the same name.
-static Class g_awt_main_bridge_cls = nil;
-static id g_awt_main_bridge_target = nil;
-static id g_awt_main_bridge_modes = nil;
-static std::once_flag g_awt_main_bridge_once;
-
-static void ensure_awt_main_bridge() {
-    std::call_once(g_awt_main_bridge_once, [] {
-        Class c = objc_allocateClassPair((Class)objc_cls("NSObject"),
-                                         "WebViewAwtMainBridge", 0);
-        class_addMethod(c, sel("performWork:"),
-                        (IMP)awt_main_bridge_perform_impl, "v@:@");
-        objc_registerClassPair(c);
-        g_awt_main_bridge_cls = c;
-        // [new] returns a +1-retained instance; keep it forever.
-        g_awt_main_bridge_target = msg((id)c, sel("new"));
-
-        // Build the modes list under which the main thread will service
-        // our performSelector dispatch.  The critical entry here is
-        // "AWTRunLoopMode" -- the private CFRunLoop mode the JDK enters
-        // from -[LWCToolkit doAWTRunLoopImpl] when AppKit calls into
-        // Java from the main thread (accessibility role queries during a
-        // VoiceOver / AX focus-changed event, IME callbacks, etc) and
-        // pumps a nested runloop waiting for the EDT to respond.  In
-        // that mode the main dispatch queue is NOT drained, so the
-        // previous dispatch_sync(main_queue, ...)-based implementation
-        // deadlocked: the EDT was already blocked in
-        // webview_embed_create, so the AX query the main thread was
-        // waiting on never got serviced, and our queued block on the
-        // main queue never got drained either.  Adding AWTRunLoopMode
-        // here lets the main thread service the perform from inside
-        // doAWTRunLoopImpl's nested CFRunLoop, breaking the cycle.
-        //
-        // The other modes mirror what the JDK's own ThreadUtilities
-        // installs (kCFRunLoopDefaultMode, NSEventTrackingRunLoopMode
-        // for live resize / drag, NSModalPanelRunLoopMode for modal
-        // panels) so we keep being serviced through every CFRunLoop
-        // mode AppKit normally runs in.
-        id arr = msg(objc_cls("NSMutableArray"), sel("alloc"));
-        arr = msg(arr, sel("init"));
-        msg<void, id>(arr, sel("addObject:"),
-                      ns_str("kCFRunLoopDefaultMode"));
-        msg<void, id>(arr, sel("addObject:"), ns_str("AWTRunLoopMode"));
-        msg<void, id>(arr, sel("addObject:"),
-                      ns_str("NSEventTrackingRunLoopMode"));
-        msg<void, id>(arr, sel("addObject:"),
-                      ns_str("NSModalPanelRunLoopMode"));
-        g_awt_main_bridge_modes = arr;
-    });
-}
-
-// Wrap `work` in an NSValue (no autorelease -- we hand-manage the +1).
-// Caller owns one ref; release after the perform call returns.
-static id awt_bridge_box(AwtBridgeWork *work) {
-    void *ptr_val = work;
-    id arg = msg(objc_cls("NSValue"), sel("alloc"));
-    arg = msg<id, const void *, const char *>(
-        arg, sel("initWithBytes:objCType:"), &ptr_val, "^v");
-    return arg;
-}
-
-static void cocoa_run_on_main(std::function<void()> f) {
-    // If we're already on the AppKit main thread, just run f inline.
-    // Otherwise route through -[NSObject performSelectorOnMainThread:
-    // withObject:waitUntilDone:modes:] with a mode set that includes
-    // "AWTRunLoopMode", so the call is serviced even when the main
-    // thread is parked inside the JDK's LWCToolkit.doAWTRunLoopImpl
-    // (accessibility-focus callbacks, IME callbacks, AWT-EDT round
-    // trips, etc).
-    //
-    // The previous implementation used dispatch_sync_f to the main
-    // dispatch queue, which deadlocks in that scenario: AppKit's main
-    // thread was inside doAWTRunLoopImpl's nested CFRunLoop in
-    // AWTRunLoopMode (which does NOT drain the main dispatch queue),
-    // waiting for the EDT to answer an accessibility role query; the
-    // EDT meanwhile was here in webview_embed_create waiting for the
-    // main thread to dequeue our sync block.  See the bug report
-    // "WebViewHeavyweightComponent deadlocks the EDT when the WebView
-    // peer is created during macOS accessibility focus events".
-    //
-    // performSelectorOnMainThread:waitUntilDone:YES is the canonical
-    // AWT-on-macOS bridge for "talk to AppKit from a JNI call" and is
-    // the same mechanism the JDK itself uses internally
-    // (sun.lwawt.macosx.ThreadUtilities / JNFRunLoop).
-    BOOL is_main = msg<BOOL>(objc_cls("NSThread"), sel("isMainThread"));
-    if (is_main) {
-        f();
-        return;
-    }
-    ensure_awt_main_bridge();
-    auto *work = new AwtBridgeWork{std::move(f)};
-    id arg = awt_bridge_box(work);
-    msg<void, SEL, id, BOOL, id>(
-        g_awt_main_bridge_target,
-        sel("performSelectorOnMainThread:withObject:waitUntilDone:modes:"),
-        sel("performWork:"), arg, YES, g_awt_main_bridge_modes);
-    // performSelectorOnMainThread retains arg for the duration of the
-    // call; releasing our +1 here brings the refcount to 1 (held by
-    // perform) and then 0 after the selector finishes.
-    msg<void>(arg, sel("release"));
-}
+// The EDT↔AppKit-main synchronous bridge has been eliminated.  Per
+// Canvas 6 Norms (the macOS sync EDT→AppKit-main bridge prohibition),
+// every per-engine native operation runs via cocoa_run_on_main_async
+// (FIFO dispatch_get_main_queue) or inlines when already on main; any
+// AppKit-thread state the EDT needs to read is mirrored into an
+// std::atomic on the Engine (see Engine::is_first_responder, fed by
+// the KVO observer on NSWindow.firstResponder, walked below).  The
+// historical scaffolding -- cocoa_run_on_main, WebViewAwtMainBridge,
+// performWork:, ensure_awt_main_bridge, awt_bridge_box,
+// awt_main_bridge_perform_impl, the g_awt_main_bridge_* statics, and
+// the AwtBridgeWork heap-allocated work item -- has been removed.  Do
+// NOT reintroduce any of them; the structural reason is documented in
+// the canvas's "Eliminate Sync EDT↔AppKit Bridge" approach entry.
 
 static void cocoa_run_on_main_async(std::function<void()> f) {
     BOOL is_main = msg<BOOL>(objc_cls("NSThread"), sel("isMainThread"));
@@ -1986,39 +1922,327 @@ static void install_click_swizzle() {
     });
 }
 
-// Returns 1 if the engine's WKWebView (or a descendant view in its
-// subview hierarchy -- WebKit content view, etc.) is currently the
-// first responder of its NSWindow.  Synchronous query against AppKit
-// main thread state; safe to call from EDT during a key press
-// (NOT during NSEventTrackingRunLoopMode, but Cmd+C isn't a tracking
-// event).
-static int cocoa_is_first_responder(Engine *e) {
-    if (!e || !e->webview) return 0;
-    int result = 0;
-    cocoa_run_on_main([&] {
-        if (!e->webview) return;
-        id window = msg(e->webview, sel("window"));
-        if (!window) return;
-        id fr = msg(window, sel("firstResponder"));
-        if (!fr) return;
-        // Walk the responder's view-hierarchy chain looking for the
-        // WKWebView.  The actual first responder is often an inner
-        // WebKit content view, not the WKWebView itself.
-        SEL is_kind_of_view = sel("isKindOfClass:");
-        id view_cls = objc_cls("NSView");
-        if (!msg<BOOL, id>(fr, is_kind_of_view, view_cls)) {
-            // First responder isn't an NSView (e.g. NSWindow itself) --
-            // not us.
+// Walk the responder chain from [window firstResponder] upward through
+// superview looking for e->webview.  Runs on the AppKit main thread
+// (invoked from the KVO observer below and from the post-window-attach
+// recompute path).  Identical logic to the previous synchronous
+// cocoa_is_first_responder probe -- correctly handles inner WebKit
+// content views (NSResponder subclasses inside WKWebView) by walking
+// up the view hierarchy until it either reaches e->webview (match) or
+// runs out of superviews (no match).  Stores the result into
+// e->is_first_responder so cocoa_is_first_responder can read it
+// lock-free with no thread hop.
+static void cocoa_recompute_first_responder_on_main(Engine *e) {
+    if (!e || !e->webview) {
+        if (e) e->is_first_responder.store(false);
+        return;
+    }
+    id window = msg(e->webview, sel("window"));
+    if (!window) {
+        e->is_first_responder.store(false);
+        return;
+    }
+    id fr = msg(window, sel("firstResponder"));
+    if (!fr) {
+        e->is_first_responder.store(false);
+        return;
+    }
+    SEL is_kind_of_view = sel("isKindOfClass:");
+    id view_cls = objc_cls("NSView");
+    if (!msg<BOOL, id>(fr, is_kind_of_view, view_cls)) {
+        // First responder isn't an NSView (e.g. NSWindow itself) -- not us.
+        e->is_first_responder.store(false);
+        return;
+    }
+    for (id v = fr; v; v = msg(v, sel("superview"))) {
+        if (v == e->webview) {
+            e->is_first_responder.store(true);
             return;
         }
-        for (id v = fr; v; v = msg(v, sel("superview"))) {
-            if (v == e->webview) {
-                result = 1;
-                return;
+    }
+    e->is_first_responder.store(false);
+}
+
+// Returns 1 if the engine's WKWebView (or a descendant view in its
+// subview hierarchy -- WebKit content view, etc.) is currently the
+// first responder of its NSWindow.  Lock-free read of the mirrored
+// state maintained by the KVO observer registered on
+// NSWindow.firstResponder; no AppKit-main-thread hop, no deadlock
+// surface.  Safe to call from any thread, but in practice fired only
+// from the EDT (the editing-shortcut dispatcher in
+// WebViewHeavyweightComponent).
+static int cocoa_is_first_responder(Engine *e) {
+    if (!e) return 0;
+    return e->is_first_responder.load() ? 1 : 0;
+}
+
+// ---------------------------------------------------------------------------
+// KVO observer for NSWindow.firstResponder + WKWebView.window.
+//
+// The Engine struct holds an std::atomic<bool> is_first_responder that
+// mirrors AppKit-main-thread state for lock-free EDT reads.  Two key paths
+// drive updates:
+//   1. NSWindow.firstResponder fires for every focus transition anywhere
+//      in the host window's responder hierarchy.  Each firing walks the
+//      responder chain via cocoa_recompute_first_responder_on_main and
+//      stores the result in the atomic.
+//   2. WKWebView.window fires when the WKWebView is added to / removed
+//      from / moved between NSWindows.  When the property goes non-nil,
+//      we register the firstResponder observer on the new window and
+//      recompute immediately.  When it changes to a different window we
+//      unregister from the previous window and register on the new one.
+//      When it goes nil (e.g. just before removeFromSuperview during
+//      destroy) we unregister and clear the cache.
+//
+// The Objective-C class is registered exactly once per JVM via
+// std::call_once -- same pattern as the existing WKWebView swizzles and
+// the WebviewEmbedDelegate class registration.  Each engine creates one
+// instance of the class and stores the back-pointer to its owning Engine*
+// via objc_setAssociatedObject (OBJC_ASSOCIATION_ASSIGN -- Engine is not
+// an Obj-C object, so the runtime won't try to retain/release it).
+// ---------------------------------------------------------------------------
+
+static std::once_flag g_kvo_observer_once;
+static Class g_kvo_observer_cls = nil;
+
+static const char KVO_ENGINE_KEY[] = "eng";
+// Distinct context pointers let observeValueForKeyPath: tell the two
+// key paths apart without string-comparing the keypath every fire.
+static int kvo_ctx_first_responder = 0;
+static int kvo_ctx_window = 0;
+
+// Forward declaration: defined after cocoa_destroy_engine so the
+// KVO observer can reference engine teardown helpers.
+static void cocoa_kvo_register_on_window(Engine *e, id window);
+static void cocoa_kvo_unregister_from_window(Engine *e);
+
+static void kvo_observe_impl(id self, SEL /*_cmd*/, id /*keyPath*/,
+                             id /*object*/, id /*change*/, void *context) {
+    auto *e = (Engine *)objc_getAssociatedObject(self, KVO_ENGINE_KEY);
+    if (!e) return;
+    if (e->destroyed.load()) return;
+    if (context == &kvo_ctx_first_responder) {
+        cocoa_recompute_first_responder_on_main(e);
+    } else if (context == &kvo_ctx_window) {
+        // WKWebView's window keypath changed.  Re-aim the firstResponder
+        // observer at the new window (or unregister if nil) and
+        // recompute.
+        id new_window = e->webview ? msg(e->webview, sel("window"))
+                                   : (id)nullptr;
+        if (new_window != e->observed_window) {
+            cocoa_kvo_unregister_from_window(e);
+            if (new_window) {
+                cocoa_kvo_register_on_window(e, new_window);
             }
         }
+        cocoa_recompute_first_responder_on_main(e);
+    }
+}
+
+static void ensure_kvo_observer_class() {
+    std::call_once(g_kvo_observer_once, [] {
+        Class c = objc_allocateClassPair((Class)objc_cls("NSObject"),
+                                         "WebviewEmbedKvoObserver", 0);
+        // observeValueForKeyPath:ofObject:change:context: --
+        // signature "v@:@@@^v"
+        //   v   void
+        //   @   id self
+        //   :   SEL _cmd
+        //   @   id keyPath  (NSString)
+        //   @   id object
+        //   @   id change   (NSDictionary)
+        //   ^v  void *context
+        class_addMethod(
+            c,
+            sel("observeValueForKeyPath:ofObject:change:context:"),
+            (IMP)kvo_observe_impl,
+            "v@:@@@^v");
+        objc_registerClassPair(c);
+        g_kvo_observer_cls = c;
     });
-    return result;
+}
+
+// Register the engine's KVO observer against `window`'s firstResponder
+// key path.  Caller MUST hold the AppKit main thread.  Idempotent
+// against repeated registration on the same window (the second call
+// is a no-op).
+static void cocoa_kvo_register_on_window(Engine *e, id window) {
+    if (!e || !window) return;
+    if (e->observed_window == window) return;
+    if (!e->kvo_observer) return;
+    msg<void, id, id, unsigned long, void *>(
+        window,
+        sel("addObserver:forKeyPath:options:context:"),
+        e->kvo_observer,
+        ns_str("firstResponder"),
+        (unsigned long)0,           // no NSKeyValueObservingOptions flags
+        &kvo_ctx_first_responder);
+    e->observed_window = window;
+}
+
+// Unregister the engine's KVO observer from its currently-observed
+// window (if any).  Caller MUST hold the AppKit main thread.
+static void cocoa_kvo_unregister_from_window(Engine *e) {
+    if (!e || !e->observed_window || !e->kvo_observer) return;
+    msg<void, id, id, void *>(
+        e->observed_window,
+        sel("removeObserver:forKeyPath:context:"),
+        e->kvo_observer,
+        ns_str("firstResponder"),  // forKeyPath:
+        &kvo_ctx_first_responder); // context:
+    // Template params: (Ret=void, Args = id observer, id keyPath, void* context)
+    e->observed_window = nullptr;
+}
+
+// Install the engine's KVO observer.  Allocates the observer object,
+// associates it with the Engine pointer, attaches the WKWebView.window
+// observer (so we react to window changes), and -- if the WKWebView
+// already has a window -- registers the firstResponder observer on
+// that window and seeds the atomic.  Caller MUST hold the AppKit main
+// thread.
+static void cocoa_kvo_install(Engine *e) {
+    if (!e || !e->webview) return;
+    ensure_kvo_observer_class();
+    id observer = msg((id)g_kvo_observer_cls, sel("new"));
+    if (!observer) return;
+    objc_setAssociatedObject(observer, KVO_ENGINE_KEY, (id)e,
+                             OBJC_ASSOCIATION_ASSIGN);
+    e->kvo_observer = observer;
+    msg<void, id, id, unsigned long, void *>(
+        e->webview,
+        sel("addObserver:forKeyPath:options:context:"),
+        observer,
+        ns_str("window"),
+        (unsigned long)0,
+        &kvo_ctx_window);
+    id w = msg(e->webview, sel("window"));
+    if (w) {
+        cocoa_kvo_register_on_window(e, w);
+        cocoa_recompute_first_responder_on_main(e);
+    }
+}
+
+// Tear down the engine's KVO observer.  Reverses cocoa_kvo_install;
+// caller MUST hold the AppKit main thread, and MUST call this BEFORE
+// any view release in the destroy lambda (AppKit logs a warning and
+// may crash if an observed object is released while observers are
+// still registered).
+static void cocoa_kvo_teardown(Engine *e) {
+    if (!e || !e->kvo_observer) return;
+    cocoa_kvo_unregister_from_window(e);
+    if (e->webview) {
+        msg<void, id, id, void *>(
+            e->webview,
+            sel("removeObserver:forKeyPath:context:"),
+            e->kvo_observer,
+            ns_str("window"),         // forKeyPath:
+            &kvo_ctx_window);         // context:
+    }
+    objc_setAssociatedObject(e->kvo_observer, KVO_ENGINE_KEY, (id)nullptr,
+                             OBJC_ASSOCIATION_ASSIGN);
+    msg<void>(e->kvo_observer, sel("release"));
+    e->kvo_observer = nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Attach-completion callback.
+//
+// The Java side registers an AttachCallback bridge object via
+// cocoa_set_attach_callback before the EmbeddedWebView factory returns.
+// The macOS async attach epilogue inside cocoa_create_engine, on
+// success or failure, calls cocoa_attach_signal_complete to publish the
+// outcome.  Two ordering cases:
+//   (a) Java registers the callback BEFORE the async epilogue fires
+//       (typical case): cocoa_set_attach_callback stores the global ref;
+//       cocoa_attach_signal_complete sees the stored callback and fires
+//       it from the main thread.
+//   (b) Java registers the callback AFTER the async epilogue fires
+//       (race window narrow but possible): the async epilogue stores the
+//       resolution state without anyone to call; cocoa_set_attach_callback
+//       sees attach_resolved==true and fires the callback from the EDT.
+// Both paths are guarded by attach_callback_mutex.  The callback fires
+// exactly once -- both paths null out the callback fields after firing.
+// ---------------------------------------------------------------------------
+
+// Caller MUST hold e->attach_callback_mutex.  Invokes the registered
+// Java callback's onResolved(boolean, String) method and clears the
+// stored callback fields.  Attaches the current thread to the JVM if
+// needed (mirrors the fire_focus_callback pattern).
+static void cocoa_attach_invoke_callback_locked(Engine *e) {
+    if (!e || !e->attach_callback || !e->attach_callback_cls) return;
+    bool ok = e->attach_ok;
+    std::string msg_text = e->attach_failure_message;
+    JavaVM *jvm = e->jvm;
+    if (!jvm) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        jvm->AttachCurrentThread((void **)&env, nullptr);
+        detach = true;
+    }
+    if (env) {
+        jmethodID m = env->GetMethodID(
+            e->attach_callback_cls, "onResolved",
+            "(ZLjava/lang/String;)V");
+        if (m) {
+            jstring js = (!ok && !msg_text.empty())
+                ? env->NewStringUTF(msg_text.c_str()) : nullptr;
+            env->CallVoidMethod(e->attach_callback, m,
+                                (jboolean)(ok ? JNI_TRUE : JNI_FALSE), js);
+            if (js) env->DeleteLocalRef(js);
+        }
+        env->DeleteGlobalRef(e->attach_callback);
+        env->DeleteGlobalRef(e->attach_callback_cls);
+    }
+    e->attach_callback = nullptr;
+    e->attach_callback_cls = nullptr;
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// Called from the async attach epilogue inside cocoa_create_engine
+// (on the AppKit main thread).  Records the outcome and fires the
+// callback if one is already registered.
+static void cocoa_attach_signal_complete(Engine *e, bool ok,
+                                         std::string failure_message) {
+    if (!e) return;
+    std::lock_guard<std::mutex> lk(e->attach_callback_mutex);
+    if (e->attach_resolved) return;  // idempotent
+    e->attach_resolved = true;
+    e->attach_ok = ok;
+    e->attach_failure_message = std::move(failure_message);
+    if (e->attach_callback) {
+        cocoa_attach_invoke_callback_locked(e);
+    }
+}
+
+// Java entry point: register the AttachCallback bridge object.  Called
+// from EmbeddedWebView.attach on the EDT immediately after
+// webview_embed_create returns.  Stores a JNI global ref; if the
+// async attach epilogue has already completed (case (b) above), fires
+// the callback immediately.
+static void cocoa_set_attach_callback(Engine *e, JNIEnv *env, jobject cb) {
+    if (!e || !env) return;
+    std::lock_guard<std::mutex> lk(e->attach_callback_mutex);
+    // If we already have a callback registered, drop the old one
+    // (defensive -- the Java factory wires this exactly once, but make
+    // the contract robust).
+    if (e->attach_callback) {
+        env->DeleteGlobalRef(e->attach_callback);
+        e->attach_callback = nullptr;
+    }
+    if (e->attach_callback_cls) {
+        env->DeleteGlobalRef(e->attach_callback_cls);
+        e->attach_callback_cls = nullptr;
+    }
+    if (cb) {
+        e->attach_callback = env->NewGlobalRef(cb);
+        jclass cls = env->GetObjectClass(cb);
+        e->attach_callback_cls = (jclass)env->NewGlobalRef(cls);
+        env->DeleteLocalRef(cls);
+    }
+    if (e->attach_resolved && e->attach_callback) {
+        cocoa_attach_invoke_callback_locked(e);
+    }
 }
 
 static void cocoa_set_focus_callback(Engine *e, JNIEnv *env, jobject cb) {
@@ -2049,6 +2273,26 @@ static void cocoa_set_click_callback(Engine *e, JNIEnv *env, jobject cb) {
     }
 }
 
+// Synchronous prologue + async epilogue.  Returns the freshly-allocated
+// Engine* (cast to jlong by the JNI export) immediately after the JAWT
+// surface-layers handoff; the WKWebView creation, host-NSView discovery,
+// addSubview:, configuration, and KVO observer install run later on the
+// AppKit main thread.  The async epilogue calls cocoa_attach_signal_
+// complete on completion to drive the Java-side AttachState transition.
+//
+// Only synchronous failure (JAWT lock failure) returns nullptr; every
+// other failure surfaces via the attach-completion callback's onResolved
+// (false, "<message>") path so the Java side can observe it through a
+// registered WebViewAttachListener.
+//
+// The C++ Engine struct itself is NOT deleted on async-attach failure --
+// the contract is that the Java side owns the EmbeddedWebView wrapper
+// and will eventually call dispose() (typically via removeNotify in the
+// heavyweight component), which triggers cocoa_destroy_engine to free
+// the Engine.  The async failure path therefore leaves the Engine in a
+// partially-initialised state but with destroyed==false, so the user
+// can still call dispose() to clean up.  destroyed is set to true only
+// inside cocoa_destroy_engine.
 static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
                                    jlong /*display*/, jint debug) {
     auto *e = new Engine();
@@ -2056,8 +2300,10 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
     e->debug = debug != 0;
 
     // Resolve the JAWT surface layers object up front, then release the
-    // surface lock immediately -- holding it across a dispatch_sync to the
-    // AppKit main thread can deadlock with AppKit's redraw loop.
+    // surface lock immediately -- holding it across a hop to the AppKit
+    // main thread (the async epilogue below) could deadlock with
+    // AppKit's redraw loop.  This is the only step that requires the
+    // calling thread's JNIEnv, so it stays in the synchronous prologue.
     {
         JawtLock lock(env, parentComponent);
         if (!lock.ok) {
@@ -2073,8 +2319,25 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
         }
     }
 
-    bool ok = false;
-    cocoa_run_on_main([&] {
+    // Async epilogue: AppKit-side setup on the main thread.  Captures e
+    // by value (pointer); never blocks the EDT.  dispatch_get_main_queue
+    // is serial FIFO, so subsequent cocoa_navigate / cocoa_eval / etc.
+    // blocks enqueued by the EDT before the user's first listener call
+    // are guaranteed to fire AFTER this block on the main thread.  Each
+    // of those blocks already null-checks e->webview / e->manager and
+    // silently no-ops if cleared -- so an op enqueued before the
+    // epilogue creates the WKWebView simply finds it ready by the time
+    // it fires.
+    cocoa_run_on_main_async([e] {
+        if (e->destroyed.load()) {
+            // The user called dispose() between the prologue returning
+            // and this block firing.  The destroy lambda is enqueued
+            // AFTER this block; bail without doing AppKit-side work so
+            // the destroy lambda has nothing to tear down.
+            cocoa_attach_signal_complete(e, false,
+                "EmbeddedWebView disposed before attach completed");
+            return;
+        }
         // Install the WKWebView first-responder swizzle once per JVM
         // BEFORE creating the WKWebView, so any becomeFirstResponder
         // calls during init are routed through our hook from the start.
@@ -2087,10 +2350,25 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
 
         e->config = msg(objc_cls("WKWebViewConfiguration"), sel("new"));
         e->manager = msg(e->config, sel("userContentController"));
-        e->webview = msg(objc_cls("WKWebView"), sel("alloc"));
-        e->webview = msg<id, CGRect, id>(
-            e->webview, sel("initWithFrame:configuration:"),
+        id wv = msg(objc_cls("WKWebView"), sel("alloc"));
+        wv = msg<id, CGRect, id>(
+            wv, sel("initWithFrame:configuration:"),
             CGRectMake(0, 0, 800, 600), e->config);
+        if (!wv) {
+            // Release the partial AppKit allocations so they don't leak
+            // before reporting the failure.  e->manager is an
+            // autoreleased getter from config so does not need explicit
+            // release; e->config does.
+            e->manager = nullptr;
+            if (e->config) {
+                msg<void>(e->config, sel("release"));
+                e->config = nullptr;
+            }
+            cocoa_attach_signal_complete(e, false,
+                "WKWebView allocation failed");
+            return;
+        }
+        e->webview = wv;
 
         // Register the WKWebView in the engine map so the swizzled
         // responder hooks can find their Engine pointer.
@@ -2214,15 +2492,57 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
                 msg<void, BOOL>(e->webview, sel("setInspectable:"), YES);
             }
         }
-        ok = true;
+
+        // Install the KVO observer on the WKWebView's window keypath --
+        // when the WKWebView lands in an NSWindow, the observer
+        // registers a firstResponder observer on that window and seeds
+        // the cached atomic so cocoa_is_first_responder can read it
+        // lock-free.  See cocoa_kvo_install above.
+        cocoa_kvo_install(e);
+
+        // Signal attach completion.  cocoa_attach_signal_complete fires
+        // the Java AttachCallback immediately if one is already
+        // registered (typical case -- the Java factory installs the
+        // callback synchronously before any wider event-loop time slice
+        // elapses); otherwise it just stores the resolution, and
+        // cocoa_set_attach_callback fires it when the registration
+        // arrives.
+        cocoa_attach_signal_complete(e, true, "");
     });
-    if (!ok) {
-        delete e;
-        return nullptr;
-    }
     return e;
 }
 
+// Asynchronous engine destroy.  Returns immediately on the calling
+// thread (typically the EDT) after a small Java-side cleanup; the
+// AppKit teardown, view-hierarchy removal, KVO observer unregister,
+// binding global-ref release, and finally `delete e` run on the
+// AppKit main thread in a single async-on-main lambda.
+//
+// Pre-async cleanup (calling thread):
+//   1. Erase from g_webview_map so the swizzled responder / mouse hooks
+//      cannot find the engine again.  This window MUST be as small as
+//      possible -- the calling thread runs this synchronously before
+//      any subsequent async ops can be enqueued.
+//   2. DeleteGlobalRef on focus_callback and click_callback so the
+//      hooks (which had read the fields up to this point) cannot fire
+//      Java callbacks against freed refs.  Uses the calling thread's
+//      JNIEnv via attach/detach.
+//
+// Async cleanup (AppKit main thread, FIFO after any previously-enqueued
+// per-engine op):
+//   1. Set destroyed=true as the FIRST action so any LATER fires of
+//      previously-enqueued lambdas (defence-in-depth -- FIFO ordering
+//      makes this impossible in normal operation) see the flag.
+//   2. Tear down the KVO observer BEFORE any view release (AppKit logs
+//      a warning if an observed object is released while observers are
+//      still registered).
+//   3. removeFromSuperview, release retained AppKit objects.
+//   4. Drain e->bindings (releasing the per-binding Java global refs).
+//   5. Release any still-pending attach callback global ref (the
+//      typical case is that it was already cleared inside attach
+//      resolution, but a never-resolved attach + dispose pattern would
+//      land here).
+//   6. delete e.
 static void cocoa_destroy_engine(Engine *e) {
     if (!e) return;
     // Drop the webview from the engine map BEFORE any teardown work --
@@ -2261,7 +2581,18 @@ static void cocoa_destroy_engine(Engine *e) {
         e->click_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
-    cocoa_run_on_main([&] {
+    cocoa_run_on_main_async([e] {
+        // Mark destroyed FIRST.  Any LATER-firing lambdas that read this
+        // flag short-circuit; FIFO ordering on the main queue makes
+        // "later" impossible in normal operation but the flag is the
+        // canvas-mandated belt-and-suspenders.
+        e->destroyed.store(true);
+
+        // KVO observer unregistration MUST happen BEFORE any view
+        // release -- AppKit warns (and may crash) if an observed object
+        // is released with observers still attached.
+        cocoa_kvo_teardown(e);
+
         if (e->webview) {
             // If we added the WKWebView as a subview, remove it before
             // releasing so AppKit unwinds the view hierarchy cleanly.
@@ -2284,24 +2615,52 @@ static void cocoa_destroy_engine(Engine *e) {
             msg<void>(e->config, sel("release"));
             e->config = nullptr;
         }
+
+        // Drain e->bindings on the main thread.  Each binding holds
+        // two Java global refs (the callback and its class); attach to
+        // the JVM via the engine's stored JavaVM* to release them.
+        for (auto &kv : e->bindings) {
+            Binding *b = kv.second;
+            JNIEnv *env2 = nullptr;
+            bool detach = false;
+            if (e->jvm && e->jvm->GetEnv((void **)&env2, JNI_VERSION_1_6) != JNI_OK) {
+                e->jvm->AttachCurrentThread((void **)&env2, nullptr);
+                detach = true;
+            }
+            if (env2) {
+                env2->DeleteGlobalRef(b->fn);
+                env2->DeleteGlobalRef(b->cls);
+            }
+            if (detach && e->jvm) e->jvm->DetachCurrentThread();
+            delete b;
+        }
+        e->bindings.clear();
+
+        // Release any still-pending attach-callback global ref.  Under
+        // normal flow cocoa_attach_signal_complete cleared this when
+        // the callback fired, but a never-resolved-then-disposed
+        // engine (rare: user disposes while the async epilogue's
+        // destroyed-check above bailed) would leave it set.
+        {
+            std::lock_guard<std::mutex> lk(e->attach_callback_mutex);
+            if (e->attach_callback || e->attach_callback_cls) {
+                JNIEnv *env2 = nullptr;
+                bool detach = false;
+                if (e->jvm && e->jvm->GetEnv((void **)&env2, JNI_VERSION_1_6) != JNI_OK) {
+                    e->jvm->AttachCurrentThread((void **)&env2, nullptr);
+                    detach = true;
+                }
+                if (env2) {
+                    if (e->attach_callback) env2->DeleteGlobalRef(e->attach_callback);
+                    if (e->attach_callback_cls) env2->DeleteGlobalRef(e->attach_callback_cls);
+                }
+                e->attach_callback = nullptr;
+                e->attach_callback_cls = nullptr;
+                if (detach && e->jvm) e->jvm->DetachCurrentThread();
+            }
+        }
+        delete e;
     });
-    for (auto &kv : e->bindings) {
-        Binding *b = kv.second;
-        JNIEnv *env = nullptr;
-        bool detach = false;
-        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
-            e->jvm->AttachCurrentThread((void **)&env, nullptr);
-            detach = true;
-        }
-        if (env) {
-            env->DeleteGlobalRef(b->fn);
-            env->DeleteGlobalRef(b->cls);
-        }
-        if (detach) e->jvm->DetachCurrentThread();
-        delete b;
-    }
-    e->bindings.clear();
-    delete e;
 }
 
 // Update the WKWebView's frame so it overlays exactly the AWT canvas
@@ -2312,7 +2671,8 @@ static void cocoa_destroy_engine(Engine *e) {
 // is translated into Cocoa's bottom-left coords.
 static void cocoa_set_bounds(Engine *e, int x, int y, int w, int h) {
     cocoa_run_on_main_async([=] {
-        if (!e || !e->webview || !e->host_view) return;
+        if (!e || e->destroyed.load()) return;
+        if (!e->webview || !e->host_view) return;
         CGFloat fx = (CGFloat)x;
         CGFloat fy = (CGFloat)y;
         CGFloat fw = (CGFloat)w;
@@ -2334,6 +2694,7 @@ static void cocoa_set_bounds(Engine *e, int x, int y, int w, int h) {
 
 static void cocoa_navigate(Engine *e, std::string url) {
     cocoa_run_on_main_async([=] {
+        if (!e || e->destroyed.load()) return;
         if (!e->webview) return;
         id nsurl = msg<id, id>(objc_cls("NSURL"), sel("URLWithString:"),
                                ns_str(url.c_str()));
@@ -2345,6 +2706,7 @@ static void cocoa_navigate(Engine *e, std::string url) {
 
 static void cocoa_init_script(Engine *e, std::string js) {
     cocoa_run_on_main_async([=] {
+        if (!e || e->destroyed.load()) return;
         if (!e->manager) return;
         id script = msg(objc_cls("WKUserScript"), sel("alloc"));
         script = msg<id, id, long, BOOL>(
@@ -2356,6 +2718,7 @@ static void cocoa_init_script(Engine *e, std::string js) {
 
 static void cocoa_eval(Engine *e, std::string js) {
     cocoa_run_on_main_async([=] {
+        if (!e || e->destroyed.load()) return;
         if (!e->webview) return;
         msg<void, id, id>(e->webview,
                           sel("evaluateJavaScript:completionHandler:"),
@@ -2365,6 +2728,7 @@ static void cocoa_eval(Engine *e, std::string js) {
 
 static void cocoa_set_visible(Engine *e, bool visible) {
     cocoa_run_on_main_async([=] {
+        if (!e || e->destroyed.load()) return;
         if (!e->webview) return;
         msg<void, BOOL>(e->webview, sel("setHidden:"), visible ? NO : YES);
     });
@@ -2372,6 +2736,7 @@ static void cocoa_set_visible(Engine *e, bool visible) {
 
 static void cocoa_request_focus(Engine *e) {
     cocoa_run_on_main_async([=] {
+        if (!e || e->destroyed.load()) return;
         if (!e->webview) return;
         id win = msg(e->webview, sel("window"));
         if (win) {
@@ -2380,7 +2745,41 @@ static void cocoa_request_focus(Engine *e) {
     });
 }
 
-static void cocoa_bind(Engine *e, Binding *b) { e->bindings[b->name] = b; }
+// Convert the per-engine binding registration to async-on-main so it
+// serialises against the script-message-handler delegate's reads of
+// e->bindings (which also run on main).  FIFO main-queue ordering
+// guarantees the bind block fires AFTER the attach epilogue (which
+// creates the WKWebView and sets up the script-message-handler) and
+// BEFORE any cocoa_navigate enqueued by the caller after the bind --
+// so the binding is registered in e->bindings before the page can call
+// it from JS.
+static void cocoa_bind(Engine *e, Binding *b) {
+    if (!e || !b) {
+        if (b) delete b;
+        return;
+    }
+    cocoa_run_on_main_async([e, b] {
+        if (e->destroyed.load()) {
+            // Engine destroyed before this bind could fire.  Release
+            // the Binding's Java global refs and delete it; no engine
+            // to attach it to.
+            JNIEnv *env = nullptr;
+            bool detach = false;
+            if (e->jvm && e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+                e->jvm->AttachCurrentThread((void **)&env, nullptr);
+                detach = true;
+            }
+            if (env) {
+                if (b->fn) env->DeleteGlobalRef(b->fn);
+                if (b->cls) env->DeleteGlobalRef(b->cls);
+            }
+            if (detach && e->jvm) e->jvm->DetachCurrentThread();
+            delete b;
+            return;
+        }
+        e->bindings[b->name] = b;
+    });
+}
 
 // macOS has no public API to programmatically open the Web Inspector; the
 // only public entry points are right-click -> Inspect Element (gated by
@@ -2412,7 +2811,11 @@ static int cocoa_open_devtools(Engine *e) {
 // cmdId values are the EditingCommand contract: 1=CUT, 2=COPY, 3=PASTE,
 // 4=SELECT_ALL.  Unknown cmdIds are silently dropped.
 static void cocoa_execute_editing_command(Engine *e, int cmdId) {
-    if (!e || !e->webview) return;
+    if (!e) return;
+    // No early bail on e->webview: the engine may still be in async
+    // attach (e->webview not yet set) -- FIFO ordering on the main
+    // queue means the lambda below sees a populated e->webview by the
+    // time it fires.
     SEL action = nullptr;
     const char *name = nullptr;
     switch (cmdId) {
@@ -2423,6 +2826,7 @@ static void cocoa_execute_editing_command(Engine *e, int cmdId) {
         default: return;
     }
     cocoa_run_on_main_async([=] {
+        if (!e || e->destroyed.load()) return;
         if (!e->webview) return;
         if (!msg<BOOL, SEL>(e->webview, sel("respondsToSelector:"),
                             action)) {
@@ -2813,6 +3217,36 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1rel
     // adequate.  Windows has its own implementation in
     // windows/webview_embed.cc that performs the cross-thread SetFocus.
     (void)wv;
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1attach_1callback
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+    auto *e = (Engine *)wv;
+    if (!e) return;
+#if defined(WEBVIEW_COCOA)
+    // macOS attach is asynchronous; the callback connects the Java
+    // EmbeddedWebView's AttachState machine to the async epilogue's
+    // resolution.  cocoa_set_attach_callback handles both orderings
+    // (callback registered before vs. after the async epilogue
+    // completes) under attach_callback_mutex.
+    embed::cocoa_set_attach_callback(e, env, cb);
+#else
+    // GTK / unsupported: attach is synchronous (the engine is fully
+    // ready by the time webview_embed_create returns), so signal
+    // completion immediately.  Fire onResolved(true, null) from the
+    // calling thread (typically the EDT); the Java handler marshals
+    // via SwingUtilities.invokeLater so the listener actually fires on
+    // the next EDT tick regardless of which thread we are on here.
+    if (!cb) return;
+    jclass cls = env->GetObjectClass(cb);
+    if (!cls) return;
+    jmethodID m = env->GetMethodID(cls, "onResolved",
+                                   "(ZLjava/lang/String;)V");
+    if (m) {
+        env->CallVoidMethod(cb, m, (jboolean)JNI_TRUE, (jstring)nullptr);
+    }
+    env->DeleteLocalRef(cls);
+#endif
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1init

--- a/windows/ca_weblite_webview_WebViewNative.h
+++ b/windows/ca_weblite_webview_WebViewNative.h
@@ -321,6 +321,14 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1rel
 
 /*
  * Class:     ca_weblite_webview_WebViewNative
+ * Method:    webview_embed_set_attach_callback
+ * Signature: (JLjava/lang/Object;)V
+ */
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1attach_1callback
+  (JNIEnv *, jclass, jlong, jobject);
+
+/*
+ * Class:     ca_weblite_webview_WebViewNative
  * Method:    webview_offscreen_init
  * Signature: (JLjava/lang/String;)V
  */

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -1010,6 +1010,28 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1rel
     }
 }
 
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1attach_1callback
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+    auto *e = (Engine *)wv;
+    if (!e || !cb) return;
+    // Windows attach is synchronous: by the time the Java factory calls
+    // this entry, embed_win::create_engine has already returned a
+    // populated Engine pointer, so the engine is fully in ATTACHED
+    // state.  Fire onResolved(true, null) immediately; the Java handler
+    // (EmbeddedWebView.AttachCallback.onResolved) marshals via
+    // SwingUtilities.invokeLater so the WebViewAttachListener actually
+    // fires on the next EDT tick regardless of which thread invoked
+    // this JNI entry.
+    jclass cls = env->GetObjectClass(cb);
+    if (!cls) return;
+    jmethodID m = env->GetMethodID(cls, "onResolved",
+                                   "(ZLjava/lang/String;)V");
+    if (m) {
+        env->CallVoidMethod(cb, m, (jboolean)JNI_TRUE, (jstring)nullptr);
+    }
+    env->DeleteLocalRef(cls);
+}
+
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1execute_1editing_1command
   (JNIEnv *, jclass, jlong wv, jint cmdId) {
     auto *e = (Engine *)wv;


### PR DESCRIPTION
## Summary

- Closes the class of EDT↔AppKit-main mutual-wait deadlocks the v1.0.5 fix (PR #30) only partially mitigated. The `WebViewDeadlockRepro` demo (added in 24bcd08) deterministically reproduces the remaining failure mode by pressing synthetic `Cmd-C` while a JS callback synchronously rendezvous with the EDT — within seconds, both threads wedge. This PR replaces every synchronous EDT→AppKit-main bridge in `src_c/webview_embed.cpp` with async-or-cached equivalents, so the cycle is structurally impossible.
- New macOS attach lifecycle: `cocoa_create_engine` splits into a synchronous Java prologue (Engine alloc + JAWT lock) and an async AppKit epilogue (WKWebView + `addSubview:` + config + KVO observer). A new public `WebViewAttachListener` API on `EmbeddedWebView` (`addOnAttachComplete` / `getAttachState`) reports the deferred outcome on the EDT. `EmbeddedWebView.attach(parent, debug)` stays a synchronous factory — no caller break. Pre-attach `setUrl` / `eval` / `addBinding` / etc. enqueue async-on-main and replay in registration order through `dispatch_get_main_queue`'s FIFO serial ordering — no Java-level buffer needed. `cocoa_bind` also goes async so `e->bindings` writes serialise against the script-message-handler reads.
- Cached first-responder: `cocoa_is_first_responder` now reads an `std::atomic<bool>` on the Engine, kept current by a KVO observer on `NSWindow.firstResponder`. Correctly handles focus on inner WebKit content views (the existing `WKWebView` `becomeFirstResponder` / `resignFirstResponder` swizzle misses those transitions). The editing-shortcut dispatcher's hot path is now a lock-free atomic load.
- Async destroy: `cocoa_destroy_engine` returns immediately; a `destroyed: std::atomic<bool>` flag is set as the first action in the destroy lambda, and every other per-engine async op short-circuits cleanly on a destroyed engine. The v1.0.5 `cocoa_run_on_main` + `WebViewAwtMainBridge` + `performWork:` + `ensure_awt_main_bridge` scaffolding is fully removed.
- Pre-existing `webview.h` clang compilation failure under Xcode 15+ is fixed by adding a typed `objc_msgSend` shim (same `msg<>` template `webview_embed.cpp` already uses) and a macro redirect. `build-mac.sh` now compiles both `webview.c` and `webview_embed.cpp` end-to-end; `run-mac-demo.sh`'s explicit workaround comment is now obsolete (left untouched in this PR — separate cleanup).
- SPDD: this branch was driven through the full lifecycle. The amended Canvas 6 (`spdd/prompt/6-…-Swing-Heavyweight-Webview-Embedding.md`) retires the v1.0.5 \`performSelectorOnMainThread:modes:\` Norm and replaces it with a prohibition on any sync EDT→main bridge in `webview_embed.cpp`. The user story (`requirements/[User-story-4]…`), strategic analysis (`spdd/analysis/…`), and Canvas amendment are committed alongside the code so spec and implementation stay in lock-step.

## Test plan

- [x] `build-mac.sh` succeeds end-to-end (was previously failing on Xcode 15+).
- [x] `c++ -c src_c/webview_embed.cpp -DWEBVIEW_COCOA=1 -std=c++11` compiles cleanly (no warnings, no errors).
- [x] All Java sources compile under `-source 1.8 -target 1.8`.
- [x] `dist/WebView.jar` rebuilds cleanly.
- [x] Grep verification: zero production-code references to `cocoa_run_on_main` (sync), `WebViewAwtMainBridge`, or `performWork:` outside the doc-comment that explains the removal.
- [x] `demos/WebViewDeadlockRepro` launches cleanly with the new dylib (verified the JVM starts and the watchdog does not fire during initial peer creation).
- [ ] **Manual interactive validation**: launch `demos/WebViewDeadlockRepro`, click "Start repro", let it run for ≥60 s — the watchdog must not fire. Pre-fix this hangs within ~5 s.
- [ ] **Manual interactive validation**: existing `WebViewHeavyweightDemo` keeps working unchanged (Cmd-C / Cmd-V / popup dismissal / focus cooperation).
- [ ] **JNI header regeneration**: `src_c/ca_weblite_webview_WebViewNative.h` and `windows/ca_weblite_webview_WebViewNative.h` were hand-edited to add the new `webview_embed_set_attach_callback` entry; recommended to regenerate via `javac -h` as part of the next CI build to confirm the diff matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)