### PR TITLE
Fix struct-return ABI crash on Intel macOS (issue #36)

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -6,14 +6,15 @@ if pkg-config --exists webkit2gtk-4.1; then
 else
     WEBKIT_PKG=webkit2gtk-4.0
 fi
-# Link against JAWT for the Swing embedding bridge.
-JAWT_LIB="-L${JAVA_HOME}/lib -ljawt"
-g++ -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -fPIC -std=c++11 -Wall -Wextra -pedantic -I./src_c -DWEBVIEW_GTK=1 \
+# Link against JAWT for the Swing embedding bridge. Use an array so the
+# -L path stays a single argument even if JAVA_HOME contains spaces.
+JAWT_LIB=(-L"${JAVA_HOME}/lib" -ljawt)
+g++ -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/linux" -fPIC -std=c++11 -Wall -Wextra -pedantic -I./src_c -DWEBVIEW_GTK=1 \
     `pkg-config --cflags gtk+-3.0 $WEBKIT_PKG` \
     src_c/webview.c src_c/webview_embed.cpp \
     $LDFLAGS \
     `pkg-config --libs gtk+-3.0 $WEBKIT_PKG` \
-    $JAWT_LIB -lX11 \
+    "${JAWT_LIB[@]}" -lX11 \
     -shared -o libwebview.so
 mkdir -p natives/linux_64
 mv libwebview.so natives/linux_64/

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 # Note: on macOS, JAWT lives next to libjli inside the JDK; -ljawt links it.
-c++ -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin -dynamiclib \
+c++ -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/darwin" -dynamiclib \
     src_c/webview.c src_c/webview_embed.cpp \
     -o libwebview.dylib \
     -DWEBVIEW_COCOA=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=1 -std=c++11 \
     -framework WebKit -framework Cocoa -framework QuartzCore \
-    -L${JAVA_HOME}/lib -ljawt
+    -L"${JAVA_HOME}/lib" -ljawt
 mkdir -p natives/osx_64
 mv libwebview.dylib natives/osx_64/

--- a/repro-issue-36-macos-intel.sh
+++ b/repro-issue-36-macos-intel.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+#
+# Reproduction script for issue #36: "SwingWebView cannot run on macOS"
+# (SIGSEGV in objc_msgSend right after the WKWebView is added as a subview).
+#
+# Hypothesis being tested
+# -----------------------
+# The crash is an Objective-C struct-return ABI mismatch that only bites on
+# Intel (x86_64) Macs.  In src_c/webview_embed.cpp, cocoa_set_bounds() does:
+#
+#       CGRect b = msg<CGRect>(e->host_view, sel("bounds"));   // line ~3888
+#
+# msg<>() always dispatches through plain objc_msgSend().  On x86_64 the SysV
+# ABI returns a 32-byte struct (CGRect) via a hidden pointer in the first
+# integer register, so a CGRect-returning selector MUST be dispatched through
+# objc_msgSend_stret().  Using plain objc_msgSend() shifts self/cmd by one
+# register; the dispatcher then reads the stack return-buffer pointer as the
+# receiver and dereferences its isa -> SIGSEGV at a bogus/zero address.
+#
+# On Apple Silicon (arm64) there is no objc_msgSend_stret and large struct
+# returns use the separate x8 register, so the very same code is correct --
+# which is why the library works on arm64 Macs but crashes on Intel.
+#
+# This crash path is only reached when host_is_awt == false, i.e. when the
+# native code attaches the WKWebView to NSWindow.contentView instead of a
+# per-Canvas AWT NSView.  The JetBrains Runtime (JBR) used by IntelliJ does
+# not expose an AWT-named NSView, so it takes that fallback path -- matching
+# the reporter's environment (Intel mac, macOS 15.7.7, JBR 25.0.3).
+#
+# What this script does
+# ---------------------
+#   Phase A  (fast, no JDK/Maven needed): compiles a ~40-line Objective-C
+#            program that calls a CGRect-returning selector two ways --
+#            through objc_msgSend (the buggy dispatch) and through the
+#            architecture-correct dispatch -- and shows the first crashes on
+#            Intel while the second succeeds.  This isolates the root cause.
+#
+#   Phase B  (end-to-end): downloads ca.weblite:webview:1.0.7, writes the
+#            exact demo from the issue, and runs it under JBR 25 to reproduce
+#            the real crash (exit 134 / SIGABRT with an hs_err log naming
+#            cocoa_set_bounds).
+#
+# Usage
+# -----
+#   ./repro-issue-36-macos-intel.sh            # run both phases
+#   ./repro-issue-36-macos-intel.sh --phase-a  # ABI micro-repro only
+#   ./repro-issue-36-macos-intel.sh --phase-b  # end-to-end only
+#
+# Environment overrides
+#   JBR_HOME=/path/to/jbr/Contents/Home   use a specific JBR (skips autodetect)
+#   JBR_URL=https://.../jbr-...-osx-x64-....tar.gz   download URL fallback
+#   WEBVIEW_VERSION=1.0.7                  library version to test (default 1.0.7)
+#   STOCK_JAVA=/path/to/stock/jdk/Home    optional: also run under a non-JBR JDK
+#                                         to show it does NOT crash there
+#
+set -uo pipefail
+
+# --------------------------------------------------------------------------
+# Pretty output helpers
+# --------------------------------------------------------------------------
+bold=$(printf '\033[1m'); red=$(printf '\033[31m'); grn=$(printf '\033[32m')
+ylw=$(printf '\033[33m'); rst=$(printf '\033[0m')
+say()  { printf '%s\n' "$*"; }
+hdr()  { printf '\n%s== %s ==%s\n' "$bold" "$*" "$rst"; }
+ok()   { printf '%s[ OK ]%s %s\n'   "$grn" "$rst" "$*"; }
+bad()  { printf '%s[FAIL]%s %s\n'   "$red" "$rst" "$*"; }
+warn() { printf '%s[warn]%s %s\n'   "$ylw" "$rst" "$*"; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/swv-issue36.XXXXXX")"
+CACHE="${HOME}/.cache/swv-issue36"
+mkdir -p "$CACHE"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+WEBVIEW_VERSION="${WEBVIEW_VERSION:-1.0.7}"
+
+PHASE="all"
+case "${1:-}" in
+  --phase-a) PHASE="a" ;;
+  --phase-b) PHASE="b" ;;
+  -h|--help) sed -n '2,60p' "$0"; exit 0 ;;
+  "") ;;
+  *) bad "unknown argument: $1"; exit 2 ;;
+esac
+
+# --------------------------------------------------------------------------
+# Platform sanity checks
+# --------------------------------------------------------------------------
+hdr "Platform"
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+say "OS:   $OS"
+say "Arch: $ARCH"
+say "macOS version: $(sw_vers -productVersion 2>/dev/null || echo '?') ($(sw_vers -buildVersion 2>/dev/null || echo '?'))"
+
+if [[ "$OS" != "Darwin" ]]; then
+  bad "This reproduction is macOS-specific. Detected: $OS"
+  exit 2
+fi
+if [[ "$ARCH" != "x86_64" && "$ARCH" != "i386" ]]; then
+  warn "This is an Apple Silicon Mac ($ARCH). The bug does NOT crash here --"
+  warn "arm64 has no objc_msgSend_stret and uses the x8 register for struct"
+  warn "returns, so the same code is correct. Run this on an Intel Mac to"
+  warn "reproduce. (Phase A is still compiled to demonstrate the difference.)"
+fi
+
+# ==========================================================================
+# Phase A -- Objective-C struct-return ABI micro-repro
+# ==========================================================================
+phase_a() {
+  hdr "Phase A: objc_msgSend vs objc_msgSend_stret (CGRect return)"
+
+  if ! command -v clang >/dev/null 2>&1; then
+    warn "clang not found (install Xcode command line tools: xcode-select --install)"
+    warn "skipping Phase A"
+    return
+  fi
+
+  cat > "$WORK/abi_repro.m" <<'OBJC'
+// Mirrors src_c/webview_embed.cpp:3888 -- msg<CGRect>(view, "bounds").
+// argv[1] == "bad"  -> dispatch a CGRect-returning selector through plain
+//                      objc_msgSend (what msg<>() does today). Wrong on x86_64.
+// argv[1] == "good" -> dispatch through the architecture-correct function.
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#import <objc/message.h>
+#include <string.h>
+#include <stdio.h>
+
+typedef CGRect (*RectMsg)(id, SEL);
+
+int main(int argc, char **argv) {
+  const char *mode = argc > 1 ? argv[1] : "good";
+  @autoreleasepool {
+    id view = ((id (*)(id, SEL))objc_msgSend)(
+        (id)objc_getClass("NSView"), sel_registerName("alloc"));
+    view = ((id (*)(id, SEL, CGRect))objc_msgSend)(
+        view, sel_registerName("initWithFrame:"), CGRectMake(0, 0, 640, 480));
+    SEL boundsSel = sel_registerName("bounds");
+
+    CGRect r;
+    if (strcmp(mode, "bad") == 0) {
+      // Buggy dispatch: identical to msg<CGRect>(...) in the library.
+      RectMsg fn = (RectMsg)objc_msgSend;
+      r = fn(view, boundsSel);                 // <-- crashes on x86_64
+    } else {
+#if defined(__x86_64__)
+      RectMsg fn = (RectMsg)objc_msgSend_stret; // correct on Intel
+#else
+      RectMsg fn = (RectMsg)objc_msgSend;       // correct on arm64
+#endif
+      r = fn(view, boundsSel);
+    }
+    printf("bounds = (%g, %g, %g, %g)\n",
+           r.origin.x, r.origin.y, r.size.width, r.size.height);
+  }
+  return 0;
+}
+OBJC
+
+  if ! clang -fobjc-arc -framework Foundation -framework AppKit \
+        -o "$WORK/abi_repro" "$WORK/abi_repro.m" 2>"$WORK/clang.log"; then
+    bad "Phase A failed to compile:"; cat "$WORK/clang.log"; return
+  fi
+
+  say "Running the BAD dispatch (plain objc_msgSend for a CGRect return)..."
+  "$WORK/abi_repro" bad >"$WORK/bad.out" 2>&1
+  bad_code=$?
+  if [[ $bad_code -ge 128 ]]; then
+    sig=$((bad_code - 128))
+    ok "BAD dispatch crashed with signal $sig (exit $bad_code) -- reproduces the bug"
+    [[ -s "$WORK/bad.out" ]] && sed 's/^/      /' "$WORK/bad.out"
+  else
+    warn "BAD dispatch did NOT crash (exit $bad_code). Output:"
+    sed 's/^/      /' "$WORK/bad.out"
+    if [[ "$ARCH" != "x86_64" && "$ARCH" != "i386" ]]; then
+      warn "Expected on arm64 -- the bug is Intel-only."
+    fi
+  fi
+
+  say "Running the GOOD dispatch (architecture-correct)..."
+  "$WORK/abi_repro" good >"$WORK/good.out" 2>&1
+  good_code=$?
+  if [[ $good_code -eq 0 ]]; then
+    ok "GOOD dispatch succeeded: $(cat "$WORK/good.out")"
+  else
+    bad "GOOD dispatch failed unexpectedly (exit $good_code):"
+    sed 's/^/      /' "$WORK/good.out"
+  fi
+
+  if [[ ( "$ARCH" == "x86_64" || "$ARCH" == "i386" ) && $bad_code -ge 128 && $good_code -eq 0 ]]; then
+    ok "Phase A confirms the root cause: the bounds call must use objc_msgSend_stret on Intel."
+  fi
+}
+
+# ==========================================================================
+# Phase B -- end-to-end repro of the actual library crash under JBR 25
+# ==========================================================================
+
+# Locate a JetBrains Runtime (JBR), preferring version 25.
+find_jbr() {
+  if [[ -n "${JBR_HOME:-}" ]]; then
+    [[ -x "$JBR_HOME/bin/java" ]] && { echo "$JBR_HOME"; return 0; }
+    warn "JBR_HOME set but $JBR_HOME/bin/java is not executable" >&2
+  fi
+  # IntelliJ / Toolbox bundled JBRs and standalone JBR installs all expose a
+  # .../jbr/Contents/Home (or .../jbr-<ver>/Contents/Home) directory.
+  local search=(/Applications "$HOME/Applications"
+    "$HOME/Library/Application Support/JetBrains/Toolbox/apps"
+    "$CACHE")
+  local best="" home v
+  while IFS= read -r home; do
+    [[ -x "$home/bin/java" ]] || continue
+    v="$("$home/bin/java" -version 2>&1 | head -1)"
+    if printf '%s' "$v" | grep -q '"25'; then echo "$home"; return 0; fi
+    [[ -z "$best" ]] && best="$home"
+  done < <(/usr/bin/find "${search[@]}" -maxdepth 7 -type d -name Home \
+             \( -path '*jbr*' -o -path '*JetBrainsRuntime*' \) 2>/dev/null)
+  [[ -n "$best" ]] && { echo "$best"; return 0; }
+  return 1
+}
+
+download_jbr() {
+  local url="${JBR_URL:-https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25.0.3-osx-x64-b480.61.tar.gz}"
+  local tgz="$CACHE/$(basename "$url")"
+  local dest="$CACHE/jbr-download"
+  if [[ ! -d "$dest" ]]; then
+    say "Downloading JBR 25 (osx-x64) from:" >&2
+    say "  $url" >&2
+    if ! curl -fL --retry 3 -o "$tgz" "$url"; then
+      warn "JBR download failed. Set JBR_HOME to a local JBR 25, or JBR_URL to a" >&2
+      warn "valid osx-x64 JBR 25 tarball from https://github.com/JetBrains/JetBrainsRuntime/releases" >&2
+      return 1
+    fi
+    mkdir -p "$dest"
+    tar -xzf "$tgz" -C "$dest" || { warn "extract failed" >&2; return 1; }
+  fi
+  /usr/bin/find "$dest" -maxdepth 4 -type d -name Home -path '*Contents*' 2>/dev/null | head -1
+}
+
+run_demo() {
+  # $1 = JAVA_HOME, $2 = label, $3 = jar path
+  local jhome="$1" label="$2" jar="$3"
+  local cls="$WORK/classes-$label"
+  mkdir -p "$cls"
+  local errfile="$WORK/hs_err_${label}.log"
+
+  say "Compiling demo with $label javac..."
+  if ! "$jhome/bin/javac" -cp "$jar" -d "$cls" "$WORK/Main.java" 2>"$WORK/javac-$label.log"; then
+    bad "compile failed under $label:"; sed 's/^/      /' "$WORK/javac-$label.log"
+    return 2
+  fi
+
+  say "Launching demo under $label ($("$jhome/bin/java" -version 2>&1 | head -1))..."
+  rm -f "$errfile"
+  # The native [webview-embed] logs go to stderr; capture everything.
+  "$jhome/bin/java" \
+      -XX:ErrorFile="$errfile" \
+      -Djava.awt.headless=false \
+      -cp "$jar:$cls" Main >"$WORK/run-$label.out" 2>&1 &
+  local pid=$!
+
+  # Manual timeout (macOS has no `timeout`): a crash exits within a second or
+  # two; if it survives, it would stay open forever, so kill after 30s.
+  ( sleep 30; kill -0 "$pid" 2>/dev/null && kill "$pid" 2>/dev/null ) &
+  local watcher=$!
+  wait "$pid"; local code=$?
+  kill "$watcher" 2>/dev/null; wait "$watcher" 2>/dev/null
+
+  say "---- native / JVM output (under $label) ----"
+  sed 's/^/      /' "$WORK/run-$label.out"
+  say "--------------------------------------------"
+
+  if [[ -f "$errfile" ]] || [[ $code -eq 134 || $code -eq 139 ]]; then
+    bad "$label CRASHED (exit $code) -- reproduced."
+    if [[ -f "$errfile" ]]; then
+      local saved="$CACHE/hs_err_${label}_$(date +%s).log"
+      cp "$errfile" "$saved"
+      say "Saved crash log: $saved"
+      say "Relevant native frames:"
+      grep -nE "objc_msgSend|cocoa_set_bounds|cocoa_run_on_main_async|libwebview" "$errfile" \
+        | head -8 | sed 's/^/      /'
+    fi
+    return 1
+  elif [[ $code -eq 143 || $code -eq 130 ]]; then
+    ok "$label survived 30s without crashing (window was open; killed by timeout)."
+    return 0
+  else
+    warn "$label exited $code without an hs_err log. Output above may explain why"
+    warn "(e.g. no display / headless). Re-run in a normal desktop session."
+    return 0
+  fi
+}
+
+phase_b() {
+  hdr "Phase B: end-to-end demo under JBR 25 (webview $WEBVIEW_VERSION)"
+
+  # 1. Fetch the library jar (bundles the native dylib; no other runtime deps).
+  local jar="$CACHE/webview-$WEBVIEW_VERSION.jar"
+  if [[ ! -f "$jar" ]]; then
+    local url="https://repo1.maven.org/maven2/ca/weblite/webview/$WEBVIEW_VERSION/webview-$WEBVIEW_VERSION.jar"
+    say "Downloading $url"
+    if ! curl -fL --retry 3 -o "$jar" "$url"; then
+      bad "Could not download webview-$WEBVIEW_VERSION.jar"; return 2
+    fi
+  fi
+  ok "Library jar: $jar"
+
+  # 2. Write the exact demo from the issue.
+  cat > "$WORK/Main.java" <<'JAVA'
+import ca.weblite.webview.swing.WebViewComponent;
+import javax.swing.*;
+import java.awt.*;
+
+public class Main {
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            WebViewComponent wv = WebViewComponent.create();
+            wv.setUrl("https://example.com");
+            wv.setPreferredSize(new Dimension(900, 600));
+
+            JFrame frame = new JFrame("WebView Demo");
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.add(wv, BorderLayout.CENTER);
+            frame.pack();
+            frame.setVisible(true);
+        });
+    }
+}
+JAVA
+
+  # 3. Find or download JBR 25.
+  local jbr; jbr="$(find_jbr || true)"
+  if [[ -z "$jbr" ]]; then
+    warn "No JBR found in IntelliJ/Toolbox locations; attempting download..."
+    jbr="$(download_jbr || true)"
+  fi
+  if [[ -z "$jbr" ]]; then
+    bad "Could not locate or download a JetBrains Runtime."
+    bad "Set JBR_HOME=/path/to/jbr/Contents/Home and re-run."
+    return 2
+  fi
+  ok "JBR: $jbr"
+
+  run_demo "$jbr" "JBR" "$jar"; local jbr_result=$?
+
+  # 4. Optional A/B: show a stock (non-JBR) JDK does NOT crash.
+  if [[ -n "${STOCK_JAVA:-}" && -x "$STOCK_JAVA/bin/java" ]]; then
+    hdr "Control run: stock JDK (expected NOT to crash)"
+    run_demo "$STOCK_JAVA" "stock" "$jar"
+  else
+    say
+    say "Tip: set STOCK_JAVA=/path/to/Temurin-or-Corretto-21/Home to also run the"
+    say "control case that should NOT crash (proving the bug is JBR/contentView-specific)."
+  fi
+
+  return $jbr_result
+}
+
+# ==========================================================================
+# Drive
+# ==========================================================================
+rc=0
+[[ "$PHASE" == "all" || "$PHASE" == "a" ]] && phase_a
+[[ "$PHASE" == "all" || "$PHASE" == "b" ]] && { phase_b || rc=$?; }
+
+hdr "Summary"
+say "Root-cause hypothesis: src_c/webview_embed.cpp cocoa_set_bounds() dispatches"
+say "a CGRect-returning selector (-[NSView bounds]) through plain objc_msgSend."
+say "On Intel (x86_64) that selector must use objc_msgSend_stret; the wrong"
+say "dispatch crashes in objc_msgSend. The path is only reached on the"
+say "NSWindow.contentView fallback that JBR triggers, so it is Intel + JBR only."
+say
+say "Crash logs (if any) saved under: $CACHE"
+exit $rc

--- a/repro-issue-36-macos-intel.sh
+++ b/repro-issue-36-macos-intel.sh
@@ -295,16 +295,26 @@ run_demo() {
 phase_b() {
   hdr "Phase B: end-to-end demo under JBR 25 (webview $WEBVIEW_VERSION)"
 
-  # 1. Fetch the library jar (bundles the native dylib; no other runtime deps).
-  local jar="$CACHE/webview-$WEBVIEW_VERSION.jar"
-  if [[ ! -f "$jar" ]]; then
-    local url="https://repo1.maven.org/maven2/ca/weblite/webview/$WEBVIEW_VERSION/webview-$WEBVIEW_VERSION.jar"
-    say "Downloading $url"
-    if ! curl -fL --retry 3 -o "$jar" "$url"; then
-      bad "Could not download webview-$WEBVIEW_VERSION.jar"; return 2
+  # 1. Obtain the library jar (bundles the native dylib; no other runtime deps).
+  #    Set WEBVIEW_JAR=/path/to/locally-built/webview.jar to verify a patched
+  #    build (e.g. after ./build-mac.sh && mvn -q package); otherwise the
+  #    released version is pulled from Maven Central.
+  local jar
+  if [[ -n "${WEBVIEW_JAR:-}" ]]; then
+    [[ -f "$WEBVIEW_JAR" ]] || { bad "WEBVIEW_JAR set but not found: $WEBVIEW_JAR"; return 2; }
+    jar="$WEBVIEW_JAR"
+    ok "Using local library jar (verifying patched build): $jar"
+  else
+    jar="$CACHE/webview-$WEBVIEW_VERSION.jar"
+    if [[ ! -f "$jar" ]]; then
+      local url="https://repo1.maven.org/maven2/ca/weblite/webview/$WEBVIEW_VERSION/webview-$WEBVIEW_VERSION.jar"
+      say "Downloading $url"
+      if ! curl -fL --retry 3 -o "$jar" "$url"; then
+        bad "Could not download webview-$WEBVIEW_VERSION.jar"; return 2
+      fi
     fi
+    ok "Library jar: $jar"
   fi
-  ok "Library jar: $jar"
 
   # 2. Write the exact demo from the issue.
   cat > "$WORK/Main.java" <<'JAVA'

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -508,6 +508,33 @@ generated_at: 2026-05-16T07:19:13-07:00
   inside Swing requires converting the canvas's location to the
   AWT Window content-pane coordinate space and subtracting the
   window insets (`WebViewHeavyweightComponent.java:171`).
+- **ABI-correct Objective-C struct-return dispatch on macOS.**
+  The generic typed `objc_msgSend` dispatch helper used for
+  native AppKit calls (`src_c/webview_embed.cpp`) is only valid
+  for selectors whose return value comes back in registers and
+  for passing struct-by-value *arguments*. Selectors that
+  *return* a struct larger than 16 bytes — notably `NSRect` /
+  `CGRect` (32 bytes), as produced by the `-[NSView bounds]`
+  query used to position the WKWebView on the
+  `NSWindow.contentView` host path in `cocoa_set_bounds` — MUST
+  be dispatched through an architecture-correct struct-return
+  variant: `objc_msgSend_stret` on `x86_64`, and plain
+  `objc_msgSend` on `arm64` (which has no `objc_msgSend_stret`
+  and returns large structs via the `x8` register). On the
+  `x86_64` SysV ABI a large struct return is passed by a hidden
+  pointer in the first integer-argument register, so dispatching
+  such a selector through plain `objc_msgSend` shifts the
+  receiver/selector registers by one and the runtime dereferences
+  the stack return-buffer pointer as the receiver — a SIGSEGV in
+  `objc_msgSend`. This is why heavyweight embedding crashed on
+  Intel Macs (issue #36) whenever the host view resolved to
+  `NSWindow.contentView` — the path taken under the JetBrains
+  Runtime, which exposes no per-Canvas AWT `NSView`. The
+  per-Canvas AWT `NSView` path (`host_is_awt == true`) never
+  queries `bounds` and is unaffected. This is a pure
+  ABI-correctness requirement: observable geometry and
+  positioning behavior is unchanged on every platform that
+  already worked.
 - **Trade-off accepted: heavyweight popup interaction.** Because
   the WebView is a real heavyweight peer, lightweight Swing
   popups (`JComboBox` dropdowns, tooltips, menus) render BEHIND

--- a/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
+++ b/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
@@ -302,6 +302,16 @@ Files: `.github/workflows/build.yml`,
      `maven-release.yml` publishes, gated on `v*` tag pushes.
 
 ## N · Norms
+- The developer `build-*.sh` scripts must quote every shell
+  expansion that carries a filesystem path — `"${JAVA_HOME}"`
+  above all — in compiler include/library flags and anywhere
+  else a path is interpolated. JDKs are routinely installed at
+  paths containing spaces (e.g. a JetBrains Runtime bundled
+  inside `/Applications/IntelliJ IDEA CE.app/Contents/jbr/Contents/Home`);
+  an unquoted `-I${JAVA_HOME}/include` word-splits on the space
+  and the build fails with "no such file or directory: 'IDEA'".
+  Quoting keeps the scripts usable with any JDK regardless of
+  where it lives.
 - Use `NativeLoader.loadLibrary` (or rely on the static
   initializer in `WebViewNative`) — do not call
   `System.loadLibrary` or `System.load` directly from feature

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -2064,6 +2064,28 @@ static inline Ret msg(id receiver, SEL selector, Args... args) {
     return reinterpret_cast<Fn>(objc_msgSend)(receiver, selector, args...);
 }
 
+// Struct-return-safe dispatch.  msg<>() above is only valid for selectors
+// whose return value comes back in registers (and for passing struct-by-value
+// *arguments*).  Selectors that *return* a struct larger than 16 bytes --
+// notably NSRect / CGRect (32 bytes), e.g. -[NSView bounds] -- must NOT go
+// through plain objc_msgSend on x86_64: the SysV ABI passes such returns via a
+// hidden pointer in the first integer-argument register, which shifts self/cmd
+// by one slot so the runtime dereferences the stack return-buffer as the
+// receiver -- a SIGSEGV in objc_msgSend.  x86_64 must dispatch these through
+// objc_msgSend_stret; arm64 has no objc_msgSend_stret and returns large
+// structs via the x8 register, so plain objc_msgSend is correct there.  See
+// the "ABI-correct Objective-C struct-return dispatch on macOS" norm in the
+// heavyweight-embedding Canvas (issue #36).
+template <typename Ret, typename... Args>
+static inline Ret msg_stret(id receiver, SEL selector, Args... args) {
+    using Fn = Ret (*)(id, SEL, Args...);
+#if defined(__x86_64__)
+    return reinterpret_cast<Fn>(objc_msgSend_stret)(receiver, selector, args...);
+#else
+    return reinterpret_cast<Fn>(objc_msgSend)(receiver, selector, args...);
+#endif
+}
+
 static id ns_str(const char *s) {
     return msg(objc_cls("NSString"), sel("stringWithUTF8String:"), s);
 }
@@ -3885,7 +3907,7 @@ static void cocoa_set_bounds(Engine *e, int x, int y, int w, int h) {
                               CGRectMake(0, 0, fw, fh));
             return;
         }
-        CGRect b = msg<CGRect>(e->host_view, sel("bounds"));
+        CGRect b = msg_stret<CGRect>(e->host_view, sel("bounds"));
         BOOL flipped = msg<BOOL>(e->host_view, sel("isFlipped"));
         CGFloat outY = flipped
             ? fy


### PR DESCRIPTION
## Summary

Fixes a SIGSEGV crash on Intel (x86_64) macOS when using heavyweight WebView embedding with the JetBrains Runtime. The crash occurs in `cocoa_set_bounds()` when dispatching the `-[NSView bounds]` selector, which returns a 32-byte `CGRect` struct.

## Root Cause

On x86_64 macOS, the SysV ABI requires large struct returns (>16 bytes) to be dispatched through `objc_msgSend_stret()`, not plain `objc_msgSend()`. The generic `msg<>()` template always used plain `objc_msgSend()`, which caused the receiver/selector to shift by one register. The runtime then dereferenced the stack return-buffer pointer as the receiver, resulting in a SIGSEGV.

This path is only reached when `host_is_awt == false` (i.e., when the WKWebView attaches to `NSWindow.contentView` instead of a per-Canvas AWT NSView). The JetBrains Runtime does not expose an AWT-named NSView, triggering this fallback on IntelliJ + Intel Mac systems.

On Apple Silicon (arm64), there is no `objc_msgSend_stret` and large structs use the x8 register, so the same code is correct — explaining why the library worked on arm64 but crashed on Intel.

## Changes

- **src_c/webview_embed.cpp**: Added `msg_stret<>()` template that dispatches struct-returning selectors through the architecture-correct function:
  - `objc_msgSend_stret` on x86_64
  - Plain `objc_msgSend` on arm64
  - Updated `cocoa_set_bounds()` to use `msg_stret<CGRect>()` for the `-[NSView bounds]` call

- **build-mac.sh, build-linux.sh**: Fixed shell quoting of `${JAVA_HOME}` and other paths in compiler flags to support JDK installations with spaces in the path (e.g., bundled JBR inside IntelliJ.app)

- **spdd/prompt/6-*.md, spdd/prompt/8-*.md**: Documented the ABI-correctness requirement and shell quoting norm

- **repro-issue-36-macos-intel.sh**: Added comprehensive reproduction script with two phases:
  - Phase A: Micro-repro showing the ABI mismatch in isolation (compiles a ~40-line Objective-C program demonstrating the crash with plain `objc_msgSend` vs. success with `objc_msgSend_stret`)
  - Phase B: End-to-end repro using the actual library under JBR 25, with optional control run under a stock JDK to confirm the bug is JBR-specific

## Implementation Details

The `msg_stret<>()` template uses preprocessor conditionals to select the correct dispatcher at compile time, ensuring zero runtime overhead. The fix is purely ABI-correctness; observable geometry and positioning behavior is unchanged on all platforms.

https://claude.ai/code/session_011t1gVK288FPKZfzWjWqsUT