### PR TITLE
docs: bump README dependency example to 1.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the dependency to your `pom.xml`:
 <dependency>
     <groupId>ca.weblite</groupId>
     <artifactId>webview</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.7</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
Updates the `ca.weblite:webview` Maven dependency example in `README.md` from `1.0.2` to `1.0.7`, the latest released version per Maven Central's `maven-metadata.xml` (`<release>1.0.7</release>`).

`docs/index.html` (Maven `<version>`, Gradle coordinate, and `v1.0.7` eyebrow) was already at 1.0.7, so no change was needed there.

## Not changed (intentionally)
- `pom.xml` `1.0-SNAPSHOT` — release version is set by CI at tag time.
- Historical `v1.0.5` references in `demos/`, `requirements/`, and `spdd/` — these intentionally name the past deadlock-repro release.
- WebView2 runtime version and CI `git tag` examples — unrelated to this library's coordinate.

## SPDD note
The README Installation version snippet is hand-maintained documentation, not a Canvas-owned generated artifact (canvases reference specific README *sections* for sync, not the dependency coordinate), so a direct edit is appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)