### PR TITLE
Add documentation website for SwingWebView

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,50 @@
+// Syntax highlighting + copy-to-clipboard buttons.
+
+document.addEventListener("DOMContentLoaded", function () {
+  if (window.hljs) {
+    document.querySelectorAll("pre code").forEach(function (block) {
+      window.hljs.highlightElement(block);
+    });
+  }
+
+  document.querySelectorAll(".copy-btn").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var target = document.getElementById(btn.getAttribute("data-copy"));
+      if (!target) return;
+      var text = target.innerText;
+      var done = function () {
+        var orig = btn.textContent;
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        setTimeout(function () {
+          btn.textContent = orig;
+          btn.classList.remove("copied");
+        }, 1400);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, function () {
+          fallbackCopy(text, done);
+        });
+      } else {
+        fallbackCopy(text, done);
+      }
+    });
+  });
+
+  function fallbackCopy(text, done) {
+    var ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "absolute";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      document.execCommand("copy");
+      done();
+    } catch (e) {
+      // give up silently
+    }
+    document.body.removeChild(ta);
+  }
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>WebView for Java Swing &middot; ca.weblite:webview</title>
+<meta name="description" content="A cross-platform native WebView component for embedding in Java Swing applications. Bundled native libraries for macOS, Linux, and Windows — no extra install step." />
+<link rel="stylesheet" href="styles.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/atom-one-dark.min.css" />
+<script defer src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/java.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/xml.min.js"></script>
+<script defer src="app.js"></script>
+</head>
+<body>
+
+<header class="topnav">
+  <div class="container nav-inner">
+    <a class="brand" href="#top">
+      <span class="brand-mark">&lt;/&gt;</span>
+      <span class="brand-text">Swing<strong>WebView</strong></span>
+    </a>
+    <nav>
+      <a href="#install">Install</a>
+      <a href="#quickstart">Quick start</a>
+      <a href="#platforms">Platforms</a>
+      <a href="#js-interop">JS interop</a>
+      <a href="#demos">Demos</a>
+      <a class="nav-cta" href="https://github.com/webliteca/swingwebview" target="_blank" rel="noopener">GitHub &#x2197;</a>
+    </nav>
+  </div>
+</header>
+
+<section id="top" class="hero">
+  <div class="container hero-inner">
+    <div class="hero-text">
+      <span class="eyebrow">ca.weblite:webview &middot; v1.0.2 &middot; MIT</span>
+      <h1>A native WebView, embedded in your <em>Java&nbsp;Swing</em> app.</h1>
+      <p class="lede">
+        Cross-platform.  Heavyweight on macOS &amp; Windows, lightweight on
+        Linux.  Native libs bundled in the jar &mdash; one Maven dependency,
+        zero install steps.
+      </p>
+      <div class="hero-ctas">
+        <a class="btn btn-primary" href="#install">Get started in 30 seconds</a>
+        <a class="btn btn-ghost" href="https://github.com/webliteca/swingwebview" target="_blank" rel="noopener">View source on GitHub</a>
+      </div>
+      <ul class="hero-badges">
+        <li><span class="dot mac"></span>macOS &middot; WKWebView</li>
+        <li><span class="dot linux"></span>Linux &middot; WebKitGTK</li>
+        <li><span class="dot win"></span>Windows &middot; WebView2</li>
+      </ul>
+    </div>
+    <div class="hero-card" aria-hidden="true">
+<pre><code class="language-java">WebViewComponent wv = WebViewComponent.create();
+wv.setUrl("https://example.com");
+
+JFrame frame = new JFrame("Hello WebView");
+frame.add(wv, BorderLayout.CENTER);
+frame.pack();
+frame.setVisible(true);</code></pre>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+
+<section id="install" class="snippet-block">
+  <header class="snippet-header">
+    <span class="step-pill">Step 1</span>
+    <h2>Add the dependency</h2>
+    <p>Drop this into your <code>pom.xml</code>. The jar bundles the
+       native libraries for macOS, Linux, and Windows.</p>
+  </header>
+  <div class="code-card">
+    <div class="code-card-bar">
+      <span class="code-card-file">pom.xml</span>
+      <button class="copy-btn" data-copy="pom">Copy</button>
+    </div>
+<pre id="pom"><code class="language-xml">&lt;dependency&gt;
+    &lt;groupId&gt;ca.weblite&lt;/groupId&gt;
+    &lt;artifactId&gt;webview&lt;/artifactId&gt;
+    &lt;version&gt;1.0.2&lt;/version&gt;
+&lt;/dependency&gt;</code></pre>
+  </div>
+
+  <details class="alt-build">
+    <summary>Using Gradle?</summary>
+    <div class="code-card">
+      <div class="code-card-bar">
+        <span class="code-card-file">build.gradle</span>
+        <button class="copy-btn" data-copy="gradle">Copy</button>
+      </div>
+<pre id="gradle"><code class="language-java">implementation 'ca.weblite:webview:1.0.2'</code></pre>
+    </div>
+  </details>
+
+  <aside class="callout callout-info">
+    <strong>Windows note.</strong>  Requires the system-wide Microsoft Edge
+    WebView2 Runtime, which ships with current Windows&nbsp;11 / Edge.  On
+    older Windows, install the Evergreen Runtime from
+    <a href="https://developer.microsoft.com/microsoft-edge/webview2/" target="_blank" rel="noopener">developer.microsoft.com/microsoft-edge/webview2</a>.
+  </aside>
+</section>
+
+<section id="quickstart" class="snippet-block">
+  <header class="snippet-header">
+    <span class="step-pill">Step 2</span>
+    <h2>Show a web page in a JFrame</h2>
+    <p>One factory call.  <code>WebViewComponent.create()</code> picks
+       heavyweight or lightweight automatically for the current platform.</p>
+  </header>
+  <div class="code-card">
+    <div class="code-card-bar">
+      <span class="code-card-file">Demo.java</span>
+      <button class="copy-btn" data-copy="demo">Copy</button>
+    </div>
+<pre id="demo"><code class="language-java">import ca.weblite.webview.swing.WebViewComponent;
+import javax.swing.*;
+import java.awt.*;
+
+public class Demo {
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -&gt; {
+            WebViewComponent wv = WebViewComponent.create();
+            wv.setUrl("https://example.com");
+            wv.setPreferredSize(new Dimension(900, 600));
+
+            JFrame frame = new JFrame("WebView Demo");
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.add(wv, BorderLayout.CENTER);
+            frame.pack();
+            frame.setVisible(true);
+        });
+    }
+}</code></pre>
+  </div>
+
+  <p class="muted small">
+    That's it &mdash; <code>mvn package &amp;&amp; java -jar
+    target/your-app.jar</code> and you have a native WebView running
+    inside Swing.
+  </p>
+</section>
+
+<section id="platforms" class="block">
+  <h2>Platform support</h2>
+  <p class="muted">
+    The factory picks the right mode per platform.  Force a specific
+    mode with <code>WebViewComponent.create(Mode.HEAVYWEIGHT)</code>
+    or the <code>ca.weblite.webview.mode</code> system property.
+  </p>
+
+  <div class="platform-grid">
+
+    <article class="platform-card">
+      <header>
+        <span class="dot mac large"></span>
+        <h3>macOS</h3>
+        <span class="subtle">Cocoa &middot; WKWebView</span>
+      </header>
+      <dl>
+        <dt>Heavyweight</dt><dd>Full &mdash; rendering, input, resize, tab visibility.</dd>
+        <dt>Lightweight</dt><dd>Stub &mdash; falls back to default Swing background.</dd>
+      </dl>
+    </article>
+
+    <article class="platform-card">
+      <header>
+        <span class="dot linux large"></span>
+        <h3>Linux</h3>
+        <span class="subtle">WebKitGTK &middot; X11</span>
+      </header>
+      <dl>
+        <dt>Heavyweight</dt><dd>Rendering, mouse, scroll, resize, tabs.  Caret blink is unreliable under <code>XReparentWindow</code>.</dd>
+        <dt>Lightweight</dt><dd><strong>Full</strong> &mdash; rendering + mouse + keyboard.</dd>
+      </dl>
+    </article>
+
+    <article class="platform-card">
+      <header>
+        <span class="dot win large"></span>
+        <h3>Windows</h3>
+        <span class="subtle">WebView2</span>
+      </header>
+      <dl>
+        <dt>Heavyweight</dt><dd>Full &mdash; rendering, input, resize, tab visibility on Windows&nbsp;11.</dd>
+        <dt>Lightweight</dt><dd>Stub.</dd>
+      </dl>
+    </article>
+
+  </div>
+</section>
+
+<section id="js-interop" class="block alt-bg">
+  <h2>Talking to JavaScript</h2>
+  <p class="muted">
+    Three methods cover the whole interop surface &mdash;
+    fire-and-forget, round-trip-with-result, and page-initiated callbacks.
+  </p>
+
+  <div class="three-col">
+
+    <div>
+      <h3><code>eval(String&nbsp;js)</code></h3>
+      <p>Fire-and-forget.  Use for side effects.</p>
+<pre><code class="language-java">wv.eval("document.title = 'Hi';");</code></pre>
+    </div>
+
+    <div>
+      <h3><code>evalAsync(String&nbsp;js)</code></h3>
+      <p>Returns a <code>CompletableFuture&lt;String&gt;</code> resolved with the
+         JSON-stringified result.  Continuations land on the EDT.</p>
+<pre><code class="language-java">wv.evalAsync("return [window.scrollX, window.scrollY];")
+  .thenAccept(json -&gt; System.out.println(json));</code></pre>
+    </div>
+
+    <div>
+      <h3><code>addJavascriptCallback(...)</code></h3>
+      <p>Exposes a Java callback at <code>window.&lt;name&gt;(arg)</code> for the page to invoke.</p>
+<pre><code class="language-java">wv.addJavascriptCallback("notify", arg -&gt; {
+    System.out.println("page said: " + arg);
+});</code></pre>
+    </div>
+
+  </div>
+
+  <aside class="callout callout-warn">
+    <strong>Use <code>return</code> inside <code>evalAsync</code>.</strong>
+    The snippet runs inside an IIFE, so a bare expression is not the IIFE's
+    return value.
+  </aside>
+</section>
+
+<section id="dialogs" class="block">
+  <h2>Browser-initiated dialogs</h2>
+  <p class="muted">
+    <code>window.alert</code>, <code>confirm</code>, <code>prompt</code>,
+    and <code>&lt;input type="file"&gt;</code> are all routed through
+    <code>WebViewDialogHandler</code>.  The default handler shows
+    Swing dialogs; install your own to customise or suppress them.
+  </p>
+
+  <div class="code-card">
+    <div class="code-card-bar">
+      <span class="code-card-file">Dialog handler</span>
+      <button class="copy-btn" data-copy="dialog">Copy</button>
+    </div>
+<pre id="dialog"><code class="language-java">wv.setDialogHandler(new WebViewDialogHandler() {
+    @Override public boolean confirmOpened(WebViewConfirmEvent e) {
+        return JOptionPane.showConfirmDialog(
+            frame, e.message(), "Confirm",
+            JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION;
+    }
+});</code></pre>
+  </div>
+
+  <p class="muted small">
+    Pass <code>null</code> to install the headless-test drop handler
+    (alert no-op, confirm &rarr; <code>false</code>, prompt &rarr;
+    <code>null</code>, file picker &rarr; empty list).  Pass
+    <code>WebViewDialogHandler.DEFAULT</code> to reset to the Swing
+    default.
+  </p>
+</section>
+
+<section id="demos" class="block alt-bg">
+  <h2>Runnable demos</h2>
+  <p class="muted">
+    Each demo has launcher scripts at the project root
+    (<code>run-mac-*.sh</code>, <code>run-linux-*.sh</code>,
+    <code>run-windows-*.bat</code>).
+  </p>
+
+  <div class="demo-grid">
+    <a class="demo-card" href="https://github.com/webliteca/swingwebview/tree/master/demos/WebViewHeavyweightDemo" target="_blank" rel="noopener">
+      <h3>Heavyweight + Lightweight</h3>
+      <p>Side-by-side, with Swing widgets (JComboBox, tabs) interacting around the WebView.</p>
+    </a>
+    <a class="demo-card" href="https://github.com/webliteca/swingwebview/tree/master/demos/WebViewAsyncEvalDemo" target="_blank" rel="noopener">
+      <h3>Async JS eval</h3>
+      <p>Primitive / object / Promise results, exceptions surfacing as <code>JavaScriptEvalException</code>, EDT continuations.</p>
+    </a>
+    <a class="demo-card" href="https://github.com/webliteca/swingwebview/tree/master/demos/WebViewDialogDemo" target="_blank" rel="noopener">
+      <h3>Dialog handlers</h3>
+      <p>Default Swing, custom programmatic answers, and headless drop mode &mdash; for all four dialog kinds.</p>
+    </a>
+    <a class="demo-card" href="https://github.com/webliteca/swingwebview/tree/master/demos/WebViewContextMenuDemo" target="_blank" rel="noopener">
+      <h3>Context menus</h3>
+      <p>Right-click target descriptors: link / image / editable / selection, and <code>setDefaultContextMenuEnabled</code>.</p>
+    </a>
+    <a class="demo-card" href="https://github.com/webliteca/swingwebview/tree/master/demos/WebViewConsoleDemo" target="_blank" rel="noopener">
+      <h3>Console (standalone)</h3>
+      <p>The non-Swing <code>WebView</code> primitive, driven from a console app.</p>
+    </a>
+  </div>
+</section>
+
+<section id="building" class="block">
+  <h2>Building from source</h2>
+  <div class="code-card">
+    <div class="code-card-bar">
+      <span class="code-card-file">shell</span>
+      <button class="copy-btn" data-copy="build">Copy</button>
+    </div>
+<pre id="build"><code>git clone https://github.com/webliteca/swingwebview
+cd swingwebview
+mvn -DskipTests package</code></pre>
+  </div>
+  <p class="muted small">
+    Produces <code>target/webview-1.0-SNAPSHOT.jar</code>.  Targets Java&nbsp;8
+    bytecode; works on JDK&nbsp;8 and any newer LTS.  Native libs are
+    rebuilt by <code>build-mac.sh</code> /
+    <code>build-linux.sh</code> / <code>build-windows.sh</code>;
+    the cross-platform fat jar is produced by the GitHub Actions
+    release workflow.
+  </p>
+</section>
+
+</main>
+
+<footer class="site-footer">
+  <div class="container footer-inner">
+    <div>
+      <strong>SwingWebView</strong>
+      <p>MIT-licensed.  Java port of Serge Zaitsev's
+        <a href="https://github.com/zserge/webview" target="_blank" rel="noopener">webview</a>
+        by <a href="https://sjhannah.com" target="_blank" rel="noopener">Steve Hannah</a>.</p>
+    </div>
+    <div>
+      <h4>Links</h4>
+      <ul>
+        <li><a href="https://github.com/webliteca/swingwebview" target="_blank" rel="noopener">GitHub repository</a></li>
+        <li><a href="https://github.com/webliteca/swingwebview/blob/master/README.md" target="_blank" rel="noopener">Full README</a></li>
+        <li><a href="https://central.sonatype.com/artifact/ca.weblite/webview" target="_blank" rel="noopener">Maven Central</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4>Credits</h4>
+      <ul>
+        <li><a href="https://sjhannah.com" target="_blank" rel="noopener">Steve Hannah</a> &mdash; Java port</li>
+        <li><a href="https://zserge.com" target="_blank" rel="noopener">Serge Zaitsev</a> &mdash; original webview</li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,619 @@
+/* -------- Reset & base ------------------------------------------------ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+html { overflow-x: hidden; }
+
+body {
+  margin: 0;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  color: #1f2733;
+  background: #fbfbfd;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4 {
+  margin: 0 0 0.6em;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: #0d1320;
+}
+
+h1 { font-size: clamp(2.1rem, 4.2vw, 3.4rem); font-weight: 700; }
+h2 { font-size: clamp(1.6rem, 2.6vw, 2.1rem); font-weight: 650; }
+h3 { font-size: 1.1rem; font-weight: 600; }
+
+p { margin: 0 0 1em; }
+
+a {
+  color: #3957d6;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+a:hover { color: #1f3aac; text-decoration: underline; }
+
+code {
+  font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  background: #f1f3f8;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  color: #2a3146;
+}
+
+pre {
+  margin: 0;
+  font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  overflow-x: auto;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  border-radius: 0;
+}
+
+.container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.muted { color: #5b6577; }
+.small { font-size: 0.9rem; }
+
+/* -------- Top nav ----------------------------------------------------- */
+
+.topnav {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: rgba(251, 251, 253, 0.85);
+  backdrop-filter: saturate(160%) blur(10px);
+  -webkit-backdrop-filter: saturate(160%) blur(10px);
+  border-bottom: 1px solid #e5e8ef;
+}
+
+.nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1.05rem;
+  color: #0d1320;
+}
+.brand:hover { text-decoration: none; }
+
+.brand-mark {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85rem;
+  color: #fff;
+  background: linear-gradient(135deg, #5b6ef5, #8a4ee0);
+  padding: 5px 8px;
+  border-radius: 6px;
+  letter-spacing: -0.05em;
+}
+
+.brand-text strong { font-weight: 700; }
+
+.topnav nav {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.topnav nav a {
+  color: #3a4254;
+  font-size: 0.94rem;
+  font-weight: 500;
+}
+
+.topnav nav a:hover {
+  color: #0d1320;
+  text-decoration: none;
+}
+
+.nav-cta {
+  border: 1px solid #d8dde7;
+  padding: 6px 12px;
+  border-radius: 6px;
+  background: #fff;
+}
+.nav-cta:hover { border-color: #0d1320; }
+
+@media (max-width: 720px) {
+  .topnav nav a:not(.nav-cta) { display: none; }
+}
+
+/* -------- Hero -------------------------------------------------------- */
+
+.hero {
+  padding: 72px 0 56px;
+  background:
+    radial-gradient(1200px 500px at 80% -100px, rgba(91,110,245,0.10), transparent 60%),
+    radial-gradient(800px 400px at 0% 0%, rgba(138,78,224,0.07), transparent 60%);
+}
+
+.hero-inner {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 56px;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .hero-inner { grid-template-columns: 1fr; gap: 32px; }
+  .hero { padding: 48px 0 32px; }
+}
+
+.eyebrow {
+  display: inline-block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: #5b6ef5;
+  background: rgba(91,110,245,0.10);
+  padding: 4px 10px;
+  border-radius: 999px;
+  margin-bottom: 18px;
+  letter-spacing: 0.02em;
+}
+
+.hero h1 em {
+  font-style: normal;
+  background: linear-gradient(135deg, #5b6ef5, #8a4ee0);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.lede {
+  font-size: 1.12rem;
+  color: #3a4254;
+  max-width: 38ch;
+  margin-bottom: 28px;
+}
+
+.hero-ctas {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 26px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 12px 20px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1;
+  transition: transform 0.08s ease, box-shadow 0.15s ease, background 0.15s;
+}
+.btn:hover { text-decoration: none; transform: translateY(-1px); }
+
+.btn-primary {
+  background: #0d1320;
+  color: #fff;
+  box-shadow: 0 6px 20px -8px rgba(13,19,32,0.6);
+}
+.btn-primary:hover { background: #1c2433; color: #fff; }
+
+.btn-ghost {
+  background: #fff;
+  color: #0d1320;
+  border: 1px solid #d8dde7;
+}
+.btn-ghost:hover { border-color: #0d1320; color: #0d1320; }
+
+.hero-badges {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  color: #5b6577;
+  font-size: 0.88rem;
+}
+
+.dot {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+.dot.large { width: 12px; height: 12px; }
+.dot.mac   { background: #0091ea; }
+.dot.linux { background: #f59e0b; }
+.dot.win   { background: #16a34a; }
+
+.hero-card {
+  background: #0d1320;
+  color: #e6e9f2;
+  border-radius: 12px;
+  padding: 22px 24px;
+  box-shadow: 0 30px 60px -30px rgba(13,19,32,0.45),
+              0 8px 20px -10px rgba(13,19,32,0.25);
+  border: 1px solid #1c2433;
+  overflow: hidden;
+}
+
+.hero-card pre {
+  background: transparent;
+  color: inherit;
+}
+
+/* -------- Blocks ------------------------------------------------------ */
+
+main { padding: 24px 0 80px; }
+
+.block {
+  padding: 56px 0;
+  border-top: 1px solid #ebeef4;
+}
+
+.block.alt-bg {
+  background: #f4f6fb;
+  margin: 0 -100vw;
+  padding-left: 100vw;
+  padding-right: 100vw;
+}
+
+/* Recover container width inside alt-bg */
+.block.alt-bg > h2,
+.block.alt-bg > p,
+.block.alt-bg > .three-col,
+.block.alt-bg > .demo-grid,
+.block.alt-bg > .code-card,
+.block.alt-bg > .callout {
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.snippet-block {
+  padding: 48px 0 32px;
+}
+
+.snippet-header {
+  text-align: center;
+  margin-bottom: 28px;
+}
+
+.snippet-header p {
+  color: #5b6577;
+  max-width: 56ch;
+  margin: 0 auto;
+}
+
+.step-pill {
+  display: inline-block;
+  background: linear-gradient(135deg, #5b6ef5, #8a4ee0);
+  color: #fff;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 5px 12px;
+  border-radius: 999px;
+  margin-bottom: 14px;
+}
+
+/* -------- Code card -------------------------------------------------- */
+
+.code-card {
+  background: #0d1320;
+  border-radius: 12px;
+  border: 1px solid #1c2433;
+  overflow: hidden;
+  box-shadow: 0 24px 50px -28px rgba(13,19,32,0.45);
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.code-card-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #161d2e;
+  padding: 8px 14px;
+  border-bottom: 1px solid #1c2433;
+}
+
+.code-card-file {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  color: #9aa3b8;
+  letter-spacing: 0.02em;
+}
+
+.copy-btn {
+  background: transparent;
+  border: 1px solid #2d3754;
+  color: #c9cee0;
+  font-size: 0.78rem;
+  padding: 4px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  font-family: inherit;
+}
+.copy-btn:hover {
+  background: #1c2433;
+  border-color: #475070;
+  color: #fff;
+}
+.copy-btn.copied {
+  border-color: #16a34a;
+  color: #4ade80;
+}
+
+.code-card pre {
+  padding: 20px 22px;
+}
+
+/* Make highlight.js fit the card */
+.hljs {
+  background: transparent !important;
+  padding: 0 !important;
+}
+
+.alt-build {
+  max-width: 760px;
+  margin: 16px auto 0;
+}
+
+.alt-build summary {
+  cursor: pointer;
+  color: #5b6577;
+  font-size: 0.92rem;
+  padding: 8px 0;
+  user-select: none;
+}
+.alt-build[open] summary { margin-bottom: 10px; }
+
+/* -------- Callouts --------------------------------------------------- */
+
+.callout {
+  max-width: 760px;
+  margin: 22px auto 0;
+  padding: 14px 18px;
+  border-radius: 8px;
+  font-size: 0.94rem;
+  line-height: 1.5;
+}
+
+.callout-info {
+  background: #eef3ff;
+  border-left: 3px solid #5b6ef5;
+  color: #2a3458;
+}
+
+.callout-warn {
+  background: #fff5e6;
+  border-left: 3px solid #f59e0b;
+  color: #5a3a08;
+}
+
+/* -------- Platform grid ---------------------------------------------- */
+
+.platform-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-top: 28px;
+}
+
+@media (max-width: 820px) {
+  .platform-grid { grid-template-columns: 1fr; }
+}
+
+.platform-card {
+  background: #fff;
+  border: 1px solid #e5e8ef;
+  border-radius: 12px;
+  padding: 22px;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.1s;
+}
+
+.platform-card:hover {
+  border-color: #c9d0e0;
+  box-shadow: 0 14px 30px -20px rgba(13,19,32,0.15);
+  transform: translateY(-2px);
+}
+
+.platform-card header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.platform-card h3 {
+  margin: 0;
+}
+
+.subtle {
+  font-size: 0.82rem;
+  color: #8a92a6;
+  font-family: "JetBrains Mono", monospace;
+}
+
+.platform-card dl {
+  margin: 0;
+}
+.platform-card dt {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #3a4254;
+  margin-top: 10px;
+}
+.platform-card dd {
+  margin: 4px 0 0;
+  font-size: 0.92rem;
+  color: #5b6577;
+}
+
+/* -------- Three column ----------------------------------------------- */
+
+.three-col {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-top: 28px;
+}
+
+@media (max-width: 900px) {
+  .three-col { grid-template-columns: 1fr; }
+}
+
+.three-col > div {
+  background: #fff;
+  border: 1px solid #e5e8ef;
+  border-radius: 12px;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+}
+
+.three-col h3 {
+  margin-bottom: 8px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.95rem;
+  color: #0d1320;
+}
+
+.three-col h3 code {
+  background: transparent;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+.three-col p {
+  color: #5b6577;
+  font-size: 0.92rem;
+  margin-bottom: 14px;
+  flex: 1;
+}
+
+.three-col pre {
+  background: #0d1320;
+  color: #e6e9f2;
+  border-radius: 8px;
+  padding: 14px 16px;
+  font-size: 0.82rem;
+  border: 1px solid #1c2433;
+}
+
+/* -------- Demos ------------------------------------------------------ */
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin-top: 28px;
+}
+
+@media (max-width: 900px) {
+  .demo-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 600px) {
+  .demo-grid { grid-template-columns: 1fr; }
+}
+
+.demo-card {
+  background: #fff;
+  border: 1px solid #e5e8ef;
+  border-radius: 12px;
+  padding: 20px;
+  display: block;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.1s;
+}
+
+.demo-card:hover {
+  text-decoration: none;
+  border-color: #5b6ef5;
+  box-shadow: 0 14px 30px -20px rgba(91,110,245,0.35);
+  transform: translateY(-2px);
+}
+
+.demo-card h3 {
+  margin-bottom: 6px;
+  color: #0d1320;
+}
+
+.demo-card p {
+  margin: 0;
+  color: #5b6577;
+  font-size: 0.92rem;
+}
+
+/* -------- Footer ----------------------------------------------------- */
+
+.site-footer {
+  border-top: 1px solid #ebeef4;
+  background: #fff;
+  padding: 40px 0 60px;
+  margin-top: 40px;
+}
+
+.footer-inner {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 36px;
+  color: #5b6577;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 720px) {
+  .footer-inner { grid-template-columns: 1fr; gap: 20px; }
+}
+
+.site-footer h4 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #8a92a6;
+  margin-bottom: 10px;
+}
+
+.site-footer ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.site-footer li {
+  margin-bottom: 6px;
+}
+.site-footer a { color: #3a4254; }
+.site-footer a:hover { color: #0d1320; }


### PR DESCRIPTION
## Summary
This PR adds a complete documentation website for the SwingWebView project, including HTML, CSS, and JavaScript files that provide installation instructions, quick-start guides, platform support details, and interactive code examples.

## Changes
- **docs/index.html**: Main documentation page with sections for installation, quick start, platform support, JavaScript interoperability, dialog handling, demos, and building from source. Includes syntax-highlighted code examples with copy-to-clipboard functionality.
- **docs/styles.css**: Comprehensive stylesheet (619 lines) providing:
  - Reset and base styles with smooth scrolling and font configuration
  - Sticky navigation bar with brand and responsive menu
  - Hero section with gradient backgrounds and call-to-action buttons
  - Code card styling with dark theme for syntax-highlighted blocks
  - Platform grid and three-column layouts for feature documentation
  - Demo card grid with hover effects
  - Footer with multi-column link organization
  - Responsive design with media queries for mobile/tablet viewports
  - Callout boxes for info and warning messages
- **docs/app.js**: Client-side JavaScript for:
  - Syntax highlighting integration with highlight.js
  - Copy-to-clipboard functionality for code blocks with visual feedback
  - Fallback clipboard implementation for older browsers
- **docs/.nojekyll**: GitHub Pages configuration file to disable Jekyll processing

## Implementation Details
- Uses semantic HTML5 with proper accessibility attributes
- CSS employs modern features (CSS Grid, clamp(), backdrop-filter) with fallbacks
- Responsive design adapts from mobile (single column) to desktop (multi-column layouts)
- Code examples cover Maven/Gradle dependency setup, basic usage, and advanced features
- Interactive elements include smooth transitions, hover states, and copy feedback
- External dependencies: Inter and JetBrains Mono fonts, highlight.js for syntax highlighting

https://claude.ai/code/session_01TcHDDsGAXztTkuZWNZUyax