### PR TITLE
Add async JavaScript function support (Canvas 14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ dispatcher decisions and Win32 `SetFocus` calls.
 
 ## Talking to JavaScript
 
-Three methods on `WebViewComponent` (and on the standalone `WebView`)
+Four methods on `WebViewComponent` (and on the standalone `WebView`)
 cover the JS-interop surface:
 
 * **`eval(String js)`** — fire-and-forget.  Runs the snippet in the
@@ -215,9 +215,22 @@ cover the JS-interop surface:
   **use `return` to yield a value** — a bare expression is not the
   IIFE's return.
 * **`addJavascriptCallback(String name, JavascriptCallback cb)`** —
-  exposes a Java callback at `window.<name>(arg)` for the page to
-  call.  Use when the page initiates the conversation, or when a
-  long-lived JS subscription needs to push events to Java.
+  exposes a *fire-and-forget* Java callback at `window.<name>(arg)`
+  for the page to call.  The callback returns nothing to JS.  Use when
+  the page initiates the conversation, or when a long-lived JS
+  subscription needs to push events to Java.
+* **`addJavascriptFunction(String name, JavascriptFunction fn)`** —
+  exposes a *value-returning* Java function at `window.<name>(arg)`.
+  In the page it returns a Promise: `const r = await window.<name>(arg)`.
+  No JavaScript glue — the Java side is just a lambda.  The library
+  runs the (synchronous) handler on a background thread, so it can
+  block safely without freezing the UI or deadlocking the engine UI
+  thread against the EDT — the reason this exists instead of a
+  synchronous, value-returning `addJavascriptCallback`.  A
+  `CompletableFuture<String>`-returning overload
+  (`AsyncJavascriptFunction`) covers inherently-async work.  Results
+  are strings (return JSON text for structured data); a thrown
+  exception rejects the page-side Promise.
 
 ```java
 WebViewComponent wv = WebViewComponent.create();
@@ -242,6 +255,11 @@ wv.evalAsync("return missing.value;").exceptionally(t -> {
     }
     return null;
 });
+
+// Expose a value-returning Java function to the page — no JS glue.
+wv.addJavascriptFunction("reverse", (String arg) ->
+    new StringBuilder(arg).reverse().toString());
+// in the page:  const r = await window.reverse("abc");   // "cba"
 ```
 
 **Threading.**  On `WebViewComponent` (both heavyweight and lightweight)
@@ -340,6 +358,10 @@ Additional demos:
   throws and Promise rejections surfacing as
   `JavaScriptEvalException`, concurrent in-flight calls, and EDT
   delivery of continuations.
+* `demos/WebViewAsyncCallbackDemo/` — exercises
+  `addJavascriptFunction(...)`: value-returning JS→Java functions
+  (sync handlers run off-thread, async `CompletableFuture` handlers,
+  errors rejecting the page Promise) with no JavaScript glue.
 * `demos/WebViewDialogDemo/` — exercises the new
   `WebViewDialogHandler` API: default Swing dialogs
   (`alert` / `confirm` / `prompt` / file picker), a custom handler

--- a/demos/WebViewAsyncCallbackDemo/README.md
+++ b/demos/WebViewAsyncCallbackDemo/README.md
@@ -65,13 +65,19 @@ pane shows the thread hops (`bind on AppKit/native thread` →
 `worker thread` → `resolve`), which is the visible proof that the work
 never runs on, or blocks, the UI thread.
 
-> **Blank / thin strip on the left edge?** That was a sizing bug in an
-> earlier version of this demo where the WebView was the bare frame's
-> only child: on macOS the native WKWebView attaches asynchronously and
-> could be left at a near-zero frame with no later relayout to fix it.
-> The demo now hosts the WebView in a `JSplitPane` and re-asserts the
-> divider after the frame is shown, matching the other working demos. If
-> you still see it, resizing the window by a few pixels forces a repaint.
+> **Blank window / content slivered to the left edge?** This is a
+> heavyweight-component limitation, not a bug in this page (the HTML
+> renders perfectly in a normal browser). On macOS the native WKWebView
+> attaches *asynchronously*, but `WebViewHeavyweightComponent` only
+> positions it on a resize/move event and does **not** re-run its
+> `sizeNative()` when the async attach completes. The first (synchronous)
+> sizing call no-ops because the native view isn't ready yet, so a simple
+> frame that never gets a later resize leaves the WebView at a zero/stale
+> frame — hence the blank/strip, and why the symptom varies run to run.
+> This demo works around it by nudging the layout a few times in the
+> first second after the window appears. The proper fix is in the library
+> (re-size on attach completion); if you still see a blank WebView,
+> dragging the window edge a few pixels forces it to appear.
 
 Click the buttons and watch the in-page log:
 

--- a/demos/WebViewAsyncCallbackDemo/README.md
+++ b/demos/WebViewAsyncCallbackDemo/README.md
@@ -65,19 +65,16 @@ pane shows the thread hops (`bind on AppKit/native thread` →
 `worker thread` → `resolve`), which is the visible proof that the work
 never runs on, or blocks, the UI thread.
 
-> **Blank window / content slivered to the left edge?** This is a
-> heavyweight-component limitation, not a bug in this page (the HTML
-> renders perfectly in a normal browser). On macOS the native WKWebView
-> attaches *asynchronously*, but `WebViewHeavyweightComponent` only
-> positions it on a resize/move event and does **not** re-run its
-> `sizeNative()` when the async attach completes. The first (synchronous)
-> sizing call no-ops because the native view isn't ready yet, so a simple
-> frame that never gets a later resize leaves the WebView at a zero/stale
-> frame — hence the blank/strip, and why the symptom varies run to run.
-> This demo works around it by nudging the layout a few times in the
-> first second after the window appears. The proper fix is in the library
-> (re-size on attach completion); if you still see a blank WebView,
-> dragging the window edge a few pixels forces it to appear.
+> **Why a localhost HTTP server instead of a `data:` URL?** On macOS the
+> embedded engine navigates via `WKWebView`'s `loadRequest:`, which
+> **silently refuses `data:` URLs** — a long-standing WKWebView
+> restriction. The page renders fine in a normal browser but shows blank
+> in the embedded view, and no amount of resizing fixes it because the
+> content never loaded. Serving the same HTML over `http://localhost`
+> loads identically to any remote site (loopback is exempt from App
+> Transport Security, so plain HTTP is allowed). The proper library-level
+> fix is for `cocoa_navigate` to load `data:` URLs via
+> `loadHTMLString:baseURL:` instead of `loadRequest:`.
 
 Click the buttons and watch the in-page log:
 

--- a/demos/WebViewAsyncCallbackDemo/README.md
+++ b/demos/WebViewAsyncCallbackDemo/README.md
@@ -57,8 +57,23 @@ compiles this demo, and launches it.
 
 ## What you should see
 
-A window with a text field and buttons. Click them and watch the in-page
-log:
+A split window: the WebView on top (a heading, a text field pre-filled
+with `Hello, WebView`, a row of five buttons, and an in-page log box),
+and a Java-side log pane below it. Clicking a button logs the round trip
+in **both** panes — the in-page log shows the awaited result, the Java
+pane shows the thread hops (`bind on AppKit/native thread` →
+`worker thread` → `resolve`), which is the visible proof that the work
+never runs on, or blocks, the UI thread.
+
+> **Blank / thin strip on the left edge?** That was a sizing bug in an
+> earlier version of this demo where the WebView was the bare frame's
+> only child: on macOS the native WKWebView attaches asynchronously and
+> could be left at a near-zero frame with no later relayout to fix it.
+> The demo now hosts the WebView in a `JSplitPane` and re-asserts the
+> divider after the frame is shown, matching the other working demos. If
+> you still see it, resizing the window by a few pixels forces a repaint.
+
+Click the buttons and watch the in-page log:
 
 - **reverse** / **upper** — Java returns a transformed string; the
   `await`ed value appears in the log.

--- a/demos/WebViewAsyncCallbackDemo/README.md
+++ b/demos/WebViewAsyncCallbackDemo/README.md
@@ -1,0 +1,89 @@
+# WebViewAsyncCallbackDemo
+
+A runnable answer to the recurring request: *"can `addJavascriptCallback`
+return a result to JavaScript?"*
+
+A **synchronous**, value-returning binding is the wrong tool: it would
+block the engine's UI thread (AppKit main thread on macOS, the WebView2
+worker on Windows, the GTK main thread on Linux) until Java produced the
+value, and the moment the Java handler needs the Swing EDT you get a
+classic two-thread deadlock — the exact hazard
+`requirements/[User-story-4]eliminate-edt-appkit-sync-deadlock-on-macos.md`
+was written to remove.
+
+This demo shows the **deadlock-free** alternative: an asynchronous,
+**Promise-returning** call. It is the mirror image of
+`WebViewComponent.evalAsync` (Java→JS with an async result) run in the
+opposite direction (JS→Java with an async result), and it uses **only
+the existing public API** — `addJavascriptCallback`, `addOnBeforeLoad`,
+and `eval`. No library changes.
+
+## How it works
+
+```
+JS:   const r = await window.callJava('reverse', 'abc');   // r === 'cba'
+```
+
+1. A document-start shim (installed via `addOnBeforeLoad`) defines
+   `window.callJava(method, arg)`. It assigns a request id, stores the
+   Promise's `{resolve, reject}`, and posts `<id>|<method>|<arg>`
+   (base64) through a normal **void** binding, then returns the Promise.
+2. The Java callback (`__rpc_call`) receives the request on the native
+   UI thread, immediately hops **off** it onto a background worker
+   (`CompletableFuture.supplyAsync`), and runs the actual logic there —
+   so the UI thread is never held.
+3. When the work finishes, Java calls `eval("window.__rpc_resolve('…')")`
+   with the base64 result. `eval` is asynchronous and non-blocking.
+4. The shim's `__rpc_resolve` looks up the pending Promise by id and
+   settles it.
+
+Nothing ever blocks one thread waiting on the other, so there is no
+deadlock. The base64-on-a-single-string-channel convention is copied
+verbatim from `ca.weblite.webview.EvalDispatcher`, which is why the demo
+needs no JSON-parsing dependency.
+
+## Running
+
+From the repo root:
+
+```
+./run-mac-async-callback-demo.sh      # macOS (Intel or Apple Silicon)
+./run-linux-async-callback-demo.sh    # Linux (lightweight mode)
+```
+
+Override the JDK with `JAVA_HOME=/path/to/jdk ./run-mac-async-callback-demo.sh`.
+Each script builds the native lib (if stale), builds `dist/WebView.jar`,
+compiles this demo, and launches it.
+
+## What you should see
+
+A window with a text field and buttons. Click them and watch the in-page
+log:
+
+- **reverse** / **upper** — Java returns a transformed string; the
+  `await`ed value appears in the log.
+- **slowEcho (1.5s)** — Java sleeps 1.5s on the worker thread before
+  resolving. The window stays fully responsive the whole time (drag it,
+  click other buttons) — the proof that nothing is blocked. A
+  synchronous binding would freeze the UI here, or deadlock.
+- **fail (rejects)** — the Java handler throws; the Promise rejects and
+  the `.catch` fires with the message.
+- **5× concurrent** — five overlapping calls; each result returns to its
+  own caller (ids keep them from cross-talking), slow ones simply settle
+  later.
+
+## Extending to structured results
+
+The channel is string-typed for clarity. For structured data, return
+JSON from `invokeMethod(...)` on the Java side and `JSON.parse` it in the
+shim's `__rpc_resolve` (the one spot that touches the value). The
+transport (ids, base64, the resolve hop) stays identical.
+
+## Making it first-class
+
+If you want this without the boilerplate, the natural library addition is
+`addJavascriptCallbackAsync(name, Function<String, CompletableFuture<?>>)`
+— the sibling of `evalAsync`, reusing the same `EvalDispatcher`
+reserved-channel plumbing. That is a behavior change, so per `CLAUDE.md`
+it goes through `/spdd-prompt-update` + `/spdd-generate` against
+`spdd/prompt/10-…-Webview-Async-Javascript-Eval.md`, not a hand-edit.

--- a/demos/WebViewAsyncCallbackDemo/README.md
+++ b/demos/WebViewAsyncCallbackDemo/README.md
@@ -1,50 +1,49 @@
 # WebViewAsyncCallbackDemo
 
-A runnable answer to the recurring request: *"can `addJavascriptCallback`
-return a result to JavaScript?"*
+Shows `addJavascriptFunction` — the Java-friendly way to expose a
+**value-returning** function to JavaScript, with **no JavaScript glue**.
 
-A **synchronous**, value-returning binding is the wrong tool: it would
-block the engine's UI thread (AppKit main thread on macOS, the WebView2
-worker on Windows, the GTK main thread on Linux) until Java produced the
-value, and the moment the Java handler needs the Swing EDT you get a
-classic two-thread deadlock — the exact hazard
+```java
+wv.addJavascriptFunction("reverse", (String arg) ->
+    new StringBuilder(arg).reverse().toString());
+// in the page:  const r = await window.reverse("abc");   // "cba"
+```
+
+That's the whole API. The page sees `window.reverse` as a normal function
+returning a Promise; your Java lambda produces the result.
+
+## Why not a synchronous `addJavascriptCallback` that returns a value?
+
+It would block the engine UI thread (AppKit main thread on macOS, the
+WebView2 worker on Windows, the GTK main thread on Linux) until Java
+produced the value, and the moment the handler touched the Swing EDT you
+would deadlock — the hazard
 `requirements/[User-story-4]eliminate-edt-appkit-sync-deadlock-on-macos.md`
-was written to remove.
+exists to prevent. `addJavascriptFunction` is deadlock-free by
+construction: the page gets a Promise, the synchronous handler runs on a
+background thread, and the result is delivered back through a
+non-blocking `eval`.
 
-This demo shows the **deadlock-free** alternative: an asynchronous,
-**Promise-returning** call. It is the mirror image of
-`WebViewComponent.evalAsync` (Java→JS with an async result) run in the
-opposite direction (JS→Java with an async result), and it uses **only
-the existing public API** — `addJavascriptCallback`, `addOnBeforeLoad`,
-and `eval`. No library changes.
+## Two flavors
 
-## How it works
+- **Synchronous** (`JavascriptFunction`, `String run(String)`): the
+  library runs your handler on a background worker thread, so it can block
+  (DB call, file IO, `Thread.sleep`) without freezing the UI. Return value
+  resolves the Promise; throwing rejects it.
+- **Asynchronous** (`AsyncJavascriptFunction`,
+  `CompletableFuture<String> run(String)`): for work that is already a
+  future. The Promise settles when the future completes.
 
-```
-JS:   const r = await window.callJava('reverse', 'abc');   // r === 'cba'
-```
+Both are overloads of `addJavascriptFunction`. A lambda returning a
+`String` binds to the sync overload; one returning a `CompletableFuture`
+binds to the async overload. Type the lambda parameter explicitly
+(`(String arg) -> ...`) so the compiler can tell them apart; a throw-only
+lambda needs a cast (`(JavascriptFunction) (String arg) -> { throw ... }`).
 
-1. A document-start shim (installed via `addOnBeforeLoad`) defines
-   `window.callJava(method, arg)`. It assigns a request id, stores the
-   Promise's `{resolve, reject}`, and posts `<id>|<method>|<arg>`
-   (base64) through a normal **void** binding, then returns the Promise.
-2. The Java callback (`__rpc_call`) receives the request on the native
-   UI thread, immediately hops **off** it onto a background worker
-   (`CompletableFuture.supplyAsync`), and runs the actual logic there —
-   so the UI thread is never held.
-3. When the work finishes, Java calls `eval("window.__rpc_resolve('…')")`
-   with the base64 result. `eval` is asynchronous and non-blocking.
-4. The shim's `__rpc_resolve` looks up the pending Promise by id and
-   settles it.
-
-Nothing ever blocks one thread waiting on the other, so there is no
-deadlock. The base64-on-a-single-string-channel convention is copied
-verbatim from `ca.weblite.webview.EvalDispatcher`, which is why the demo
-needs no JSON-parsing dependency.
+Results are **strings** (string passthrough, like `evalAsync`). For
+structured data, return JSON text and `JSON.parse` it in the page.
 
 ## Running
-
-From the repo root:
 
 ```
 ./run-mac-async-callback-demo.sh      # macOS (Intel or Apple Silicon)
@@ -52,56 +51,25 @@ From the repo root:
 ```
 
 Override the JDK with `JAVA_HOME=/path/to/jdk ./run-mac-async-callback-demo.sh`.
-Each script builds the native lib (if stale), builds `dist/WebView.jar`,
-compiles this demo, and launches it.
 
 ## What you should see
 
-A split window: the WebView on top (a heading, a text field pre-filled
-with `Hello, WebView`, a row of five buttons, and an in-page log box),
-and a Java-side log pane below it. Clicking a button logs the round trip
-in **both** panes — the in-page log shows the awaited result, the Java
-pane shows the thread hops (`bind on AppKit/native thread` →
-`worker thread` → `resolve`), which is the visible proof that the work
-never runs on, or blocks, the UI thread.
-
-> **Why a localhost HTTP server instead of a `data:` URL?** On macOS the
-> embedded engine navigates via `WKWebView`'s `loadRequest:`, which
-> **silently refuses `data:` URLs** — a long-standing WKWebView
-> restriction. The page renders fine in a normal browser but shows blank
-> in the embedded view, and no amount of resizing fixes it because the
-> content never loaded. Serving the same HTML over `http://localhost`
-> loads identically to any remote site (loopback is exempt from App
-> Transport Security, so plain HTTP is allowed). The proper library-level
-> fix is for `cocoa_navigate` to load `data:` URLs via
-> `loadHTMLString:baseURL:` instead of `loadRequest:`.
-
+A split window: the WebView on top (input + buttons), the Java log below.
 Click the buttons and watch the in-page log:
 
-- **reverse** / **upper** — Java returns a transformed string; the
-  `await`ed value appears in the log.
-- **slowEcho (1.5s)** — Java sleeps 1.5s on the worker thread before
-  resolving. The window stays fully responsive the whole time (drag it,
-  click other buttons) — the proof that nothing is blocked. A
-  synchronous binding would freeze the UI here, or deadlock.
-- **fail (rejects)** — the Java handler throws; the Promise rejects and
-  the `.catch` fires with the message.
-- **5× concurrent** — five overlapping calls; each result returns to its
-  own caller (ids keep them from cross-talking), slow ones simply settle
-  later.
+- **reverse** / **upper** — Java returns a transformed string.
+- **slowEcho (1.5s)** — the handler sleeps 1.5s on a worker thread; the
+  window stays fully responsive (drag it during the wait). The Java log
+  shows the handler thread is `webview-fn-…`, not the EDT.
+- **fail (rejects)** — the handler throws; the Promise rejects and the
+  `.catch` fires.
+- **asyncLookup** — an `AsyncJavascriptFunction` returning a future.
+- **5× concurrent** — overlapping calls; each result returns to its own
+  caller, slow ones simply settle later.
 
-## Extending to structured results
-
-The channel is string-typed for clarity. For structured data, return
-JSON from `invokeMethod(...)` on the Java side and `JSON.parse` it in the
-shim's `__rpc_resolve` (the one spot that touches the value). The
-transport (ids, base64, the resolve hop) stays identical.
-
-## Making it first-class
-
-If you want this without the boilerplate, the natural library addition is
-`addJavascriptCallbackAsync(name, Function<String, CompletableFuture<?>>)`
-— the sibling of `evalAsync`, reusing the same `EvalDispatcher`
-reserved-channel plumbing. That is a behavior change, so per `CLAUDE.md`
-it goes through `/spdd-prompt-update` + `/spdd-generate` against
-`spdd/prompt/10-…-Webview-Async-Javascript-Eval.md`, not a hand-edit.
+> **Why a localhost HTTP server?** The embedded macOS engine navigates
+> with `WKWebView`'s `loadRequest:`, which silently refuses `data:` URLs.
+> The demo serves its HTML over `http://localhost` so it loads like any
+> remote site. (The library also handles `data:` URLs correctly now via
+> `loadHTMLString:` — this demo keeps the server so it runs identically on
+> every platform.)

--- a/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
+++ b/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
@@ -1,0 +1,297 @@
+/*
+ * MIT License
+ *
+ * Demonstrates the recommended, deadlock-free way to expose a Java
+ * function to JavaScript that *returns a result* — without a synchronous
+ * addJavascriptCallback.
+ *
+ * The page calls `await window.callJava(method, arg)` and gets a value
+ * back.  Under the hood this is the mirror image of WebViewComponent's
+ * evalAsync:
+ *
+ *   JS  --(void binding __rpc_call)-->  Java        (request, base64)
+ *   Java does its work OFF the UI thread (never blocks)
+ *   Java --(eval window.__rpc_resolve)-->  JS        (result, base64)
+ *   JS settles the Promise it handed the caller.
+ *
+ * Because nothing ever blocks one thread waiting on the other, there is
+ * no EDT <-> native-UI-thread deadlock — the hazard a synchronous,
+ * value-returning binding would reintroduce (see
+ * requirements/[User-story-4]eliminate-edt-appkit-sync-deadlock-on-macos.md).
+ *
+ * The base64 envelope and the single-string channel mirror the
+ * convention used by ca.weblite.webview.EvalDispatcher so this demo
+ * needs no JSON-parsing dependency.
+ */
+package ca.weblite.webview.demos;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import javax.swing.JFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.ToolTipManager;
+
+public class WebViewAsyncCallbackDemo {
+
+    /**
+     * Reserved-prefix note: the only real binding installed here is
+     * {@code __rpc_call}.  It does NOT start with
+     * {@link WebViewComponent#RESERVED_BINDING_PREFIX} ({@code __webview_}),
+     * so it passes the reserved-name guard.  {@code __rpc_resolve} is a
+     * page-side function the shim defines — it is invoked via {@code eval},
+     * not registered as a binding.
+     */
+    private static final String INBOUND_BINDING = "__rpc_call";
+
+    /** Background pool so Java handlers never run on the engine UI thread. */
+    private static final Executor WORKER =
+        Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "rpc-worker");
+            t.setDaemon(true);
+            return t;
+        });
+
+    public static void main(String[] args) {
+        // Heavyweight popups so any menu renders above the WebView region.
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+        EventQueue.invokeLater(WebViewAsyncCallbackDemo::run);
+    }
+
+    private static void run() {
+        WebViewComponent.Mode mode = WebViewComponent.resolveDefaultMode();
+        System.err.println("[demo] os.name=" + System.getProperty("os.name")
+            + "  resolved mode=" + mode);
+
+        final WebViewComponent wv = WebViewComponent.create();
+
+        // 1. Install the JS glue at document-start of every page.  It
+        //    defines window.callJava(method, arg) -> Promise, and the
+        //    window.__rpc_resolve(b64) sink that Java calls back into.
+        wv.addOnBeforeLoad(RPC_SHIM_JS);
+
+        // 2. Register the (void) inbound binding.  This is a STANDARD
+        //    addJavascriptCallback — the result travels back out-of-band
+        //    via eval, so the binding itself stays fire-and-forget.
+        wv.addJavascriptCallback(INBOUND_BINDING, raw -> handleCall(wv, raw));
+
+        wv.setUrl("data:text/html;charset=utf-8," + PAGE_HTML);
+
+        wv.setPreferredSize(new Dimension(820, 560));
+        JFrame frame = new JFrame("WebViewAsyncCallbackDemo");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.getContentPane().add(wv, BorderLayout.CENTER);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    /**
+     * Handle one inbound JS->Java request.  Runs on the engine's native
+     * UI thread (AppKit main thread on macOS).  We extract the request,
+     * then immediately hop OFF this thread onto {@link #WORKER} so the
+     * UI thread is never held while the "business logic" runs — this is
+     * what keeps the round trip deadlock-free.
+     */
+    private static void handleCall(WebViewComponent wv, String rawEnvelope) {
+        // The native engine hands us {"name":..,"seq":..,"args":["<b64>"]}.
+        String b64 = extractFirstArg(rawEnvelope);
+        if (b64 == null) return;
+        String rec = decodeBase64Utf8(b64);
+        if (rec == null) return;
+
+        // rec = "<id>|<method>|<rawArg>".  rawArg may itself contain '|',
+        // so split on the first two delimiters only (EvalDispatcher does
+        // the same).
+        int p1 = rec.indexOf('|');
+        if (p1 < 0) return;
+        int p2 = rec.indexOf('|', p1 + 1);
+        if (p2 < 0) return;
+        final String id = rec.substring(0, p1);
+        final String method = rec.substring(p1 + 1, p2);
+        final String arg = rec.substring(p2 + 1);
+
+        // Do the work asynchronously; resolve (or reject) when it's done.
+        CompletableFuture
+            .supplyAsync(() -> invokeMethod(method, arg), WORKER)
+            .whenComplete((result, error) -> {
+                if (error != null) {
+                    Throwable cause = error.getCause() != null
+                        ? error.getCause() : error;
+                    resolve(wv, id, false,
+                        cause.getClass().getSimpleName() + ": "
+                            + cause.getMessage());
+                } else {
+                    resolve(wv, id, true, result);
+                }
+            });
+    }
+
+    /**
+     * The actual "exposed" Java methods.  Returns a plain String; the
+     * channel is string-typed for clarity.  For structured results you
+     * would return JSON here and {@code JSON.parse} it in
+     * {@code __rpc_resolve} (the shim already isolates that one spot).
+     */
+    private static String invokeMethod(String method, String arg) {
+        switch (method) {
+            case "reverse":
+                return new StringBuilder(arg).reverse().toString();
+            case "upper":
+                return arg.toUpperCase();
+            case "slowEcho":
+                // Simulate slow work on the worker thread.  The UI stays
+                // fully responsive; a synchronous binding would freeze it
+                // (or deadlock).
+                sleep(1500);
+                return "echo after 1.5s: " + arg;
+            case "fail":
+                throw new IllegalStateException("intentional failure for: " + arg);
+            default:
+                throw new IllegalArgumentException("unknown method: " + method);
+        }
+    }
+
+    /**
+     * Settle the page-side Promise by calling window.__rpc_resolve with a
+     * base64 payload {@code "<id>|<ok>|<value>"}.  eval() is asynchronous
+     * and non-blocking, so this never waits on the page.  The base64
+     * alphabet (A-Za-z0-9+/=) is safe inside a single-quoted JS string,
+     * so no escaping is needed.
+     */
+    private static void resolve(WebViewComponent wv, String id,
+                                boolean ok, String value) {
+        String rec = id + "|" + (ok ? "1" : "0") + "|" + value;
+        String b64 = encodeBase64Utf8(rec);
+        wv.eval("window.__rpc_resolve('" + b64 + "')");
+    }
+
+    // ---- base64 helpers (mirror EvalDispatcher) ---------------------------
+
+    private static String extractFirstArg(String json) {
+        int argsIdx = json.indexOf("\"args\":[");
+        if (argsIdx < 0) return null;
+        int quoteStart = json.indexOf('"', argsIdx + 8);
+        if (quoteStart < 0) return null;
+        int quoteEnd = json.indexOf('"', quoteStart + 1);
+        if (quoteEnd < 0) return null;
+        return json.substring(quoteStart + 1, quoteEnd);
+    }
+
+    private static String decodeBase64Utf8(String b64) {
+        try {
+            return new String(Base64.getDecoder().decode(b64), "UTF-8");
+        } catch (IllegalArgumentException | UnsupportedEncodingException e) {
+            return null;
+        }
+    }
+
+    private static String encodeBase64Utf8(String s) {
+        try {
+            return Base64.getEncoder().encodeToString(s.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            return "";
+        }
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    // ---- page assets ------------------------------------------------------
+
+    /**
+     * Document-start shim.  Defines window.callJava(method, arg) returning
+     * a Promise, plus the window.__rpc_resolve(b64) sink Java calls back
+     * into.  Idempotency-guarded so repeated navigations are a no-op.
+     */
+    private static final String RPC_SHIM_JS =
+        "(function(){"
+      + "if(window.__rpcInstalled)return; window.__rpcInstalled=true;"
+      + "var pending={}, seq=0;"
+      + "function enc(s){return btoa(unescape(encodeURIComponent(s)));}"
+      + "function dec(s){return decodeURIComponent(escape(atob(s)));}"
+      // The async, value-returning function page authors call:
+      + "window.callJava=function(method,arg){"
+      + "  var id=++seq;"
+      + "  return new Promise(function(resolve,reject){"
+      + "    pending[id]={resolve:resolve,reject:reject};"
+      + "    var rec=id+'|'+method+'|'+(arg==null?'':String(arg));"
+      + "    window." + INBOUND_BINDING + "(enc(rec));"
+      + "  });"
+      + "};"
+      // Java settles the Promise through here:
+      + "window.__rpc_resolve=function(b64){"
+      + "  var rec=dec(b64);"
+      + "  var p1=rec.indexOf('|'); if(p1<0)return;"
+      + "  var p2=rec.indexOf('|',p1+1); if(p2<0)return;"
+      + "  var id=rec.substring(0,p1);"
+      + "  var ok=rec.substring(p1+1,p2);"
+      + "  var val=rec.substring(p2+1);"
+      + "  var e=pending[id]; if(!e)return; delete pending[id];"
+      + "  if(ok==='1') e.resolve(val); else e.reject(new Error(val));"
+      + "};"
+      + "})();";
+
+    private static final String PAGE_HTML =
+        "<!doctype html><html><head><meta charset='utf-8'>"
+      + "<title>async callback demo</title><style>"
+      + "  body{font:14px/1.5 system-ui,sans-serif;padding:1.2em;"
+      + "    max-width:46em;margin:0 auto;}"
+      + "  h1{font-size:1.2em;} input{font:inherit;padding:.3em .4em;width:18em;}"
+      + "  button{font:inherit;padding:.3em .7em;margin:.1em;cursor:pointer;}"
+      + "  #log{margin-top:1em;border:1px solid #ccc;border-radius:.3em;"
+      + "    padding:.6em;height:14em;overflow:auto;background:#fafafa;"
+      + "    font:12px/1.4 ui-monospace,Menlo,Consolas,monospace;white-space:pre-wrap;}"
+      + "  .spin{color:#c60;}"
+      + "</style></head><body>"
+      + "<h1>window.callJava(method, arg) &rarr; Promise</h1>"
+      + "<p>Each button does <code>const r = await window.callJava(...)</code>."
+      + " Java computes the result on a background thread and resolves the"
+      + " Promise — the UI never blocks.</p>"
+      + "<p><input id='in' value='Hello, WebView'/></p>"
+      + "<p>"
+      + "  <button onclick=\"call('reverse')\">reverse</button>"
+      + "  <button onclick=\"call('upper')\">upper</button>"
+      + "  <button onclick=\"call('slowEcho')\">slowEcho (1.5s)</button>"
+      + "  <button onclick=\"call('fail')\">fail (rejects)</button>"
+      + "  <button onclick=\"stress()\">5&times; concurrent</button>"
+      + "</p>"
+      + "<div id='log'></div>"
+      + "<script>"
+      + "function log(s){var d=document.getElementById('log');"
+      + "  d.textContent+=s+'\\n'; d.scrollTop=d.scrollHeight;}"
+      + "function call(method){"
+      + "  var arg=document.getElementById('in').value;"
+      + "  var t0=performance.now();"
+      + "  log('-> '+method+'('+JSON.stringify(arg)+')');"
+      + "  window.callJava(method,arg).then(function(r){"
+      + "    log('   <- '+JSON.stringify(r)+'  ('+Math.round(performance.now()-t0)+' ms)');"
+      + "  }).catch(function(e){"
+      + "    log('   x rejected: '+e.message+'  ('+Math.round(performance.now()-t0)+' ms)');"
+      + "  });"
+      + "}"
+      // Fire several at once to show concurrency + that results match
+      // their own request (slow ones resolve later, none cross-talk).
+      + "function stress(){"
+      + "  for(var i=1;i<=5;i++){(function(n){"
+      + "    window.callJava(n%2?'slowEcho':'upper','req#'+n).then(function(r){"
+      + "      log('   [concurrent] req#'+n+' <- '+JSON.stringify(r));"
+      + "    });"
+      + "  })(i);}"
+      + "  log('-> fired 5 concurrent calls; UI stays responsive');"
+      + "}"
+      + "</script></body></html>";
+}

--- a/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
+++ b/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
@@ -122,10 +122,30 @@ public class WebViewAsyncCallbackDemo {
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
 
-        // Re-assert the divider once the frame is realized; the resulting
-        // canvas resize re-runs the heavyweight peer's sizeNative() after
-        // the macOS async attach has had a chance to complete.
-        EventQueue.invokeLater(() -> split.setDividerLocation(0.72));
+        // Workaround for a heavyweight-component limitation: on macOS the
+        // native WKWebView attaches ASYNCHRONOUSLY, but
+        // WebViewHeavyweightComponent only positions it on a resize/move
+        // event -- it does not re-run sizeNative() when the async attach
+        // completes.  The synchronous sizeNative() at first paint therefore
+        // no-ops (the native view isn't ready yet), and a simple frame may
+        // never get a later resize, leaving the WebView at a zero/stale
+        // frame (blank).  Nudge the layout a few times across the first
+        // second so at least one resize lands after the attach resolves.
+        // The real fix belongs in the library (re-size on attach
+        // completion); see this demo's README.
+        final int[] ticks = {0};
+        final javax.swing.Timer nudge = new javax.swing.Timer(250, null);
+        nudge.addActionListener(ev -> {
+            split.setDividerLocation(0.72);
+            Dimension sz = frame.getSize();
+            // Net-zero jiggle: a real size delta is what fires the
+            // canvas's componentResized -> sizeNative path.
+            frame.setSize(sz.width, sz.height + (ticks[0] % 2 == 0 ? 1 : -1));
+            if (++ticks[0] >= 4) nudge.stop();
+        });
+        nudge.setInitialDelay(200);
+        nudge.setRepeats(true);
+        nudge.start();
     }
 
     /**

--- a/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
+++ b/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
@@ -30,13 +30,19 @@ import ca.weblite.webview.swing.WebViewComponent;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.EventQueue;
+import java.awt.Font;
 import java.io.UnsupportedEncodingException;
 import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 import javax.swing.JFrame;
 import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 
 public class WebViewAsyncCallbackDemo {
@@ -73,6 +79,17 @@ public class WebViewAsyncCallbackDemo {
 
         final WebViewComponent wv = WebViewComponent.create();
 
+        // Java-side log.  The page has its own log, but this one proves the
+        // threading on the Java side: the inbound call lands on the native
+        // UI thread, the work runs on a worker thread, and nothing blocks.
+        final JTextArea javaLog = new JTextArea(8, 80);
+        javaLog.setEditable(false);
+        javaLog.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+        final Consumer<String> log = msg -> SwingUtilities.invokeLater(() -> {
+            javaLog.append(msg + "\n");
+            javaLog.setCaretPosition(javaLog.getDocument().getLength());
+        });
+
         // 1. Install the JS glue at document-start of every page.  It
         //    defines window.callJava(method, arg) -> Promise, and the
         //    window.__rpc_resolve(b64) sink that Java calls back into.
@@ -81,17 +98,34 @@ public class WebViewAsyncCallbackDemo {
         // 2. Register the (void) inbound binding.  This is a STANDARD
         //    addJavascriptCallback — the result travels back out-of-band
         //    via eval, so the binding itself stays fire-and-forget.
-        wv.addJavascriptCallback(INBOUND_BINDING, raw -> handleCall(wv, raw));
+        wv.addJavascriptCallback(INBOUND_BINDING, raw -> handleCall(wv, raw, log));
 
         wv.setUrl("data:text/html;charset=utf-8," + PAGE_HTML);
 
-        wv.setPreferredSize(new Dimension(820, 560));
+        // Embed the WebView in a split pane with the Java log below.  This
+        // matches the layout of the other working demos: a heavyweight
+        // native WebView that is the *sole* child of a bare frame can be
+        // left at a near-zero native frame because its async attach (on
+        // macOS) completes with no subsequent relayout to re-size it.
+        // Living inside a split pane guarantees a post-show relayout, and
+        // the explicit setDividerLocation below forces one more after the
+        // frame is realized.
+        wv.setPreferredSize(new Dimension(900, 540));
+        final JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT,
+            wv, new JScrollPane(javaLog));
+        split.setResizeWeight(0.72);
+
         JFrame frame = new JFrame("WebViewAsyncCallbackDemo");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        frame.getContentPane().add(wv, BorderLayout.CENTER);
+        frame.getContentPane().add(split, BorderLayout.CENTER);
         frame.pack();
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
+
+        // Re-assert the divider once the frame is realized; the resulting
+        // canvas resize re-runs the heavyweight peer's sizeNative() after
+        // the macOS async attach has had a chance to complete.
+        EventQueue.invokeLater(() -> split.setDividerLocation(0.72));
     }
 
     /**
@@ -101,7 +135,8 @@ public class WebViewAsyncCallbackDemo {
      * UI thread is never held while the "business logic" runs — this is
      * what keeps the round trip deadlock-free.
      */
-    private static void handleCall(WebViewComponent wv, String rawEnvelope) {
+    private static void handleCall(WebViewComponent wv, String rawEnvelope,
+                                   Consumer<String> log) {
         // The native engine hands us {"name":..,"seq":..,"args":["<b64>"]}.
         String b64 = extractFirstArg(rawEnvelope);
         if (b64 == null) return;
@@ -119,17 +154,27 @@ public class WebViewAsyncCallbackDemo {
         final String method = rec.substring(p1 + 1, p2);
         final String arg = rec.substring(p2 + 1);
 
+        log.accept("<- " + method + "(\"" + arg + "\")  [bind on "
+            + Thread.currentThread().getName() + "]");
+
         // Do the work asynchronously; resolve (or reject) when it's done.
         CompletableFuture
-            .supplyAsync(() -> invokeMethod(method, arg), WORKER)
+            .supplyAsync(() -> {
+                log.accept("   computing #" + id + " [worker "
+                    + Thread.currentThread().getName() + "]");
+                return invokeMethod(method, arg);
+            }, WORKER)
             .whenComplete((result, error) -> {
                 if (error != null) {
                     Throwable cause = error.getCause() != null
                         ? error.getCause() : error;
+                    log.accept("-> reject #" + id + ": "
+                        + cause.getClass().getSimpleName());
                     resolve(wv, id, false,
                         cause.getClass().getSimpleName() + ": "
                             + cause.getMessage());
                 } else {
+                    log.accept("-> resolve #" + id + " = \"" + result + "\"");
                     resolve(wv, id, true, result);
                 }
             });

--- a/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
+++ b/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
@@ -1,30 +1,29 @@
 /*
  * MIT License
  *
- * Demonstrates the recommended, deadlock-free way to expose a Java
- * function to JavaScript that *returns a result* — without a synchronous
- * addJavascriptCallback.
+ * Demonstrates addJavascriptFunction: the Java-friendly way to expose a
+ * value-returning function to JavaScript, with NO JavaScript glue.
  *
- * The page calls `await window.callJava(method, arg)` and gets a value
- * back.  Under the hood this is the mirror image of WebViewComponent's
- * evalAsync:
+ * The page calls `const r = await window.<name>(arg)` and gets a result
+ * back. On the Java side you just register a lambda:
  *
- *   JS  --(void binding __rpc_call)-->  Java        (request, base64)
- *   Java does its work OFF the UI thread (never blocks)
- *   Java --(eval window.__rpc_resolve)-->  JS        (result, base64)
- *   JS settles the Promise it handed the caller.
+ *     wv.addJavascriptFunction("reverse", arg -> reverse(arg));
  *
- * Because nothing ever blocks one thread waiting on the other, there is
- * no EDT <-> native-UI-thread deadlock — the hazard a synchronous,
- * value-returning binding would reintroduce (see
+ * The library runs the (synchronous) handler on a background thread, so a
+ * slow handler never blocks the UI or deadlocks the engine UI thread
+ * against the Swing EDT -- the hazard a synchronous, value-returning
+ * addJavascriptCallback would reintroduce (see
  * requirements/[User-story-4]eliminate-edt-appkit-sync-deadlock-on-macos.md).
+ * For inherently-async work, register an AsyncJavascriptFunction returning
+ * a CompletableFuture.
  *
- * The base64 envelope and the single-string channel mirror the
- * convention used by ca.weblite.webview.EvalDispatcher so this demo
- * needs no JSON-parsing dependency.
+ * The page is served over a localhost HTTP server because the embedded
+ * macOS engine navigates with WKWebView's loadRequest:, which refuses
+ * data: URLs.
  */
 package ca.weblite.webview.demos;
 
+import ca.weblite.webview.JavascriptFunction;
 import ca.weblite.webview.swing.WebViewComponent;
 
 import com.sun.net.httpserver.HttpServer;
@@ -35,12 +34,9 @@ import java.awt.EventQueue;
 import java.awt.Font;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import javax.swing.JFrame;
@@ -53,26 +49,7 @@ import javax.swing.ToolTipManager;
 
 public class WebViewAsyncCallbackDemo {
 
-    /**
-     * Reserved-prefix note: the only real binding installed here is
-     * {@code __rpc_call}.  It does NOT start with
-     * {@link WebViewComponent#RESERVED_BINDING_PREFIX} ({@code __webview_}),
-     * so it passes the reserved-name guard.  {@code __rpc_resolve} is a
-     * page-side function the shim defines — it is invoked via {@code eval},
-     * not registered as a binding.
-     */
-    private static final String INBOUND_BINDING = "__rpc_call";
-
-    /** Background pool so Java handlers never run on the engine UI thread. */
-    private static final Executor WORKER =
-        Executors.newCachedThreadPool(r -> {
-            Thread t = new Thread(r, "rpc-worker");
-            t.setDaemon(true);
-            return t;
-        });
-
     public static void main(String[] args) {
-        // Heavyweight popups so any menu renders above the WebView region.
         JPopupMenu.setDefaultLightWeightPopupEnabled(false);
         ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
         EventQueue.invokeLater(WebViewAsyncCallbackDemo::run);
@@ -85,9 +62,8 @@ public class WebViewAsyncCallbackDemo {
 
         final WebViewComponent wv = WebViewComponent.create();
 
-        // Java-side log.  The page has its own log, but this one proves the
-        // threading on the Java side: the inbound call lands on the native
-        // UI thread, the work runs on a worker thread, and nothing blocks.
+        // Java-side log: shows that the synchronous handlers run on a
+        // background thread (never the EDT / engine UI thread).
         final JTextArea javaLog = new JTextArea(8, 80);
         javaLog.setEditable(false);
         javaLog.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
@@ -96,29 +72,48 @@ public class WebViewAsyncCallbackDemo {
             javaLog.setCaretPosition(javaLog.getDocument().getLength());
         });
 
-        // 1. Install the JS glue at document-start of every page.  It
-        //    defines window.callJava(method, arg) -> Promise, and the
-        //    window.__rpc_resolve(b64) sink that Java calls back into.
-        wv.addOnBeforeLoad(RPC_SHIM_JS);
+        // ---- The whole API surface: register Java functions, no JS glue. ----
 
-        // 2. Register the (void) inbound binding.  This is a STANDARD
-        //    addJavascriptCallback — the result travels back out-of-band
-        //    via eval, so the binding itself stays fire-and-forget.
-        wv.addJavascriptCallback(INBOUND_BINDING, raw -> handleCall(wv, raw, log));
+        // Synchronous handlers. The library runs each on a worker thread and
+        // resolves the page Promise with the returned String.  (Explicit
+        // (String arg) typing disambiguates the sync vs async overload.)
+        wv.addJavascriptFunction("reverse", (String arg) -> {
+            log.accept("reverse(\"" + arg + "\")  [" + Thread.currentThread().getName() + "]");
+            return new StringBuilder(arg).reverse().toString();
+        });
+        wv.addJavascriptFunction("upper", (String arg) -> {
+            log.accept("upper(\"" + arg + "\")  [" + Thread.currentThread().getName() + "]");
+            return arg.toUpperCase();
+        });
+        // Slow handler: sleeps 1.5s. The UI stays fully responsive because the
+        // library ran it off the UI thread -- a synchronous callback would
+        // freeze the window here.
+        wv.addJavascriptFunction("slowEcho", (String arg) -> {
+            log.accept("slowEcho(\"" + arg + "\") sleeping 1.5s  ["
+                + Thread.currentThread().getName() + "]");
+            Thread.sleep(1500);
+            return "echo after 1.5s: " + arg;
+        });
+        // Throwing a checked or unchecked exception rejects the page Promise.
+        // (A throw-only lambda fits both overloads, so cast to disambiguate.)
+        wv.addJavascriptFunction("fail", (JavascriptFunction) (String arg) -> {
+            throw new IllegalStateException("intentional failure for: " + arg);
+        });
+        // Asynchronous handler: returns a CompletableFuture; the page Promise
+        // settles when the future completes.
+        wv.addJavascriptFunction("asyncLookup", (String arg) ->
+            CompletableFuture.supplyAsync(() -> {
+                try { Thread.sleep(800); } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return "async result for \"" + arg + "\"";
+            }));
 
-        // Serve the page over a localhost HTTP server instead of a data:
-        // URL.  The embedded macOS engine navigates via WKWebView's
-        // loadRequest:, which silently refuses data: URLs (a long-standing
-        // WKWebView restriction) -- the page would load fine in a normal
-        // browser but show blank in the embedded view.  An http://localhost
-        // URL loads identically to any remote site (loopback is exempt from
-        // App Transport Security, so plain HTTP is fine).
         int port = startPageServer();
         wv.setUrl("http://localhost:" + port + "/");
 
-        // Embed the WebView in a split pane with the Java log below.
         wv.setPreferredSize(new Dimension(900, 540));
-        final JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT,
+        JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT,
             wv, new JScrollPane(javaLog));
         split.setResizeWeight(0.72);
 
@@ -131,9 +126,7 @@ public class WebViewAsyncCallbackDemo {
     }
 
     /**
-     * Start a tiny localhost HTTP server that serves {@link #PAGE_HTML} at
-     * {@code /}.  Returns the chosen ephemeral port.  Bound to the loopback
-     * interface only; daemon-threaded so it never blocks JVM exit.
+     * Start a loopback HTTP server serving {@link #PAGE_HTML} at {@code /}.
      */
     private static int startPageServer() {
         try {
@@ -148,12 +141,11 @@ public class WebViewAsyncCallbackDemo {
                     os.write(body);
                 }
             });
-            Executor pool = Executors.newCachedThreadPool(r -> {
+            server.setExecutor(Executors.newCachedThreadPool(r -> {
                 Thread t = new Thread(r, "page-http");
                 t.setDaemon(true);
                 return t;
-            });
-            server.setExecutor(pool);
+            }));
             server.start();
             return server.getAddress().getPort();
         } catch (IOException e) {
@@ -161,211 +153,47 @@ public class WebViewAsyncCallbackDemo {
         }
     }
 
-    /**
-     * Handle one inbound JS->Java request.  Runs on the engine's native
-     * UI thread (AppKit main thread on macOS).  We extract the request,
-     * then immediately hop OFF this thread onto {@link #WORKER} so the
-     * UI thread is never held while the "business logic" runs — this is
-     * what keeps the round trip deadlock-free.
-     */
-    private static void handleCall(WebViewComponent wv, String rawEnvelope,
-                                   Consumer<String> log) {
-        // The native engine hands us {"name":..,"seq":..,"args":["<b64>"]}.
-        String b64 = extractFirstArg(rawEnvelope);
-        if (b64 == null) return;
-        String rec = decodeBase64Utf8(b64);
-        if (rec == null) return;
-
-        // rec = "<id>|<method>|<rawArg>".  rawArg may itself contain '|',
-        // so split on the first two delimiters only (EvalDispatcher does
-        // the same).
-        int p1 = rec.indexOf('|');
-        if (p1 < 0) return;
-        int p2 = rec.indexOf('|', p1 + 1);
-        if (p2 < 0) return;
-        final String id = rec.substring(0, p1);
-        final String method = rec.substring(p1 + 1, p2);
-        final String arg = rec.substring(p2 + 1);
-
-        log.accept("<- " + method + "(\"" + arg + "\")  [bind on "
-            + Thread.currentThread().getName() + "]");
-
-        // Do the work asynchronously; resolve (or reject) when it's done.
-        CompletableFuture
-            .supplyAsync(() -> {
-                log.accept("   computing #" + id + " [worker "
-                    + Thread.currentThread().getName() + "]");
-                return invokeMethod(method, arg);
-            }, WORKER)
-            .whenComplete((result, error) -> {
-                if (error != null) {
-                    Throwable cause = error.getCause() != null
-                        ? error.getCause() : error;
-                    log.accept("-> reject #" + id + ": "
-                        + cause.getClass().getSimpleName());
-                    resolve(wv, id, false,
-                        cause.getClass().getSimpleName() + ": "
-                            + cause.getMessage());
-                } else {
-                    log.accept("-> resolve #" + id + " = \"" + result + "\"");
-                    resolve(wv, id, true, result);
-                }
-            });
-    }
-
-    /**
-     * The actual "exposed" Java methods.  Returns a plain String; the
-     * channel is string-typed for clarity.  For structured results you
-     * would return JSON here and {@code JSON.parse} it in
-     * {@code __rpc_resolve} (the shim already isolates that one spot).
-     */
-    private static String invokeMethod(String method, String arg) {
-        switch (method) {
-            case "reverse":
-                return new StringBuilder(arg).reverse().toString();
-            case "upper":
-                return arg.toUpperCase();
-            case "slowEcho":
-                // Simulate slow work on the worker thread.  The UI stays
-                // fully responsive; a synchronous binding would freeze it
-                // (or deadlock).
-                sleep(1500);
-                return "echo after 1.5s: " + arg;
-            case "fail":
-                throw new IllegalStateException("intentional failure for: " + arg);
-            default:
-                throw new IllegalArgumentException("unknown method: " + method);
-        }
-    }
-
-    /**
-     * Settle the page-side Promise by calling window.__rpc_resolve with a
-     * base64 payload {@code "<id>|<ok>|<value>"}.  eval() is asynchronous
-     * and non-blocking, so this never waits on the page.  The base64
-     * alphabet (A-Za-z0-9+/=) is safe inside a single-quoted JS string,
-     * so no escaping is needed.
-     */
-    private static void resolve(WebViewComponent wv, String id,
-                                boolean ok, String value) {
-        String rec = id + "|" + (ok ? "1" : "0") + "|" + value;
-        String b64 = encodeBase64Utf8(rec);
-        wv.eval("window.__rpc_resolve('" + b64 + "')");
-    }
-
-    // ---- base64 helpers (mirror EvalDispatcher) ---------------------------
-
-    private static String extractFirstArg(String json) {
-        int argsIdx = json.indexOf("\"args\":[");
-        if (argsIdx < 0) return null;
-        int quoteStart = json.indexOf('"', argsIdx + 8);
-        if (quoteStart < 0) return null;
-        int quoteEnd = json.indexOf('"', quoteStart + 1);
-        if (quoteEnd < 0) return null;
-        return json.substring(quoteStart + 1, quoteEnd);
-    }
-
-    private static String decodeBase64Utf8(String b64) {
-        try {
-            return new String(Base64.getDecoder().decode(b64), "UTF-8");
-        } catch (IllegalArgumentException | UnsupportedEncodingException e) {
-            return null;
-        }
-    }
-
-    private static String encodeBase64Utf8(String s) {
-        try {
-            return Base64.getEncoder().encodeToString(s.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            return "";
-        }
-    }
-
-    private static void sleep(long ms) {
-        try {
-            Thread.sleep(ms);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    // ---- page assets ------------------------------------------------------
-
-    /**
-     * Document-start shim.  Defines window.callJava(method, arg) returning
-     * a Promise, plus the window.__rpc_resolve(b64) sink Java calls back
-     * into.  Idempotency-guarded so repeated navigations are a no-op.
-     */
-    private static final String RPC_SHIM_JS =
-        "(function(){"
-      + "if(window.__rpcInstalled)return; window.__rpcInstalled=true;"
-      + "var pending={}, seq=0;"
-      + "function enc(s){return btoa(unescape(encodeURIComponent(s)));}"
-      + "function dec(s){return decodeURIComponent(escape(atob(s)));}"
-      // The async, value-returning function page authors call:
-      + "window.callJava=function(method,arg){"
-      + "  var id=++seq;"
-      + "  return new Promise(function(resolve,reject){"
-      + "    pending[id]={resolve:resolve,reject:reject};"
-      + "    var rec=id+'|'+method+'|'+(arg==null?'':String(arg));"
-      + "    window." + INBOUND_BINDING + "(enc(rec));"
-      + "  });"
-      + "};"
-      // Java settles the Promise through here:
-      + "window.__rpc_resolve=function(b64){"
-      + "  var rec=dec(b64);"
-      + "  var p1=rec.indexOf('|'); if(p1<0)return;"
-      + "  var p2=rec.indexOf('|',p1+1); if(p2<0)return;"
-      + "  var id=rec.substring(0,p1);"
-      + "  var ok=rec.substring(p1+1,p2);"
-      + "  var val=rec.substring(p2+1);"
-      + "  var e=pending[id]; if(!e)return; delete pending[id];"
-      + "  if(ok==='1') e.resolve(val); else e.reject(new Error(val));"
-      + "};"
-      + "})();";
-
     private static final String PAGE_HTML =
         "<!doctype html><html><head><meta charset='utf-8'>"
-      + "<title>async callback demo</title><style>"
+      + "<title>addJavascriptFunction demo</title><style>"
       + "  body{font:14px/1.5 system-ui,sans-serif;padding:1.2em;"
       + "    max-width:46em;margin:0 auto;}"
       + "  h1{font-size:1.2em;} input{font:inherit;padding:.3em .4em;width:18em;}"
       + "  button{font:inherit;padding:.3em .7em;margin:.1em;cursor:pointer;}"
       + "  #log{margin-top:1em;border:1px solid #ccc;border-radius:.3em;"
-      + "    padding:.6em;height:14em;overflow:auto;background:#fafafa;"
+      + "    padding:.6em;height:13em;overflow:auto;background:#fafafa;"
       + "    font:12px/1.4 ui-monospace,Menlo,Consolas,monospace;white-space:pre-wrap;}"
-      + "  .spin{color:#c60;}"
       + "</style></head><body>"
-      + "<h1>window.callJava(method, arg) &rarr; Promise</h1>"
-      + "<p>Each button does <code>const r = await window.callJava(...)</code>."
-      + " Java computes the result on a background thread and resolves the"
-      + " Promise — the UI never blocks.</p>"
+      + "<h1>Java functions called from JavaScript</h1>"
+      + "<p>Each button does <code>const r = await window.&lt;name&gt;(arg)</code>."
+      + " The Java side is just <code>wv.addJavascriptFunction(\"reverse\", arg "
+      + "-&gt; ...)</code> &mdash; no JavaScript glue.</p>"
       + "<p><input id='in' value='Hello, WebView'/></p>"
       + "<p>"
       + "  <button onclick=\"call('reverse')\">reverse</button>"
       + "  <button onclick=\"call('upper')\">upper</button>"
       + "  <button onclick=\"call('slowEcho')\">slowEcho (1.5s)</button>"
       + "  <button onclick=\"call('fail')\">fail (rejects)</button>"
+      + "  <button onclick=\"call('asyncLookup')\">asyncLookup</button>"
       + "  <button onclick=\"stress()\">5&times; concurrent</button>"
       + "</p>"
       + "<div id='log'></div>"
       + "<script>"
       + "function log(s){var d=document.getElementById('log');"
       + "  d.textContent+=s+'\\n'; d.scrollTop=d.scrollHeight;}"
-      + "function call(method){"
+      + "function call(name){"
       + "  var arg=document.getElementById('in').value;"
       + "  var t0=performance.now();"
-      + "  log('-> '+method+'('+JSON.stringify(arg)+')');"
-      + "  window.callJava(method,arg).then(function(r){"
+      + "  log('-> '+name+'('+JSON.stringify(arg)+')');"
+      + "  window[name](arg).then(function(r){"
       + "    log('   <- '+JSON.stringify(r)+'  ('+Math.round(performance.now()-t0)+' ms)');"
       + "  }).catch(function(e){"
       + "    log('   x rejected: '+e.message+'  ('+Math.round(performance.now()-t0)+' ms)');"
       + "  });"
       + "}"
-      // Fire several at once to show concurrency + that results match
-      // their own request (slow ones resolve later, none cross-talk).
       + "function stress(){"
       + "  for(var i=1;i<=5;i++){(function(n){"
-      + "    window.callJava(n%2?'slowEcho':'upper','req#'+n).then(function(r){"
+      + "    window[n%2?'slowEcho':'upper']('req#'+n).then(function(r){"
       + "      log('   [concurrent] req#'+n+' <- '+JSON.stringify(r));"
       + "    });"
       + "  })(i);}"

--- a/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
+++ b/demos/WebViewAsyncCallbackDemo/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java
@@ -27,11 +27,17 @@ package ca.weblite.webview.demos;
 
 import ca.weblite.webview.swing.WebViewComponent;
 
+import com.sun.net.httpserver.HttpServer;
+
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.Font;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -100,16 +106,17 @@ public class WebViewAsyncCallbackDemo {
         //    via eval, so the binding itself stays fire-and-forget.
         wv.addJavascriptCallback(INBOUND_BINDING, raw -> handleCall(wv, raw, log));
 
-        wv.setUrl("data:text/html;charset=utf-8," + PAGE_HTML);
+        // Serve the page over a localhost HTTP server instead of a data:
+        // URL.  The embedded macOS engine navigates via WKWebView's
+        // loadRequest:, which silently refuses data: URLs (a long-standing
+        // WKWebView restriction) -- the page would load fine in a normal
+        // browser but show blank in the embedded view.  An http://localhost
+        // URL loads identically to any remote site (loopback is exempt from
+        // App Transport Security, so plain HTTP is fine).
+        int port = startPageServer();
+        wv.setUrl("http://localhost:" + port + "/");
 
-        // Embed the WebView in a split pane with the Java log below.  This
-        // matches the layout of the other working demos: a heavyweight
-        // native WebView that is the *sole* child of a bare frame can be
-        // left at a near-zero native frame because its async attach (on
-        // macOS) completes with no subsequent relayout to re-size it.
-        // Living inside a split pane guarantees a post-show relayout, and
-        // the explicit setDividerLocation below forces one more after the
-        // frame is realized.
+        // Embed the WebView in a split pane with the Java log below.
         wv.setPreferredSize(new Dimension(900, 540));
         final JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT,
             wv, new JScrollPane(javaLog));
@@ -121,31 +128,37 @@ public class WebViewAsyncCallbackDemo {
         frame.pack();
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
+    }
 
-        // Workaround for a heavyweight-component limitation: on macOS the
-        // native WKWebView attaches ASYNCHRONOUSLY, but
-        // WebViewHeavyweightComponent only positions it on a resize/move
-        // event -- it does not re-run sizeNative() when the async attach
-        // completes.  The synchronous sizeNative() at first paint therefore
-        // no-ops (the native view isn't ready yet), and a simple frame may
-        // never get a later resize, leaving the WebView at a zero/stale
-        // frame (blank).  Nudge the layout a few times across the first
-        // second so at least one resize lands after the attach resolves.
-        // The real fix belongs in the library (re-size on attach
-        // completion); see this demo's README.
-        final int[] ticks = {0};
-        final javax.swing.Timer nudge = new javax.swing.Timer(250, null);
-        nudge.addActionListener(ev -> {
-            split.setDividerLocation(0.72);
-            Dimension sz = frame.getSize();
-            // Net-zero jiggle: a real size delta is what fires the
-            // canvas's componentResized -> sizeNative path.
-            frame.setSize(sz.width, sz.height + (ticks[0] % 2 == 0 ? 1 : -1));
-            if (++ticks[0] >= 4) nudge.stop();
-        });
-        nudge.setInitialDelay(200);
-        nudge.setRepeats(true);
-        nudge.start();
+    /**
+     * Start a tiny localhost HTTP server that serves {@link #PAGE_HTML} at
+     * {@code /}.  Returns the chosen ephemeral port.  Bound to the loopback
+     * interface only; daemon-threaded so it never blocks JVM exit.
+     */
+    private static int startPageServer() {
+        try {
+            HttpServer server = HttpServer.create(
+                new InetSocketAddress("localhost", 0), 0);
+            final byte[] body = PAGE_HTML.getBytes(StandardCharsets.UTF_8);
+            server.createContext("/", exchange -> {
+                exchange.getResponseHeaders().set(
+                    "Content-Type", "text/html; charset=utf-8");
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body);
+                }
+            });
+            Executor pool = Executors.newCachedThreadPool(r -> {
+                Thread t = new Thread(r, "page-http");
+                t.setDaemon(true);
+                return t;
+            });
+            server.setExecutor(pool);
+            server.start();
+            return server.getAddress().getPort();
+        } catch (IOException e) {
+            throw new RuntimeException("could not start page server", e);
+        }
     }
 
     /**

--- a/demos/WebViewDataUrlSmokeTest/README.md
+++ b/demos/WebViewDataUrlSmokeTest/README.md
@@ -1,0 +1,32 @@
+# WebViewDataUrlSmokeTest
+
+Verifies the macOS `data:`-URL navigation fix (`cocoa_navigate` now loads
+`data:text/html` via `WKWebView -loadHTMLString:baseURL:` instead of
+`-loadRequest:`, which silently refuses `data:` URLs).
+
+## Running
+
+```
+./run-mac-data-smoketest.sh        # macOS
+./run-linux-data-smoketest.sh      # Linux
+```
+
+## What you should see
+
+A WebView showing a colored heading **"data: URL OK — plain"**, plus four
+buttons:
+
+- **plain** — `data:text/html,<raw html>` (the case that rendered blank
+  before the fix).
+- **percent-encoded** — `data:text/html,<percent-encoded>` (exercises
+  `stringByRemovingPercentEncoding`).
+- **base64** — `data:text/html;base64,<...>` (exercises the `NSData`
+  base64 decode path).
+- **https (control)** — `https://example.com`, which always worked via
+  `loadRequest:`, as a sanity control.
+
+**Pass:** every button shows readable heading text (and the Unicode line
+`café ✅ 😀` renders, confirming UTF-8 decoding).
+
+**Fail:** a `data:` button shows a blank/white WebView while the **https**
+control still renders — that means `data:` navigation is still broken.

--- a/demos/WebViewDataUrlSmokeTest/src/ca/weblite/webview/demos/WebViewDataUrlSmokeTest.java
+++ b/demos/WebViewDataUrlSmokeTest/src/ca/weblite/webview/demos/WebViewDataUrlSmokeTest.java
@@ -1,0 +1,110 @@
+/*
+ * MIT License
+ *
+ * Smoke test for the macOS data:-URL navigation fix (cocoa_navigate ->
+ * loadHTMLString:baseURL:).  Loads data:text/html URLs through all three
+ * decode paths and lets you eyeball that each renders instead of showing
+ * a blank WKWebView.
+ *
+ * If the fix works you see the colored heading text for each variant.
+ * If data: navigation is still broken you see a blank/white WebView.
+ */
+package ca.weblite.webview.demos;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.ToolTipManager;
+
+public class WebViewDataUrlSmokeTest {
+
+    private static String html(String variant, String color) {
+        return "<!doctype html><html><head><meta charset='utf-8'></head>"
+             + "<body style='font-family:sans-serif;padding:2em'>"
+             + "<h1 style='color:" + color + "'>data: URL OK &mdash; " + variant + "</h1>"
+             + "<p>If you can read this, WKWebView loaded a <code>data:</code> "
+             + "URL via <code>loadHTMLString:</code>.</p>"
+             + "<p>Unicode check: caf&#233; &#9989; &#128512;</p>"
+             + "</body></html>";
+    }
+
+    /** data:text/html,<raw html> — exercises the no-encoding path. */
+    private static String plainUrl() {
+        return "data:text/html," + html("plain", "#0a7");
+    }
+
+    /** data:text/html,<percent-encoded> — exercises stringByRemovingPercentEncoding. */
+    private static String percentUrl() {
+        try {
+            String enc = URLEncoder.encode(html("percent-encoded", "#06c"), "UTF-8")
+                .replace("+", "%20");
+            return "data:text/html," + enc;
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** data:text/html;base64,<base64> — exercises the NSData base64 path. */
+    private static String base64Url() {
+        String b64 = Base64.getEncoder().encodeToString(
+            html("base64", "#a05").getBytes(StandardCharsets.UTF_8));
+        return "data:text/html;base64," + b64;
+    }
+
+    public static void main(String[] args) {
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+        EventQueue.invokeLater(WebViewDataUrlSmokeTest::run);
+    }
+
+    private static void run() {
+        System.err.println("[smoke] os.name=" + System.getProperty("os.name")
+            + "  mode=" + WebViewComponent.resolveDefaultMode());
+
+        final WebViewComponent wv = WebViewComponent.create();
+        wv.setPreferredSize(new Dimension(760, 420));
+        // Initial page is a plain data: URL — the case that was blank before.
+        wv.setUrl(plainUrl());
+
+        final JLabel status = new JLabel("Loaded: plain data: URL");
+        JPanel buttons = new JPanel();
+        buttons.add(mkButton("plain", wv, status, plainUrl()));
+        buttons.add(mkButton("percent-encoded", wv, status, percentUrl()));
+        buttons.add(mkButton("base64", wv, status, base64Url()));
+        buttons.add(mkButton("https (control)", wv, status, "https://example.com"));
+
+        JPanel south = new JPanel(new BorderLayout());
+        south.add(buttons, BorderLayout.CENTER);
+        south.add(status, BorderLayout.SOUTH);
+
+        JFrame frame = new JFrame("WebViewDataUrlSmokeTest");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.getContentPane().add(wv, BorderLayout.CENTER);
+        frame.getContentPane().add(south, BorderLayout.SOUTH);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static JButton mkButton(final String label, final WebViewComponent wv,
+                                    final JLabel status, final String url) {
+        JButton b = new JButton(label);
+        b.addActionListener(e -> {
+            wv.setUrl(url);
+            status.setText("Loaded: " + label + "  (" +
+                (url.length() > 60 ? url.substring(0, 60) + "..." : url) + ")");
+        });
+        return b;
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -191,8 +191,9 @@ public class Demo {
 <section id="js-interop" class="block alt-bg">
   <h2>Talking to JavaScript</h2>
   <p class="muted">
-    Three methods cover the whole interop surface &mdash;
-    fire-and-forget, round-trip-with-result, and page-initiated callbacks.
+    Four methods cover the whole interop surface &mdash; fire-and-forget,
+    round-trip-with-result, page-initiated callbacks, and value-returning
+    Java functions.
   </p>
 
   <div class="three-col">
@@ -213,10 +214,18 @@ public class Demo {
 
     <div>
       <h3><code>addJavascriptCallback(...)</code></h3>
-      <p>Exposes a Java callback at <code>window.&lt;name&gt;(arg)</code> for the page to invoke.</p>
+      <p>Exposes a fire-and-forget Java callback at <code>window.&lt;name&gt;(arg)</code> for the page to invoke.</p>
 <pre><code class="language-java">wv.addJavascriptCallback("notify", arg -&gt; {
     System.out.println("page said: " + arg);
 });</code></pre>
+    </div>
+
+    <div>
+      <h3><code>addJavascriptFunction(...)</code></h3>
+      <p>Exposes a <em>value-returning</em> Java function &mdash; the page <code>await</code>s a result. No JavaScript glue; the sync handler runs off the UI thread.</p>
+<pre><code class="language-java">wv.addJavascriptFunction("reverse", (String arg) -&gt;
+    new StringBuilder(arg).reverse().toString());
+// page:  const r = await window.reverse("abc");</code></pre>
     </div>
 
   </div>
@@ -276,6 +285,10 @@ public class Demo {
     <a class="demo-card" href="https://github.com/webliteca/swingwebview/tree/master/demos/WebViewAsyncEvalDemo" target="_blank" rel="noopener">
       <h3>Async JS eval</h3>
       <p>Primitive / object / Promise results, exceptions surfacing as <code>JavaScriptEvalException</code>, EDT continuations.</p>
+    </a>
+    <a class="demo-card" href="https://github.com/webliteca/swingwebview/tree/master/demos/WebViewAsyncCallbackDemo" target="_blank" rel="noopener">
+      <h3>JS&rarr;Java functions</h3>
+      <p>Value-returning <code>addJavascriptFunction</code>: sync handlers run off-thread, async <code>CompletableFuture</code> handlers, errors rejecting the page Promise &mdash; no JS glue.</p>
     </a>
     <a class="demo-card" href="https://github.com/webliteca/swingwebview/tree/master/demos/WebViewDialogDemo" target="_blank" rel="noopener">
       <h3>Dialog handlers</h3>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -485,7 +485,7 @@ main { padding: 24px 0 80px; }
 
 .three-col {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 20px;
   margin-top: 28px;
 }

--- a/run-linux-async-callback-demo.sh
+++ b/run-linux-async-callback-demo.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# One-shot script: build the Linux native lib, build WebView.jar, compile
+# and run the async-callback Swing demo.  No Ant required.
+#
+# Usage:    ./run-linux-async-callback-demo.sh
+# Override: JAVA_HOME=/path/to/jdk ./run-linux-async-callback-demo.sh
+#
+# Required packages:
+#   - g++, pkg-config
+#   - libgtk-3-dev
+#   - libwebkit2gtk-4.1-dev (Ubuntu 24.04+) or libwebkit2gtk-4.0-dev (older)
+#   - libx11-dev
+#   - libxt-dev   <-- pulled in because JDK 8's jawt_md.h includes
+#                     <X11/Intrinsic.h>.  JDK 9+ does not need this.
+set -e
+set -o pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if command -v javac >/dev/null 2>&1; then
+        JAVAC_PATH="$(readlink -f "$(command -v javac)" 2>/dev/null || command -v javac)"
+        JAVA_HOME="$(dirname "$(dirname "$JAVAC_PATH")")"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g. via mise / asdf:" >&2
+    echo "  mise install   # picks up .tool-versions" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Pick a WebKit pkg-config name
+# ---------------------------------------------------------------------------
+if pkg-config --exists webkit2gtk-4.1; then
+    WEBKIT_PKG=webkit2gtk-4.1
+elif pkg-config --exists webkit2gtk-4.0; then
+    WEBKIT_PKG=webkit2gtk-4.0
+else
+    echo "Neither webkit2gtk-4.1 nor webkit2gtk-4.0 was found via pkg-config." >&2
+    echo "Install one of the following with your package manager:" >&2
+    echo "  Debian/Ubuntu 24.04+:  sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev libx11-dev" >&2
+    echo "  Debian/Ubuntu older:   sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev libx11-dev" >&2
+    echo "  Fedora:                sudo dnf install gtk3-devel webkit2gtk4.1-devel libX11-devel" >&2
+    exit 1
+fi
+if ! pkg-config --exists gtk+-3.0; then
+    echo "gtk+-3.0 (libgtk-3-dev) is required." >&2
+    exit 1
+fi
+echo "Using WebKit package: $WEBKIT_PKG"
+
+# JDK 8's jawt_md.h on Linux #include's <X11/Intrinsic.h>, which is in
+# libxt-dev (Debian/Ubuntu) -- separate from libx11-dev.  Probe with the
+# preprocessor so we surface a clear message before cl/g++ buries the
+# error several screens of WebKit deprecation noise deep.
+if ! printf '#include <X11/Intrinsic.h>\nint main(){return 0;}\n' | \
+        g++ -E -x c++ - >/dev/null 2>&1; then
+    echo "" >&2
+    echo "ERROR: <X11/Intrinsic.h> not found." >&2
+    echo "" >&2
+    echo "JDK 8 on Linux pulls X11 Intrinsics in via jawt_md.h.  Install:" >&2
+    echo "  Debian/Ubuntu:  sudo apt install libxt-dev" >&2
+    echo "  Fedora:         sudo dnf install libXt-devel" >&2
+    echo "  Arch:           sudo pacman -S libxt" >&2
+    echo "" >&2
+    echo "JDK 9 and newer do not have this dependency.  If you are using" >&2
+    echo "JDK 9+ and still hit this, your headers are in an unusual spot." >&2
+    echo "" >&2
+    exit 1
+fi
+echo "Found X11 Intrinsics."
+
+# ---------------------------------------------------------------------------
+# 3. Build libwebview.so for the current arch.
+#    The directory name has to match NativeLibraryUtil.Architecture lowercased
+#    (linux_64 on x86_64, linux_arm64 on aarch64); the JVM os.arch decides
+#    which folder the runtime extractor looks in.
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    x86_64|amd64)   NATIVE_DIR=linux_64 ;;
+    aarch64|arm64)  NATIVE_DIR=linux_arm64 ;;
+    armv7l|armv7)   NATIVE_DIR=linux_arm ;;
+    i?86)           NATIVE_DIR=linux_32 ;;
+    *)              NATIVE_DIR=linux_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR (arch: $(uname -m))"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+SO="$REPO_DIR/src/$NATIVE_DIR/libwebview.so"
+
+NEED_SO=0
+if [ ! -f "$SO" ]; then
+    NEED_SO=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
+    done
+fi
+
+if [ "$NEED_SO" = "1" ]; then
+    echo "Building libwebview.so ..."
+    # libjawt is intentionally NOT linked at build time -- the Linux dynamic
+    # linker's default behaviour for shared objects is to permit undefined
+    # symbols, and webview_embed.cpp's resolve_jawt_get_awt() looks libjawt
+    # up via dlopen at first call.  WebViewNative also does an explicit
+    # System.loadLibrary("jawt") before loading this lib, so the symbol is
+    # already in-process either way.
+    g++ -fPIC -std=c++11 -Wall \
+        -DWEBVIEW_GTK=1 \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
+        -I./src_c \
+        $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp \
+        $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+        -lX11 -ldl \
+        -shared -o "$SO"
+    echo "Built $SO"
+else
+    echo "libwebview.so up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 5. Build WebView.jar -- classes + <arch>/libwebview.so at jar root.
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$SO" "$STAGE/$NATIVE_DIR/libwebview.so"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 6. Compile and run the async-callback demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewAsyncCallbackDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java"
+
+echo "Launching demo ..."
+# Force the X11 GDK backend; embedding via XReparentWindow needs a real X11
+# GdkDisplay on both sides.  The same flag is set programmatically in the
+# native code as a safety net, but exporting it here covers any GTK call
+# that happens before our pump thread initializes.
+export GDK_BACKEND=x11
+# Disable WebKitGTK's DMA-BUF renderer and sandbox.  Both have been seen
+# to silently fail in virtualized environments (Parallels ARM in
+# particular) and produce a permanently empty WebView.  Newer WebKitGTK
+# renamed the sandbox-disable env var; keep the older one set for
+# compatibility with older WebKit builds where it was named differently.
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+export WEBKIT_FORCE_SANDBOX=0
+
+# Uncomment to enable verbose paint-pipeline diagnostics inside our
+# embed code (per-frame draw / frame-clock-phase logging and widget
+# state dump after attach):
+#   export DEBUG_WEBVIEW_EMBED=1
+#
+# Uncomment the next two to also enable GTK/GDK's own verbose update +
+# event tracing.  Loud but invaluable when investigating "draw never
+# fires" symptoms:
+#   export GDK_DEBUG=frames,events
+#   export GTK_DEBUG=updates
+exec "$JAVA" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewAsyncCallbackDemo

--- a/run-linux-data-smoketest.sh
+++ b/run-linux-data-smoketest.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# One-shot script: build the Linux native lib, build WebView.jar, compile
+# and run the data: URL smoke test.  No Ant required.
+#
+# Usage:    ./run-linux-data-smoketest.sh
+# Override: JAVA_HOME=/path/to/jdk ./run-linux-data-smoketest.sh
+#
+# Required packages:
+#   - g++, pkg-config
+#   - libgtk-3-dev
+#   - libwebkit2gtk-4.1-dev (Ubuntu 24.04+) or libwebkit2gtk-4.0-dev (older)
+#   - libx11-dev
+#   - libxt-dev   <-- pulled in because JDK 8's jawt_md.h includes
+#                     <X11/Intrinsic.h>.  JDK 9+ does not need this.
+set -e
+set -o pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if command -v javac >/dev/null 2>&1; then
+        JAVAC_PATH="$(readlink -f "$(command -v javac)" 2>/dev/null || command -v javac)"
+        JAVA_HOME="$(dirname "$(dirname "$JAVAC_PATH")")"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g. via mise / asdf:" >&2
+    echo "  mise install   # picks up .tool-versions" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Pick a WebKit pkg-config name
+# ---------------------------------------------------------------------------
+if pkg-config --exists webkit2gtk-4.1; then
+    WEBKIT_PKG=webkit2gtk-4.1
+elif pkg-config --exists webkit2gtk-4.0; then
+    WEBKIT_PKG=webkit2gtk-4.0
+else
+    echo "Neither webkit2gtk-4.1 nor webkit2gtk-4.0 was found via pkg-config." >&2
+    echo "Install one of the following with your package manager:" >&2
+    echo "  Debian/Ubuntu 24.04+:  sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev libx11-dev" >&2
+    echo "  Debian/Ubuntu older:   sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev libx11-dev" >&2
+    echo "  Fedora:                sudo dnf install gtk3-devel webkit2gtk4.1-devel libX11-devel" >&2
+    exit 1
+fi
+if ! pkg-config --exists gtk+-3.0; then
+    echo "gtk+-3.0 (libgtk-3-dev) is required." >&2
+    exit 1
+fi
+echo "Using WebKit package: $WEBKIT_PKG"
+
+# JDK 8's jawt_md.h on Linux #include's <X11/Intrinsic.h>, which is in
+# libxt-dev (Debian/Ubuntu) -- separate from libx11-dev.  Probe with the
+# preprocessor so we surface a clear message before cl/g++ buries the
+# error several screens of WebKit deprecation noise deep.
+if ! printf '#include <X11/Intrinsic.h>\nint main(){return 0;}\n' | \
+        g++ -E -x c++ - >/dev/null 2>&1; then
+    echo "" >&2
+    echo "ERROR: <X11/Intrinsic.h> not found." >&2
+    echo "" >&2
+    echo "JDK 8 on Linux pulls X11 Intrinsics in via jawt_md.h.  Install:" >&2
+    echo "  Debian/Ubuntu:  sudo apt install libxt-dev" >&2
+    echo "  Fedora:         sudo dnf install libXt-devel" >&2
+    echo "  Arch:           sudo pacman -S libxt" >&2
+    echo "" >&2
+    echo "JDK 9 and newer do not have this dependency.  If you are using" >&2
+    echo "JDK 9+ and still hit this, your headers are in an unusual spot." >&2
+    echo "" >&2
+    exit 1
+fi
+echo "Found X11 Intrinsics."
+
+# ---------------------------------------------------------------------------
+# 3. Build libwebview.so for the current arch.
+#    The directory name has to match NativeLibraryUtil.Architecture lowercased
+#    (linux_64 on x86_64, linux_arm64 on aarch64); the JVM os.arch decides
+#    which folder the runtime extractor looks in.
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    x86_64|amd64)   NATIVE_DIR=linux_64 ;;
+    aarch64|arm64)  NATIVE_DIR=linux_arm64 ;;
+    armv7l|armv7)   NATIVE_DIR=linux_arm ;;
+    i?86)           NATIVE_DIR=linux_32 ;;
+    *)              NATIVE_DIR=linux_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR (arch: $(uname -m))"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+SO="$REPO_DIR/src/$NATIVE_DIR/libwebview.so"
+
+NEED_SO=0
+if [ ! -f "$SO" ]; then
+    NEED_SO=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
+    done
+fi
+
+if [ "$NEED_SO" = "1" ]; then
+    echo "Building libwebview.so ..."
+    # libjawt is intentionally NOT linked at build time -- the Linux dynamic
+    # linker's default behaviour for shared objects is to permit undefined
+    # symbols, and webview_embed.cpp's resolve_jawt_get_awt() looks libjawt
+    # up via dlopen at first call.  WebViewNative also does an explicit
+    # System.loadLibrary("jawt") before loading this lib, so the symbol is
+    # already in-process either way.
+    g++ -fPIC -std=c++11 -Wall \
+        -DWEBVIEW_GTK=1 \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
+        -I./src_c \
+        $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp \
+        $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+        -lX11 -ldl \
+        -shared -o "$SO"
+    echo "Built $SO"
+else
+    echo "libwebview.so up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 5. Build WebView.jar -- classes + <arch>/libwebview.so at jar root.
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$SO" "$STAGE/$NATIVE_DIR/libwebview.so"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 6. Compile and run the data: URL smoke test
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewDataUrlSmokeTest"
+DEMO_CLASSES="$BUILD_DIR/classes-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewDataUrlSmokeTest.java"
+
+echo "Launching demo ..."
+# Force the X11 GDK backend; embedding via XReparentWindow needs a real X11
+# GdkDisplay on both sides.  The same flag is set programmatically in the
+# native code as a safety net, but exporting it here covers any GTK call
+# that happens before our pump thread initializes.
+export GDK_BACKEND=x11
+# Disable WebKitGTK's DMA-BUF renderer and sandbox.  Both have been seen
+# to silently fail in virtualized environments (Parallels ARM in
+# particular) and produce a permanently empty WebView.  Newer WebKitGTK
+# renamed the sandbox-disable env var; keep the older one set for
+# compatibility with older WebKit builds where it was named differently.
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+export WEBKIT_FORCE_SANDBOX=0
+
+# Uncomment to enable verbose paint-pipeline diagnostics inside our
+# embed code (per-frame draw / frame-clock-phase logging and widget
+# state dump after attach):
+#   export DEBUG_WEBVIEW_EMBED=1
+#
+# Uncomment the next two to also enable GTK/GDK's own verbose update +
+# event tracing.  Loud but invaluable when investigating "draw never
+# fires" symptoms:
+#   export GDK_DEBUG=frames,events
+#   export GTK_DEBUG=updates
+exec "$JAVA" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewDataUrlSmokeTest

--- a/run-mac-async-callback-demo.sh
+++ b/run-mac-async-callback-demo.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# One-shot script: build the macOS native lib, build WebView.jar, build and run
+# the async-callback Swing demo.  No Ant required.
+#
+# Usage:    ./run-mac-async-callback-demo.sh
+# Override: JAVA_HOME=/path/to/jdk ./run-mac-async-callback-demo.sh
+#
+set -e
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if [ -x /usr/libexec/java_home ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g.:" >&2
+    echo "  brew install --cask temurin" >&2
+    echo "  export JAVA_HOME=\"\$(/usr/libexec/java_home)\"" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Build libwebview.dylib if missing or source is newer.
+#    The directory name has to match NativeLibraryUtil.Architecture lowercased
+#    (osx_64 for Intel, osx_arm64 for Apple Silicon).  The JVM os.arch value
+#    determines which folder the runtime extractor looks in.
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    arm64|aarch64) NATIVE_DIR=osx_arm64 ;;
+    x86_64)        NATIVE_DIR=osx_64 ;;
+    *)             NATIVE_DIR=osx_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+DYLIB="$REPO_DIR/src/$NATIVE_DIR/libwebview.dylib"
+NEED_DYLIB=0
+if [ ! -f "$DYLIB" ]; then
+    NEED_DYLIB=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$DYLIB" ]; then NEED_DYLIB=1; break; fi
+    done
+fi
+
+if [ "$NEED_DYLIB" = "1" ]; then
+    echo "Building libwebview.dylib (arch: $(uname -m)) ..."
+    # Note: src_c/webview.c (the upstream zserge WebView engine for the legacy
+    # `WebView` Java class) is intentionally NOT compiled here.  Its Cocoa
+    # branch in webview.h relies on the implicit variadic prototype of
+    # objc_msgSend which has been removed from the macOS SDK (Xcode 15+) and
+    # is broken on ARM64 for struct-by-value arguments anyway.  Fixing it is
+    # a separate effort.  For this demo we only need the
+    # embedded WebView entry points which live in webview_embed.cpp.
+    #
+    # libjawt lives in different places across JDK distributions
+    # (Corretto 8: $JAVA_HOME/jre/lib, JDK 9+: $JAVA_HOME/lib, Temurin: same,
+    # GraalVM: different again).  Rather than probe every layout, defer
+    # JAWT symbol resolution to runtime via -undefined dynamic_lookup: by
+    # the time this dylib is loaded the JVM has already loaded libjawt for
+    # Swing/AWT, so JAWT_GetAWT resolves naturally then.
+    c++ \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/darwin" \
+        -dynamiclib \
+        src_c/webview_embed.cpp \
+        -o "$DYLIB" \
+        -DWEBVIEW_COCOA=1 \
+        -std=c++11 \
+        -framework WebKit -framework Cocoa -framework QuartzCore \
+        -Wl,-undefined,dynamic_lookup
+    echo "Built $DYLIB"
+else
+    echo "libwebview.dylib up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Compile WebView Java sources to build/classes-webview
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" \
+    -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 4. Build WebView.jar -- bundle classes + osx_64/libwebview.dylib at the jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$DYLIB" "$STAGE/$NATIVE_DIR/libwebview.dylib"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 5. Compile and run the async-callback demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewAsyncCallbackDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" \
+    -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewAsyncCallbackDemo.java"
+
+echo "Launching demo ..."
+exec "$JAVA" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewAsyncCallbackDemo

--- a/run-mac-data-smoketest.sh
+++ b/run-mac-data-smoketest.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# One-shot script: build the macOS native lib, build WebView.jar, build and run
+# the data: URL smoke test.  No Ant required.
+#
+# Usage:    ./run-mac-data-smoketest.sh
+# Override: JAVA_HOME=/path/to/jdk ./run-mac-data-smoketest.sh
+#
+set -e
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if [ -x /usr/libexec/java_home ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g.:" >&2
+    echo "  brew install --cask temurin" >&2
+    echo "  export JAVA_HOME=\"\$(/usr/libexec/java_home)\"" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Build libwebview.dylib if missing or source is newer.
+#    The directory name has to match NativeLibraryUtil.Architecture lowercased
+#    (osx_64 for Intel, osx_arm64 for Apple Silicon).  The JVM os.arch value
+#    determines which folder the runtime extractor looks in.
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    arm64|aarch64) NATIVE_DIR=osx_arm64 ;;
+    x86_64)        NATIVE_DIR=osx_64 ;;
+    *)             NATIVE_DIR=osx_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+DYLIB="$REPO_DIR/src/$NATIVE_DIR/libwebview.dylib"
+NEED_DYLIB=0
+if [ ! -f "$DYLIB" ]; then
+    NEED_DYLIB=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$DYLIB" ]; then NEED_DYLIB=1; break; fi
+    done
+fi
+
+if [ "$NEED_DYLIB" = "1" ]; then
+    echo "Building libwebview.dylib (arch: $(uname -m)) ..."
+    # Note: src_c/webview.c (the upstream zserge WebView engine for the legacy
+    # `WebView` Java class) is intentionally NOT compiled here.  Its Cocoa
+    # branch in webview.h relies on the implicit variadic prototype of
+    # objc_msgSend which has been removed from the macOS SDK (Xcode 15+) and
+    # is broken on ARM64 for struct-by-value arguments anyway.  Fixing it is
+    # a separate effort.  For this demo we only need the
+    # embedded WebView entry points which live in webview_embed.cpp.
+    #
+    # libjawt lives in different places across JDK distributions
+    # (Corretto 8: $JAVA_HOME/jre/lib, JDK 9+: $JAVA_HOME/lib, Temurin: same,
+    # GraalVM: different again).  Rather than probe every layout, defer
+    # JAWT symbol resolution to runtime via -undefined dynamic_lookup: by
+    # the time this dylib is loaded the JVM has already loaded libjawt for
+    # Swing/AWT, so JAWT_GetAWT resolves naturally then.
+    c++ \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/darwin" \
+        -dynamiclib \
+        src_c/webview_embed.cpp \
+        -o "$DYLIB" \
+        -DWEBVIEW_COCOA=1 \
+        -std=c++11 \
+        -framework WebKit -framework Cocoa -framework QuartzCore \
+        -Wl,-undefined,dynamic_lookup
+    echo "Built $DYLIB"
+else
+    echo "libwebview.dylib up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Compile WebView Java sources to build/classes-webview
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" \
+    -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 4. Build WebView.jar -- bundle classes + osx_64/libwebview.dylib at the jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$DYLIB" "$STAGE/$NATIVE_DIR/libwebview.dylib"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 5. Compile and run the data: URL smoke test
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewDataUrlSmokeTest"
+DEMO_CLASSES="$BUILD_DIR/classes-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" \
+    -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewDataUrlSmokeTest.java"
+
+echo "Launching demo ..."
+exec "$JAVA" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewDataUrlSmokeTest

--- a/spdd/prompt/14-20260625-1405-[Feat]-Webview-Async-Javascript-Functions.md
+++ b/spdd/prompt/14-20260625-1405-[Feat]-Webview-Async-Javascript-Functions.md
@@ -1,0 +1,653 @@
+---
+generated_at: 2026-06-25T14:05:00-07:00
+---
+
+# REASONS Canvas: Value-Returning JavaScript Functions — Dispatcher and Java API
+
+## R · Requirements
+- Let Java developers expose a Java method to the page as a real,
+  value-returning JavaScript function **without writing any
+  JavaScript**. In the page the registered function appears as a
+  global that returns a Promise: `const result = await
+  window.<name>(arg)`. This is the inverse direction of the
+  future-returning eval feature ([[webview-async-javascript-eval]]):
+  there, Java calls JS and awaits a result; here, JS calls Java and
+  awaits a result.
+- Provide a per-engine fan-out hub (`FunctionDispatcher`) usable by
+  every WebView surface — standalone in-process `WebView`
+  ([[in-process-webview-java-api]]), heavyweight embedded
+  `WebViewHeavyweightComponent`
+  ([[swing-heavyweight-webview-embedding]]), and lightweight
+  `WebViewLightweightComponent`
+  ([[swing-lightweight-webview-embedding]]). The dispatcher owns the
+  `name → handler` registry, a background worker pool for synchronous
+  handlers, the canonical JS shim (`SHIM_JS`), the per-name wrapper
+  installer, the inbound-call parsing, the outbound resolve, and the
+  dispose drain.
+- Two registration overloads, both named `addJavascriptFunction`,
+  exposed on every surface (and on the abstract `WebViewComponent`):
+  - `addJavascriptFunction(String name, JavascriptFunction fn)` — the
+    handler is **synchronous** (`String run(String arg) throws
+    Exception`). The library runs it on a background worker thread so
+    a slow handler can never block, or deadlock against, the engine
+    UI thread. This is the headline API for the
+    JavaScript-allergic developer.
+  - `addJavascriptFunction(String name, AsyncJavascriptFunction fn)` —
+    the handler returns a `CompletableFuture<String>` for
+    inherently-asynchronous work. The dispatcher resolves the page
+    Promise when the future completes.
+  - Overload resolution is unambiguous because the two functional
+    interfaces have different abstract-method return types: a lambda
+    `arg -> "x"` binds to `JavascriptFunction`; a lambda
+    `arg -> someCompletableFuture` binds to `AsyncJavascriptFunction`.
+- Result encoding is **string passthrough**, consistent with
+  `evalAsync` ([[webview-async-javascript-eval]]): the handler returns
+  a `String`, and the page Promise resolves to that exact string. For
+  structured results the handler returns JSON text and the page
+  `JSON.parse`s it. No JSON-serialization dependency is added (the
+  project has none — `pom.xml`).
+- Error propagation: if a synchronous handler throws, or an
+  asynchronous handler's future completes exceptionally, the page
+  Promise **rejects** with an `Error` whose message is the Java-side
+  exception message. Successful completion **resolves** with the
+  returned string.
+- The reserved channel names MUST live under the existing
+  `RESERVED_BINDING_PREFIX = "__webview_"` so they are protected from
+  caller collision by the existing guard on
+  `WebViewComponent.addJavascriptCallback`
+  (`WebViewComponent.java:57`, enforced at
+  `WebViewHeavyweightComponent.java` and
+  `WebViewLightweightComponent.java`). Concretely: an inbound binding
+  `__webview_fn_call__` and a page-side resolver
+  `window.__webview_fn_resolve__`. In addition, the public
+  `addJavascriptFunction` MUST itself reject a `name` that starts with
+  `__webview_` (and reject a `name` that is not a valid JS identifier),
+  so a caller cannot shadow the internal channels or inject JS through
+  the per-name wrapper.
+- The implementation MUST NOT introduce a JSON-parsing dependency. Wire
+  format follows the precedent set by `EvalDispatcher`
+  (`EvalDispatcher.java`), `ConsoleDispatcher`, and
+  `WebViewMouseDispatcher`: the JS shim base64-encodes a
+  pipe-separated record before posting it through the binding, and the
+  Java side uses `indexOf`-based slicing on the known-shape native bind
+  envelope.
+- The implementation MUST NOT require new JNI entry points and MUST NOT
+  touch native code. The existing eval entry points (`webview_eval`,
+  `webview_embed_eval`, `webview_offscreen_eval`), bind entry points
+  (`webview_bind`, `webview_embed_bind`, `webview_offscreen_bind`),
+  and init entry points (`webview_init`, `webview_embed_init`,
+  `webview_offscreen_init`) are sufficient. The dispatcher delegates
+  the actual native calls to its owner via an injected sink (parallel
+  to `WebViewMouseDispatcher.FlagSink`, which already carries both
+  `eval` and `addOnBeforeLoad`) so it has no compile-time dependency on
+  any engine wrapper class.
+- The JS shim MUST be idempotent across page navigations (re-entry
+  guarded by `window.__webview_fn_installed__`, mirroring
+  `EvalDispatcher.SHIM_JS` and `ConsoleDispatcher.SHIM_JS`). Per-name
+  wrappers are (re)installed at document-start on every navigation
+  because they are registered via the `addOnBeforeLoad` sink; a
+  registration made while a page is already loaded ALSO takes effect
+  immediately on the current document via a one-shot `eval` of the same
+  wrapper.
+- The JS shim MUST be robust against user JS that mutates the resolver
+  binding: the per-call invoke helper caches a stable reference to the
+  inbound binding at install time, mirroring `EvalDispatcher`'s
+  cache-before-user-JS defense.
+- Threading / deadlock contract (the reason this feature exists rather
+  than a synchronous value-returning callback): a synchronous,
+  value-returning `addJavascriptCallback` would block the engine UI
+  thread until Java produced the value, deadlocking against the Swing
+  EDT — the precise hazard removed by
+  [[eliminate-edt-appkit-sync-deadlock-on-macos]]. This feature is
+  deadlock-free by construction: the inbound binding callback returns
+  immediately, synchronous handlers run on a background pool, and the
+  result is delivered back to the page through a non-blocking `eval`
+  (NOT `evalAsync`, and never `.get()`).
+- Definition of Done: a `FunctionDispatcherTest` JUnit test under
+  `test/` exercises name registration (sync + async), reserved-name
+  and invalid-name rejection, inbound-envelope parsing, that a
+  synchronous handler runs OFF the calling thread, async-handler
+  resolve, handler-throw → reject, malformed-payload silent drop, and
+  dispose draining — all with a mock sink so no native WebView is
+  required. Integration with the live engines is covered by the
+  consuming canvases. The `WebViewAsyncCallbackDemo` under `demos/` is
+  updated (by hand, out of scope for generation) to use
+  `addJavascriptFunction`, and the README's API/Demos section mentions
+  the new method.
+- Out of scope (explicit non-goals, owned elsewhere or deferred):
+  - The public `addJavascriptFunction(...)` methods on `WebView`.
+    Owned by [[in-process-webview-java-api]].
+  - The abstract `addJavascriptFunction(...)` on `WebViewComponent`.
+    Owned by [[swing-webview-component-mode-selection]].
+  - The concrete `addJavascriptFunction(...)` on
+    `WebViewHeavyweightComponent` and `EmbeddedWebView`. Owned by
+    [[swing-heavyweight-webview-embedding]].
+  - The concrete `addJavascriptFunction(...)` on
+    `WebViewLightweightComponent` and `OffscreenWebView`. Owned by
+    [[swing-lightweight-webview-embedding]].
+  - The per-engine registration of `FunctionDispatcher.SHIM_JS` and the
+    `__webview_fn_call__` binding inside `createPeer` / `addNotify` /
+    `WebView.show()`. Owned by the consuming canvases above. THIS
+    canvas owns `FunctionDispatcher`, `JavascriptFunction`, and
+    `AsyncJavascriptFunction` only.
+  - Multi-argument JS functions. The function takes a single string
+    argument this iteration; callers needing multiple values pack a
+    JSON string and unpack it Java-side.
+  - Typed / auto-JSON-decoded results. The page Promise resolves to a
+    `String`; callers parse it with the JSON tool of their choice.
+  - A synchronous blocking `String callSync(...)` convenience. The
+    whole point is to avoid blocking the UI thread.
+  - Aborting an in-flight Java handler when the page drops/ignores the
+    returned Promise. The handler runs to completion; its result is
+    discarded if no resolver remains.
+
+## E · Entities
+
+- **FunctionDispatcher** (new public class,
+  `src/ca/weblite/webview/FunctionDispatcher.java`). Mirrors
+  `EvalDispatcher` (`EvalDispatcher.java`) in shape and visibility,
+  with a `name → handler` registry and a worker pool instead of an
+  in-flight future map. Internal-only — the class is `public` for
+  cross-package access from `ca.weblite.webview.swing`, NOT part of
+  the supported API (Javadoc leads with the verbatim
+  `<strong>Internal:</strong> not part of the public API surface.`
+  paragraph used by `EvalDispatcher`/`ConsoleDispatcher`).
+  Invariants:
+  - `INBOUND_CHANNEL: public static final String` —
+    `"__webview_fn_call__"`. The reserved binding name the consuming
+    surface registers; JS posts `<id>|<name>|<arg>` (base64) through
+    it.
+  - `SHIM_JS: public static final String` — the canonical base shim
+    installed once per page via `addOnBeforeLoad`. Defines the b64
+    helpers, the pending-resolver map, `window.__webview_fn_invoke`,
+    and `window.__webview_fn_resolve__`. Idempotency-guarded with
+    `window.__webview_fn_installed__`. Full text in Operation 5.
+  - `handlers: ConcurrentHashMap<String, AsyncJavascriptFunction>` —
+    the registry. A synchronous `JavascriptFunction` is adapted to an
+    `AsyncJavascriptFunction` at registration time (see Approach) so
+    the inbound dispatch path is uniform. Allocated at construction;
+    never replaced; cleared on `disposeAll`.
+  - `worker: final ExecutorService` — daemon-threaded cached pool used
+    to run synchronous handlers off the engine UI thread. Created at
+    construction; shut down on `disposeAll`.
+  - `sink: final FunctionSink` — non-null; the engine-specific
+    delivery channel (eval + addOnBeforeLoad) injected by the
+    constructor. The dispatcher never touches `WebViewNative` directly.
+  - `disposeLabel: final String` — non-null; folded into messages /
+    thread names (e.g. `"EmbeddedWebView"`).
+  - `disposed: volatile boolean` — `false` initially; flipped by
+    `disposeAll()`. Subsequent `registerSync`/`registerAsync` calls
+    after the flag flips are no-ops.
+  - `NAME_PATTERN: a compiled validity check` — a registered name must
+    match `^[A-Za-z_$][A-Za-z0-9_$]*$` and must not start with
+    `__webview_`. Enforced in `registerSync`/`registerAsync`.
+
+- **FunctionDispatcher.FunctionSink** (new public nested
+  `@FunctionalInterface`-style interface — note it has TWO methods, so
+  it is NOT annotated `@FunctionalInterface`; modeled on
+  `WebViewMouseDispatcher.FlagSink` which likewise carries `eval` and
+  `addOnBeforeLoad`). Invariants:
+  - `void eval(String js)` — issue a fire-and-forget native eval of
+    the given snippet on the live engine. Used for the outbound
+    resolve and for the one-shot install of a per-name wrapper on the
+    already-loaded document. The implementation owns engine-alive
+    checks and `IllegalStateException` swallowing.
+  - `void addOnBeforeLoad(String js)` — register a document-start
+    script so per-name wrappers survive navigations. Same swallowing
+    contract.
+
+- **JavascriptFunction** (new public top-level interface,
+  `src/ca/weblite/webview/JavascriptFunction.java`).
+  `@FunctionalInterface`. Single method
+  `String run(String arg) throws Exception`. Synchronous handler; the
+  returned `String` resolves the page Promise, a thrown exception
+  rejects it. The library guarantees `run` is invoked off the engine
+  UI thread.
+
+- **AsyncJavascriptFunction** (new public top-level interface,
+  `src/ca/weblite/webview/AsyncJavascriptFunction.java`).
+  `@FunctionalInterface`. Single method
+  `CompletableFuture<String> run(String arg)`. The dispatcher resolves
+  the page Promise when the future completes normally, rejects it when
+  the future completes exceptionally. `run` is invoked on the inbound
+  binding-callback thread and MUST return promptly with a future
+  (it MUST NOT block).
+
+## A · Approach
+- **Mirror the existing dispatcher pattern.** `EvalDispatcher`,
+  `ConsoleDispatcher`, and `WebViewMouseDispatcher` define the
+  canonical shape: per-engine instance, registered eagerly at peer
+  creation, public-but-internal visibility, base64-encoded payload
+  over a reserved `__webview_*` channel, `indexOf`-based parsing on
+  the native bind envelope, sink-decoupled from the engine.
+  `FunctionDispatcher` follows the same shape; the differences are
+  (a) state is a `name → handler` registry plus a worker pool rather
+  than an in-flight future map, and (b) the matching of a call to its
+  pending resolver happens in JS (the page owns the request id), so
+  Java is essentially stateless per call beyond routing and echoing
+  the id back.
+- **Unify sync and async at registration.** `registerSync(name,
+  JavascriptFunction fn)` adapts the synchronous handler into an
+  `AsyncJavascriptFunction` by submitting `fn.run(arg)` to the worker
+  pool and returning the resulting future (a thrown checked/unchecked
+  exception completes the future exceptionally). `registerAsync(name,
+  AsyncJavascriptFunction fn)` stores the handler directly. Both store
+  into `handlers`, validate the name, and install the per-name wrapper
+  via the sink. The inbound dispatch path then deals only with
+  `AsyncJavascriptFunction`.
+- **No JNI / native changes.** Built entirely on existing primitives,
+  exactly as console capture, DOM mouse events, and async eval are:
+  `addOnBeforeLoad` installs the base shim and per-name wrappers;
+  `bind` carries the inbound channel; `eval` delivers the outbound
+  resolve. The native eval entry points are fire-and-forget
+  (`WebViewNative.java`: "Evaluation happens asynchronously … the
+  result … is ignored. Use RPC bindings if you want to receive
+  notifications"), which is why the round-trip is built in Java + JS.
+- **`FunctionSink` decouples dispatcher from engine.** The dispatcher
+  does not know whether it wraps `webview_eval`/`webview_embed_eval`/
+  `webview_offscreen_eval` (and the matching `*_init`). The consuming
+  surface supplies a sink at construction; the dispatcher trusts it to
+  do alive-checks, marshaling, and `IllegalStateException` swallowing.
+  Same role as `WebViewMouseDispatcher.FlagSink`.
+- **Registration flow** (`registerSync` / `registerAsync`):
+  1. Validate: `name` non-null, matches `NAME_PATTERN`, does not start
+     with `__webview_`; handler non-null. Violations throw
+     `IllegalArgumentException` (name) / `NullPointerException`
+     (nulls) synchronously — these are programming errors.
+  2. If `disposed`, no-op return.
+  3. Put the (adapted) handler into `handlers`.
+  4. Build the per-name wrapper JS (`wrapperFor(name)`), register it
+     via `sink.addOnBeforeLoad(wrapper)` (future navigations) AND
+     `sink.eval(wrapper)` (current document) so the function is usable
+     immediately and after reloads.
+- **Inbound dispatch flow** (`dispatch(rawJson)`):
+  1. Extract the base64 arg from the native bind envelope
+     (`extractFirstArg`, copied from `EvalDispatcher`/
+     `ConsoleDispatcher`), decode UTF-8 (`decodeBase64Utf8`, copied).
+  2. Split the record `<id>|<name>|<arg>` with two `indexOf('|')`
+     calls; the third field (`arg`) is taken verbatim and MAY contain
+     pipes.
+  3. Look up `handlers.get(name)`. If absent (unregistered or
+     post-dispose), resolve the page Promise with a rejection
+     (`<id>|0|no such function: <name>`) so the caller's `await` does
+     not hang.
+  4. Invoke `handler.run(arg)`; on the returned future register a
+     completion that calls `resolve(id, ok, payload)`:
+     - normal completion → `resolve(id, true, value)` (value may be
+       `null`; coerce to the empty string for transport).
+     - exceptional completion → `resolve(id, false, message)` where
+       message is the exception's message (or its class name when the
+       message is null).
+- **Outbound resolve** (`resolve(long id, boolean ok, String
+  payload)`): build `<id>|<okFlag>|<payload>`, base64-encode it, and
+  call `sink.eval("window.__webview_fn_resolve__('" + b64 + "')")`.
+  The base64 alphabet (`A–Za–z0–9+/=`) is safe inside a single-quoted
+  JS string, so no escaping is required. `eval` is asynchronous and
+  non-blocking — the resolve hop never waits on the page, preserving
+  the deadlock-free property.
+- **Wire-format choice: base64 + pipe-separated**, same precedent as
+  the existing dispatchers. JS uses
+  `btoa(unescape(encodeURIComponent(s)))`; Java uses
+  `Base64.getDecoder()/getEncoder()` with `new String(bytes,"UTF-8")`.
+- **Dispose ordering** (`disposeAll`):
+  1. `if (disposed) return;` then `disposed = true`.
+  2. `handlers.clear();`
+  3. `worker.shutdownNow();` — in-flight synchronous handlers are
+     interrupted; their results, if any, are dropped (no resolver
+     remains after native teardown). The dispatcher does NOT attempt
+     to unbind the inbound channel — native destroy invalidates it.
+
+## S · Structure
+
+### Inheritance Relationships
+1. `FunctionDispatcher` is a concrete `public final` class extending
+   `Object`, implementing no interfaces. Symmetric with
+   `EvalDispatcher` (`EvalDispatcher.java`).
+2. `FunctionDispatcher.FunctionSink` is a `public static` nested
+   interface with two methods (`eval`, `addOnBeforeLoad`).
+   Implementations are anonymous inner classes / lambdas-with-two-
+   methods... — since it has two abstract methods it is implemented as
+   an anonymous inner class in the consuming wrappers (cannot be a
+   single lambda). Modeled on `WebViewMouseDispatcher.FlagSink`.
+3. `JavascriptFunction` and `AsyncJavascriptFunction` are
+   `public @FunctionalInterface` top-level interfaces extending
+   nothing. No named implementations exist in this canvas (callers
+   pass lambdas / method references).
+
+### Dependencies
+1. `FunctionDispatcher` depends on:
+   - `java.util.concurrent.CompletableFuture` (Java 8).
+   - `java.util.concurrent.ConcurrentHashMap` — the registry.
+   - `java.util.concurrent.ExecutorService` /
+     `java.util.concurrent.Executors` — the worker pool.
+   - `java.util.concurrent.ThreadFactory` — daemon worker threads.
+   - `java.util.Base64` (Java 8) — payload encode/decode.
+   - `java.util.regex.Pattern` — name validation.
+   - `ca.weblite.webview.JavascriptFunction`,
+     `ca.weblite.webview.AsyncJavascriptFunction` — handler types.
+   - `ca.weblite.webview.FunctionDispatcher.FunctionSink` — its own
+     nested type.
+2. `FunctionDispatcher` does NOT depend on `WebViewNative`,
+   `EmbeddedWebView`, `OffscreenWebView`, `WebView`,
+   `WebViewComponent`, or any Swing class. (Unlike `EvalDispatcher`,
+   it does not even import `javax.swing.SwingUtilities` — handlers run
+   on the worker pool, not the EDT, and the resolve hop is a plain
+   `eval`.) The `FunctionSink` indirection is the entire decoupling
+   mechanism.
+3. `JavascriptFunction` depends only on `java.lang`.
+   `AsyncJavascriptFunction` depends on
+   `java.util.concurrent.CompletableFuture`.
+
+### Layered Architecture
+1. **JS layer (page-side):** `FunctionDispatcher.SHIM_JS` plus the
+   per-name wrappers run in the page. Responsibility: expose
+   `window.<name>(arg)` returning a Promise, allocate a request id,
+   stash the `{resolve,reject}` pair, post `<id>|<name>|<arg>`
+   (base64) through `window.__webview_fn_call__`, and settle the
+   stashed Promise when `window.__webview_fn_resolve__` is invoked.
+2. **Native bind / eval layer:** the engine converts the JS call into
+   a `WebViewNativeCallback` on the engine UI thread, and converts the
+   outbound `eval` into a script run in the page. Out of scope — owned
+   by the consuming canvases and the native code at `src_c/`.
+3. **Dispatcher layer:** `FunctionDispatcher.dispatch(rawJson)` parses
+   the inbound envelope, routes to the handler, runs it off-thread
+   (sync) or awaits its future (async), and resolves via the sink.
+4. **Handler layer:** the host application's `JavascriptFunction` /
+   `AsyncJavascriptFunction` lambdas. Pure Java; out of scope of the
+   transport.
+
+## O · Operations
+
+### 1. Construct the dispatcher — FunctionDispatcher constructor
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: build a per-engine hub with its sink and disposal
+   label, and start the worker pool.
+2. Methods:
+   - `public FunctionDispatcher(FunctionSink sink, String disposeLabel)`
+     - Logic:
+       - `if (sink == null) throw new NullPointerException("sink");`
+       - `if (disposeLabel == null) throw new NullPointerException("disposeLabel");`
+       - Store `this.sink`, `this.disposeLabel`.
+       - `this.handlers = new ConcurrentHashMap<String, AsyncJavascriptFunction>();`
+       - `this.worker = Executors.newCachedThreadPool(threadFactory);`
+         where `threadFactory` returns daemon threads named
+         `"webview-fn-" + disposeLabel + "-" + n`.
+       - `disposed` defaults `false`.
+3. Constraints: `sink`, `disposeLabel`, `worker` are `final`. The
+   worker pool uses daemon threads so it never blocks JVM exit.
+
+### 2. Register a synchronous handler — FunctionDispatcher.registerSync
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: validate and store a synchronous handler, adapting
+   it to the async path, and install its page-side wrapper.
+2. Methods:
+   - `public void registerSync(String name, JavascriptFunction fn)`
+     - Logic:
+       - `validateName(name);` (Operation 7) and
+         `if (fn == null) throw new NullPointerException("fn");`
+       - `if (disposed) return;`
+       - Adapt: build an `AsyncJavascriptFunction` whose `run(arg)`
+         does `CompletableFuture.supplyAsync(() -> { try { return
+         fn.run(arg); } catch (RuntimeException|Error e) { throw e; }
+         catch (Exception e) { throw new CompletionException(e); } },
+         worker)`. (Wrap checked exceptions in `CompletionException`
+         so the future completes exceptionally with the original
+         cause.)
+       - `handlers.put(name, adapted);`
+       - `installWrapper(name);` (Operation 6).
+3. Constraints: the adapter MUST submit to `worker` so `fn.run` never
+   executes on the inbound binding-callback (engine UI) thread.
+
+### 3. Register an async handler — FunctionDispatcher.registerAsync
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: validate and store an async handler, install its
+   page-side wrapper.
+2. Methods:
+   - `public void registerAsync(String name, AsyncJavascriptFunction fn)`
+     - Logic:
+       - `validateName(name);` and null-check `fn`.
+       - `if (disposed) return;`
+       - `handlers.put(name, fn);`
+       - `installWrapper(name);`
+3. Constraints: `fn.run` is invoked on the inbound binding-callback
+   thread in `dispatch`; the contract (Javadoc) requires it to return
+   promptly with a future and not block.
+
+### 4. Dispatch an inbound call — FunctionDispatcher.dispatch
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: parse the inbound envelope, route to the handler,
+   and arrange the resolve.
+2. Methods:
+   - `public void dispatch(String rawJson)`
+     - Logic:
+       - `if (rawJson == null) return;`
+       - `String b64 = extractFirstArg(rawJson); if (b64 == null) return;`
+       - `String rec = decodeBase64Utf8(b64); if (rec == null) return;`
+       - `int p1 = rec.indexOf('|'); if (p1 <= 0) return;`
+       - `long id; try { id = Long.parseLong(rec.substring(0, p1)); } catch (NumberFormatException e) { return; }`
+       - `int p2 = rec.indexOf('|', p1 + 1); if (p2 < 0) return;`
+       - `String name = rec.substring(p1 + 1, p2);`
+       - `String arg = rec.substring(p2 + 1);` (verbatim; may contain `|`).
+       - `AsyncJavascriptFunction h = handlers.get(name);`
+       - `if (h == null) { resolve(id, false, "no such function: " + name); return; }`
+       - `CompletableFuture<String> fut; try { fut = h.run(arg); } catch (Throwable t) { resolve(id, false, msgOf(t)); return; }`
+       - `if (fut == null) { resolve(id, true, ""); return; }`
+       - `fut.whenComplete((value, err) -> { if (err != null) resolve(id, false, msgOf(unwrap(err))); else resolve(id, true, value == null ? "" : value); });`
+3. Constraints: never throws out of `dispatch` (it runs on the native
+   binding callback thread); every path either resolves or silently
+   drops malformed input. `unwrap` peels `CompletionException`;
+   `msgOf` returns `t.getMessage()` or `t.getClass().getSimpleName()`.
+
+### 5. Canonical JS shim — FunctionDispatcher.SHIM_JS
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: the idempotent base shim installed once per page.
+2. Constant `public static final String SHIM_JS`:
+   ```js
+   (function(){
+     if(window.__webview_fn_installed__)return;
+     window.__webview_fn_installed__=true;
+     var pending={}, seq=0;
+     function enc(s){try{return btoa(unescape(encodeURIComponent(s)));}catch(e){return '';}}
+     function dec(s){try{return decodeURIComponent(escape(atob(s)));}catch(e){return '';}}
+     var post=window.__webview_fn_call__;   // cached before any user JS
+     window.__webview_fn_invoke=function(name,arg){
+       var id=++seq;
+       return new Promise(function(resolve,reject){
+         pending[id]={resolve:resolve,reject:reject};
+         var sink=post||window.__webview_fn_call__;
+         if(typeof sink!=='function'){reject(new Error('webview function channel unavailable'));return;}
+         sink(enc(id+'|'+name+'|'+(arg==null?'':String(arg))));
+       });
+     };
+     window.__webview_fn_resolve__=function(b64){
+       var rec=dec(b64);
+       var p1=rec.indexOf('|'); if(p1<0)return;
+       var p2=rec.indexOf('|',p1+1); if(p2<0)return;
+       var id=rec.substring(0,p1), ok=rec.substring(p1+1,p2), val=rec.substring(p2+1);
+       var e=pending[id]; if(!e)return; delete pending[id];
+       if(ok==='1') e.resolve(val); else e.reject(new Error(val));
+     };
+   })();
+   ```
+3. Constraints: idempotent (`__webview_fn_installed__`); installed at
+   document-start via `addOnBeforeLoad`; caches the inbound binding
+   reference; `pending` keys are JS-allocated ids so the page matches
+   its own resolvers.
+
+### 6. Install a per-name wrapper — FunctionDispatcher.installWrapper / wrapperFor
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: expose `window.<name>` and make it survive reloads.
+2. Methods:
+   - `private String wrapperFor(String name)` returns:
+     ```js
+     (function(){window["<NAME>"]=function(a){return window.__webview_fn_invoke("<NAME>",a);};})();
+     ```
+     `<NAME>` is substituted with the validated `name` (safe: it
+     matches `NAME_PATTERN`, so it contains no quotes or backslashes).
+   - `private void installWrapper(String name)`:
+     - `String js = wrapperFor(name);`
+     - `sink.addOnBeforeLoad(js);` — future navigations.
+     - `sink.eval(js);` — current document.
+3. Constraints: ordering (`addOnBeforeLoad` then `eval`) does not
+   matter for correctness; both are issued so the function works
+   immediately and after reloads.
+
+### 7. Validate a name — FunctionDispatcher.validateName
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: reject names that could shadow internal channels or
+   break the wrapper.
+2. Methods:
+   - `private static void validateName(String name)`:
+     - `if (name == null) throw new NullPointerException("name");`
+     - `if (name.startsWith("__webview_")) throw new IllegalArgumentException("name must not start with __webview_: " + name);`
+     - `if (!NAME_PATTERN.matcher(name).matches()) throw new IllegalArgumentException("name must be a valid JS identifier: " + name);`
+3. Constraints: `NAME_PATTERN = Pattern.compile("^[A-Za-z_$][A-Za-z0-9_$]*$");`.
+
+### 8. Resolve back to the page — FunctionDispatcher.resolve
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: deliver the result to the page Promise.
+2. Methods:
+   - `private void resolve(long id, boolean ok, String payload)`:
+     - `String rec = id + "|" + (ok ? "1" : "0") + "|" + (payload == null ? "" : payload);`
+     - `String b64 = Base64.getEncoder().encodeToString(utf8(rec));`
+     - `sink.eval("window.__webview_fn_resolve__('" + b64 + "')");`
+3. Constraints: uses `eval` (non-blocking); base64 is single-quote
+   safe so no escaping needed; never blocks the calling thread.
+
+### 9. Dispose — FunctionDispatcher.disposeAll
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: stop accepting work and release the pool.
+2. Methods:
+   - `public void disposeAll()`:
+     - `if (disposed) return;`
+     - `disposed = true;`
+     - `handlers.clear();`
+     - `worker.shutdownNow();`
+3. Constraints: idempotent; safe from any thread.
+
+### 10. Base64 helpers — extractFirstArg / decodeBase64Utf8 / utf8
+File: `src/ca/weblite/webview/FunctionDispatcher.java`
+1. Responsibility: envelope/payload codec, copied verbatim from
+   `EvalDispatcher` (`extractFirstArg`, `decodeBase64Utf8`) plus a
+   small `private static byte[] utf8(String s)` returning
+   `s.getBytes("UTF-8")` (wrapped to swallow the checked
+   `UnsupportedEncodingException`, which never fires for UTF-8).
+
+### 11. The functional interfaces — JavascriptFunction / AsyncJavascriptFunction
+Files: `src/ca/weblite/webview/JavascriptFunction.java`,
+`src/ca/weblite/webview/AsyncJavascriptFunction.java`
+1. `JavascriptFunction`: `@FunctionalInterface public interface
+   JavascriptFunction { String run(String arg) throws Exception; }`
+   with Javadoc stating it runs off the engine UI thread, return value
+   resolves the page Promise, thrown exception rejects it.
+2. `AsyncJavascriptFunction`: `@FunctionalInterface public interface
+   AsyncJavascriptFunction { CompletableFuture<String> run(String
+   arg); }` with Javadoc stating `run` is invoked on the binding
+   thread and must return promptly with a future; the future's normal
+   completion resolves and exceptional completion rejects the page
+   Promise.
+
+## N · Norms
+- **Visibility / internal marker:** `FunctionDispatcher` Javadoc leads
+  with the verbatim `<strong>Internal:</strong> not part of the public
+  API surface.` paragraph (as `EvalDispatcher`/`ConsoleDispatcher`).
+  The two functional interfaces ARE public API and carry user-facing
+  Javadoc.
+- **Annotation standards:** `@FunctionalInterface` on
+  `JavascriptFunction` and `AsyncJavascriptFunction`. No annotations on
+  `FunctionDispatcher` or `FunctionSink` (the latter has two methods,
+  so it is deliberately NOT `@FunctionalInterface`).
+- **Dependency injection / construction:** `FunctionSink` is
+  constructor-injected; consuming wrappers build it as an anonymous
+  inner class once and store the dispatcher in a `final` field. No
+  setters.
+- **Exception handling:**
+  - `dispatch(rawJson)` MUST NOT throw — it runs on the native binding
+    callback thread. Malformed input is silently dropped (matching
+    `EvalDispatcher.dispatch`); a handler that throws synchronously, or
+    a future that completes exceptionally, becomes a Promise rejection.
+  - Registration methods MAY throw `IllegalArgumentException` /
+    `NullPointerException` synchronously for programming errors
+    (bad name, null handler) — these are caller bugs, surfaced loudly.
+  - The Promise rejection message contains only the Java-side
+    exception message; no stack traces or peer pointers.
+- **Threading:** synchronous handlers run on the dispatcher's daemon
+  worker pool. The outbound resolve uses `eval` (never `evalAsync`,
+  never `.get()`), so no dispatcher code blocks the engine UI thread
+  or the EDT. This is the deadlock-free contract.
+- **Data validation:** ids parsed with `Long.parseLong` (silent drop
+  on `NumberFormatException`); ok-flag checked with exact
+  `equals("1")`; registered names validated against `NAME_PATTERN` and
+  the reserved prefix.
+- **Logging:** none, matching the other dispatchers.
+- **Java 8 idioms:** no `var`, no `List.of`, no `String.isBlank`, no
+  `CompletableFuture.failedFuture`; use anonymous inner classes for
+  the `FunctionSink` implementations in consuming wrappers (it has two
+  methods anyway). Lambdas are acceptable inside the dispatcher's own
+  adapter code.
+- **Documentation standards:** `SHIM_JS` carries Javadoc documenting
+  the page contract (`await window.<name>(arg)`, string passthrough,
+  reject-on-throw) and idempotency. The functional interfaces document
+  the threading and error contract.
+
+## S · Safeguards
+- **Functional constraints:**
+  - A registered function MUST appear as `window.<name>` and return a
+    Promise resolving to the handler's returned string (or rejecting
+    with its exception message). Verified by `FunctionDispatcherTest`
+    against a mock sink that captures the per-name wrapper and the
+    resolve `eval`.
+  - A synchronous handler MUST run on a thread other than the one that
+    called `dispatch`. Verified by a test asserting the handler's
+    observed thread differs from the dispatch thread.
+  - An unknown function name MUST reject (not hang) the page Promise.
+- **Performance constraints:** one `ConcurrentHashMap` lookup per call;
+  one worker-pool task per synchronous call; base64 + a few `indexOf`
+  on each boundary crossing. No per-call allocation beyond the
+  `CompletableFuture` and the wrapped strings.
+- **Security constraints:**
+  - The reserved channels (`__webview_fn_call__`,
+    `window.__webview_fn_resolve__`, and the `__webview_fn_*` window
+    members) live under `__webview_` and are protected by the existing
+    reserved-prefix guard on `addJavascriptCallback`. The public
+    `addJavascriptFunction` additionally rejects reserved-prefix and
+    non-identifier names, so a caller can neither shadow the internal
+    channel nor inject JS through the per-name wrapper (the name is
+    substituted into a JS string/identifier position but is constrained
+    to `[A-Za-z_$][A-Za-z0-9_$]*`).
+  - The invoke helper caches the inbound binding reference before any
+    user JS runs (mirroring `EvalDispatcher`'s defense), so user JS
+    reassigning `window.__webview_fn_call__` cannot reroute calls.
+  - Rejection messages carry only Java-side text; callers rendering
+    them into the DOM are responsible for escaping.
+  - The wrapper/resolve scripts run through `eval`; CSPs that forbid
+    `eval` reject them wholesale — same constraint as the existing
+    fire-and-forget `eval` path, documented not mitigated.
+- **Integration constraints:**
+  - `FunctionDispatcher` MUST NOT depend on any engine wrapper or Swing
+    class; the `FunctionSink` indirection is the decoupling mechanism.
+  - The inbound binding callback registered by the consuming surface
+    MUST be anchored in that surface's `heap` field (JNI lifecycle
+    norm) — this canvas relies on that anchoring; each consuming
+    canvas restates the reminder.
+- **Business-rule constraints:**
+  - Single string argument and string result this iteration (JSON for
+    structure). Multi-arg / typed results are future canvases.
+  - A page that drops the returned Promise still lets the Java handler
+    run to completion; the result is discarded.
+- **Exception-handling constraints:**
+  - Handler failures surface as page-side Promise rejections; library
+    misuse (bad name, null handler) surfaces as synchronous Java
+    exceptions; neither is conflated with the other.
+- **Technical constraints:** Java 8 source/target (`pom.xml`); no new
+  external dependencies; no JNI additions; no native changes. Uses only
+  `java.util.*`, `java.util.concurrent.*`, `java.util.regex.*`.
+- **Data constraints:** ids are JS-allocated positive integers echoed
+  back verbatim; the pipe-separated wire format splits at most twice so
+  the final field may contain `|`.
+- **API constraints:** `FunctionDispatcher` is `public final`;
+  `FunctionSink` is a two-method nested interface (new abstract methods
+  are a breaking change — extend via `default` methods only);
+  `JavascriptFunction` and `AsyncJavascriptFunction` are
+  `@FunctionalInterface` and binary-compatibility-frozen at one
+  abstract method each.

--- a/spdd/prompt/2-20260516-0719-[Feat]-In-Process-Webview-Java-Api.md
+++ b/spdd/prompt/2-20260516-0719-[Feat]-In-Process-Webview-Java-Api.md
@@ -388,3 +388,33 @@ File: `src/ca/weblite/webview/WebView.java`
   [[swing-lightweight-webview-embedding]]) take the
   `marshalToEdt = true` branch so callers there receive
   continuations on the EDT directly.
+
+## Addendum · Async JavaScript Functions integration (see [[webview-async-javascript-functions]])
+
+Wires the value-returning JS→Java function API (Canvas 14:
+`FunctionDispatcher`, `JavascriptFunction`, `AsyncJavascriptFunction`)
+into the standalone `WebView`, mirroring the existing `EvalDispatcher`/`evalAsync`
+integration. No native changes.
+
+- **Construct.** the standalone `WebView` holds a `final FunctionDispatcher`
+  constructed with a `FunctionDispatcher.FunctionSink` whose `eval`
+  and `addOnBeforeLoad` delegate to `webview_eval`/`webview_init` (guarded so they no-op
+  when the peer is absent).
+- **Install at peer bring-up.** Alongside the eval bridge, install
+  `FunctionDispatcher.SHIM_JS` in `show()` (after the eval shim, before replaying buffered onBeforeLoad scripts so the base shim precedes per-name wrappers) and bind the reserved
+  `FunctionDispatcher.INBOUND_CHANNEL` to a `WebViewNativeCallback`
+  that routes into `functionDispatcher.dispatch(arg)`. The callback is
+  anchored in the surface's `heap` (JNI lifecycle norm) so the native
+  global ref stays reachable.
+- **Public API.** Two overloads, `addJavascriptFunction(String,
+  JavascriptFunction)` and `addJavascriptFunction(String,
+  AsyncJavascriptFunction)`, delegate to
+  `functionDispatcher.registerSync` / `registerAsync`. The reserved
+  `__webview_` prefix and JS-identifier validity are enforced by the
+  dispatcher (the Swing components additionally fast-fail the reserved
+  prefix at the call site, matching `addJavascriptCallback`).
+- **Teardown.** `functionDispatcher.disposeAll()` is called from the
+  surface's existing dispose path (next to
+  `evalDispatcher.disposeAllPending()`), shutting down the worker pool.
+- **Out of scope:** `FunctionDispatcher` and the two functional
+  interfaces themselves — owned by [[webview-async-javascript-functions]].

--- a/spdd/prompt/5-20260516-0719-[Feat]-Swing-Webview-Component-Mode-Selection.md
+++ b/spdd/prompt/5-20260516-0719-[Feat]-Swing-Webview-Component-Mode-Selection.md
@@ -550,3 +550,33 @@ File: `src/ca/weblite/webview/swing/WebViewComponent.java`
   ("no-op until displayable") except that `evalAsync` cannot
   silently no-op — callers expect a future to complete one way
   or another.
+
+## Addendum · Async JavaScript Functions integration (see [[webview-async-javascript-functions]])
+
+Wires the value-returning JS→Java function API (Canvas 14:
+`FunctionDispatcher`, `JavascriptFunction`, `AsyncJavascriptFunction`)
+into the abstract `WebViewComponent` (two abstract `addJavascriptFunction` overloads; concretes delegate to their engine), mirroring the existing `EvalDispatcher`/`evalAsync`
+integration. No native changes.
+
+- **Construct.** the abstract `WebViewComponent` (two abstract `addJavascriptFunction` overloads; concretes delegate to their engine) holds a `final FunctionDispatcher`
+  constructed with a `FunctionDispatcher.FunctionSink` whose `eval`
+  and `addOnBeforeLoad` delegate to the engine wrapper (guarded so they no-op
+  when the peer is absent).
+- **Install at peer bring-up.** Alongside the eval bridge, install
+  `FunctionDispatcher.SHIM_JS` by the concrete subclasses' engines and bind the reserved
+  `FunctionDispatcher.INBOUND_CHANNEL` to a `WebViewNativeCallback`
+  that routes into `functionDispatcher.dispatch(arg)`. The callback is
+  anchored in the surface's `heap` (JNI lifecycle norm) so the native
+  global ref stays reachable.
+- **Public API.** Two overloads, `addJavascriptFunction(String,
+  JavascriptFunction)` and `addJavascriptFunction(String,
+  AsyncJavascriptFunction)`, delegate to
+  `functionDispatcher.registerSync` / `registerAsync`. The reserved
+  `__webview_` prefix and JS-identifier validity are enforced by the
+  dispatcher (the Swing components additionally fast-fail the reserved
+  prefix at the call site, matching `addJavascriptCallback`).
+- **Teardown.** `functionDispatcher.disposeAll()` is called from the
+  surface's existing dispose path (next to
+  `evalDispatcher.disposeAllPending()`), shutting down the worker pool.
+- **Out of scope:** `FunctionDispatcher` and the two functional
+  interfaces themselves — owned by [[webview-async-javascript-functions]].

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -2778,3 +2778,50 @@ integration. No native changes.
   `evalDispatcher.disposeAllPending()`), shutting down the worker pool.
 - **Out of scope:** `FunctionDispatcher` and the two functional
   interfaces themselves — owned by [[webview-async-javascript-functions]].
+
+## Addendum · Bug fixes (macOS embedded engine)
+
+Two defects found via the WebViewAsyncCallbackDemo on macOS Intel.
+
+### Fix 1 · data: URLs must load via loadHTMLString:baseURL:
+
+`cocoa_navigate` (src_c/webview_embed.cpp) navigated every URL with
+`WKWebView -loadRequest:`. WKWebView **silently refuses `data:` URLs**
+through `loadRequest:` (a long-standing WKWebView restriction): the page
+renders blank with no error, and no resize/repaint recovers it because
+the content never loaded.
+
+- Requirement: a `data:text/html[...][;base64],<body>` URL passed to
+  `navigate(...)` MUST render its HTML.
+- Approach: in `cocoa_navigate`, detect a `data:text/html` URL, split at
+  the first comma into the metadata prefix and the body, decode the body
+  (`NSData -initWithBase64EncodedString:` when the prefix contains
+  `;base64`, otherwise `NSString -stringByRemovingPercentEncoding` with a
+  fallback to the raw body when percent-decoding yields nil), and load it
+  with `WKWebView -loadHTMLString:baseURL:` (nil base URL). All other URLs
+  (http/https/file/non-html data) keep the existing `loadRequest:` path.
+- Norms/Safeguards: ObjC dispatch uses the existing `msg<>()` typed
+  helper (object and NSUInteger args are register-passed, matching the
+  file's existing usage); no struct-return calls are introduced. Never
+  throws across JNI; a malformed data: URL falls through to the raw body.
+
+### Fix 2 · re-size the heavyweight peer when the async attach completes
+
+`WebViewHeavyweightComponent.sizeNative()` ran only at first paint (when
+the macOS WKWebView attach is still in flight and the native view is not
+yet positionable) and on subsequent AWT resize/move events. A frame whose
+WebView is the sole child, with no later resize, left the native view at
+a zero/stale frame (blank / content slivered to an edge; nondeterministic
+by timing).
+
+- Requirement: after the macOS asynchronous attach resolves, the native
+  WebView MUST be positioned to the canvas bounds without requiring a
+  user resize.
+- Approach: in `createPeer`, register a `WebViewAttachListener` via
+  `EmbeddedWebView.addOnAttachComplete(...)` whose `onAttached` calls
+  `sizeNative()`. The listener fires on the Swing EDT once attach resolves
+  (immediately/next-tick on Windows/Linux where attach is synchronous),
+  so the bounds are re-applied after the WKWebView exists.
+- Safeguards: `onAttachFailed` is a no-op (the engine is unusable and
+  discarded by existing paths). Idempotent with the existing
+  resize/move-driven `sizeNative()` calls.

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -2748,3 +2748,33 @@ Files:
   re-introduce a race between binding registration and
   page-load JS calls that the existing canvas code already
   documents around.
+
+## Addendum · Async JavaScript Functions integration (see [[webview-async-javascript-functions]])
+
+Wires the value-returning JS→Java function API (Canvas 14:
+`FunctionDispatcher`, `JavascriptFunction`, `AsyncJavascriptFunction`)
+into `EmbeddedWebView` (and `WebViewHeavyweightComponent`, which buffers pre-display registrations and replays them in `createPeer`), mirroring the existing `EvalDispatcher`/`evalAsync`
+integration. No native changes.
+
+- **Construct.** `EmbeddedWebView` (and `WebViewHeavyweightComponent`, which buffers pre-display registrations and replays them in `createPeer`) holds a `final FunctionDispatcher`
+  constructed with a `FunctionDispatcher.FunctionSink` whose `eval`
+  and `addOnBeforeLoad` delegate to `webview_embed_eval`/`webview_embed_init` (guarded so they no-op
+  when the peer is absent).
+- **Install at peer bring-up.** Alongside the eval bridge, install
+  `FunctionDispatcher.SHIM_JS` in the `attach(...)` factory and bind the reserved
+  `FunctionDispatcher.INBOUND_CHANNEL` to a `WebViewNativeCallback`
+  that routes into `functionDispatcher.dispatch(arg)`. The callback is
+  anchored in the surface's `heap` (JNI lifecycle norm) so the native
+  global ref stays reachable.
+- **Public API.** Two overloads, `addJavascriptFunction(String,
+  JavascriptFunction)` and `addJavascriptFunction(String,
+  AsyncJavascriptFunction)`, delegate to
+  `functionDispatcher.registerSync` / `registerAsync`. The reserved
+  `__webview_` prefix and JS-identifier validity are enforced by the
+  dispatcher (the Swing components additionally fast-fail the reserved
+  prefix at the call site, matching `addJavascriptCallback`).
+- **Teardown.** `functionDispatcher.disposeAll()` is called from the
+  surface's existing dispose path (next to
+  `evalDispatcher.disposeAllPending()`), shutting down the worker pool.
+- **Out of scope:** `FunctionDispatcher` and the two functional
+  interfaces themselves — owned by [[webview-async-javascript-functions]].

--- a/spdd/prompt/7-20260516-0719-[Feat]-Swing-Lightweight-Webview-Embedding.md
+++ b/spdd/prompt/7-20260516-0719-[Feat]-Swing-Lightweight-Webview-Embedding.md
@@ -1264,3 +1264,33 @@ Files:
   the standalone `WebView` surface's opposite
   `marshalToEdt = false` branch documented in
   [[in-process-webview-java-api]].
+
+## Addendum · Async JavaScript Functions integration (see [[webview-async-javascript-functions]])
+
+Wires the value-returning JS→Java function API (Canvas 14:
+`FunctionDispatcher`, `JavascriptFunction`, `AsyncJavascriptFunction`)
+into `OffscreenWebView` (and `WebViewLightweightComponent`, which buffers pre-display registrations and replays them at engine bring-up), mirroring the existing `EvalDispatcher`/`evalAsync`
+integration. No native changes.
+
+- **Construct.** `OffscreenWebView` (and `WebViewLightweightComponent`, which buffers pre-display registrations and replays them at engine bring-up) holds a `final FunctionDispatcher`
+  constructed with a `FunctionDispatcher.FunctionSink` whose `eval`
+  and `addOnBeforeLoad` delegate to `webview_offscreen_eval`/`webview_offscreen_init` (guarded so they no-op
+  when the peer is absent).
+- **Install at peer bring-up.** Alongside the eval bridge, install
+  `FunctionDispatcher.SHIM_JS` in `create(...)` and bind the reserved
+  `FunctionDispatcher.INBOUND_CHANNEL` to a `WebViewNativeCallback`
+  that routes into `functionDispatcher.dispatch(arg)`. The callback is
+  anchored in the surface's `heap` (JNI lifecycle norm) so the native
+  global ref stays reachable.
+- **Public API.** Two overloads, `addJavascriptFunction(String,
+  JavascriptFunction)` and `addJavascriptFunction(String,
+  AsyncJavascriptFunction)`, delegate to
+  `functionDispatcher.registerSync` / `registerAsync`. The reserved
+  `__webview_` prefix and JS-identifier validity are enforced by the
+  dispatcher (the Swing components additionally fast-fail the reserved
+  prefix at the call site, matching `addJavascriptCallback`).
+- **Teardown.** `functionDispatcher.disposeAll()` is called from the
+  surface's existing dispose path (next to
+  `evalDispatcher.disposeAllPending()`), shutting down the worker pool.
+- **Out of scope:** `FunctionDispatcher` and the two functional
+  interfaces themselves — owned by [[webview-async-javascript-functions]].

--- a/src/ca/weblite/webview/AsyncJavascriptFunction.java
+++ b/src/ca/weblite/webview/AsyncJavascriptFunction.java
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction.
+ */
+package ca.weblite.webview;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A Java-backed JavaScript function with an <em>asynchronous</em> handler.
+ *
+ * <p>Register one with
+ * {@code addJavascriptFunction(String name, AsyncJavascriptFunction fn)} and it
+ * appears in the page as a global that returns a Promise:
+ *
+ * <pre>{@code
+ * webView.addJavascriptFunction("lookup", arg ->
+ *     myService.lookupAsync(arg));            // returns CompletableFuture<String>
+ * // in the page:  const row = await window.lookup("42");
+ * }</pre>
+ *
+ * <p>Use this overload when the work is already asynchronous (the handler
+ * returns a future rather than blocking). For ordinary blocking work, prefer
+ * {@link JavascriptFunction}, which the library runs on a worker thread for
+ * you.
+ *
+ * <p><strong>Threading.</strong> {@link #run(String)} is invoked on the
+ * engine's binding-callback thread and MUST return promptly with a future
+ * &mdash; it MUST NOT block. The library never calls {@code get()} on the
+ * returned future; it attaches a completion callback, so the round trip stays
+ * deadlock-free.
+ *
+ * <p><strong>Result.</strong> When the future completes normally its
+ * {@code String} value resolves the page-side Promise (string passthrough; a
+ * {@code null} value resolves to the empty string). When it completes
+ * exceptionally, the page-side Promise rejects with an {@code Error} carrying
+ * the exception message.
+ */
+@FunctionalInterface
+public interface AsyncJavascriptFunction {
+
+    /**
+     * Begin computing the result for one page-side invocation.
+     *
+     * @param arg the single string argument the JavaScript caller passed
+     *            (never {@code null}).
+     * @return a future that completes with the value the page-side Promise
+     *         resolves to, or completes exceptionally to reject it. Returning
+     *         {@code null} resolves the Promise to the empty string.
+     */
+    CompletableFuture<String> run(String arg);
+}

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -67,6 +67,15 @@ public class EmbeddedWebView {
     private final EvalDispatcher evalDispatcher;
 
     /**
+     * Per-engine hub for {@link #addJavascriptFunction} — value-returning
+     * JS&rarr;Java functions.  Its {@code FunctionSink} issues
+     * {@code webview_embed_eval} / {@code webview_embed_init} when
+     * {@code peer != 0}; the sink-level guard is belt-and-suspenders
+     * against a destroy that races a dispatch.
+     */
+    private final FunctionDispatcher functionDispatcher;
+
+    /**
      * Attach lifecycle state.  Reads and writes are confined to the
      * Swing EDT.  Initialised to {@link AttachState#PENDING}; the
      * native attach-completion callback drives the transition to
@@ -110,6 +119,23 @@ public class EmbeddedWebView {
                 }
             }
         }, true, "EmbeddedWebView");
+        this.functionDispatcher = new FunctionDispatcher(
+            new FunctionDispatcher.FunctionSink() {
+                @Override
+                public void eval(String js) {
+                    long p = EmbeddedWebView.this.peer;
+                    if (p != 0L) {
+                        WebViewNative.webview_embed_eval(p, js);
+                    }
+                }
+                @Override
+                public void addOnBeforeLoad(String js) {
+                    long p = EmbeddedWebView.this.peer;
+                    if (p != 0L) {
+                        WebViewNative.webview_embed_init(p, js);
+                    }
+                }
+            }, "EmbeddedWebView");
         // Anchor the attach callback against GC for as long as the engine
         // is alive; the native side holds a JNI global ref but releasing
         // it via the destroy lambda is the only mechanism that drops the
@@ -175,6 +201,19 @@ public class EmbeddedWebView {
         };
         ewv.heap.add(evalCb);
         WebViewNative.webview_embed_bind(p, EvalDispatcher.CHANNEL_NAME, evalCb, p);
+        // Install the addJavascriptFunction bridge the same way: SHIM_JS at
+        // document-start and the reserved inbound binding that routes page
+        // calls into the FunctionDispatcher.  Anchored in heap so the JNI
+        // global ref stays reachable.
+        WebViewNative.webview_embed_init(p, FunctionDispatcher.SHIM_JS);
+        WebViewNativeCallback fnCb = new WebViewNativeCallback() {
+            @Override
+            public void invoke(String arg, long wv) {
+                ewv.functionDispatcher.dispatch(arg);
+            }
+        };
+        ewv.heap.add(fnCb);
+        WebViewNative.webview_embed_bind(p, FunctionDispatcher.INBOUND_CHANNEL, fnCb, p);
         return ewv;
     }
 
@@ -298,6 +337,28 @@ public class EmbeddedWebView {
         };
         heap.add(fn);
         WebViewNative.webview_embed_bind(peer, name, fn, peer);
+        return this;
+    }
+
+    /**
+     * Register a synchronous Java-backed JavaScript function under
+     * {@code window.<name>}.  See {@link JavascriptFunction}.  The handler
+     * runs on a background thread; the page calls
+     * {@code await window.<name>(arg)}.
+     */
+    public EmbeddedWebView addJavascriptFunction(String name, JavascriptFunction fn) {
+        checkAlive();
+        functionDispatcher.registerSync(name, fn);
+        return this;
+    }
+
+    /**
+     * Register an asynchronous Java-backed JavaScript function under
+     * {@code window.<name>}.  See {@link AsyncJavascriptFunction}.
+     */
+    public EmbeddedWebView addJavascriptFunction(String name, AsyncJavascriptFunction fn) {
+        checkAlive();
+        functionDispatcher.registerAsync(name, fn);
         return this;
     }
 
@@ -605,6 +666,7 @@ public class EmbeddedWebView {
             // such a late callback finds an empty pending map and
             // silently drops.
             evalDispatcher.disposeAllPending();
+            functionDispatcher.disposeAll();
             // Clear any native focus callback BEFORE we hand off to destroy,
             // so the swizzled responder hooks never fire into a freed Java
             // global ref.  checkAlive would still pass here since peer is

--- a/src/ca/weblite/webview/FunctionDispatcher.java
+++ b/src/ca/weblite/webview/FunctionDispatcher.java
@@ -1,0 +1,359 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+/**
+ * <p><strong>Internal:</strong> not part of the public API surface.  Use
+ * the {@code addJavascriptFunction(String, ...)} methods on {@code WebView}
+ * or {@code WebViewComponent} instead.  This class is {@code public} only
+ * because the consuming Swing subclasses live in a different package and
+ * Java has no cross-package-but-non-public access modifier; matches the
+ * existing pattern used by {@code EvalDispatcher},
+ * {@code ConsoleDispatcher}, and {@code WebViewMouseDispatcher}.
+ *
+ * <p>Per-engine fan-out hub for value-returning JS&rarr;Java functions &mdash;
+ * the mirror image of {@link EvalDispatcher} (which lets Java call JS and
+ * await a result).  Here the page calls a registered global,
+ * {@code const r = await window.<name>(arg)}, and a Java handler produces
+ * the result.  The dispatcher owns the {@code name -> handler} registry, a
+ * daemon worker pool that runs synchronous handlers off the engine UI
+ * thread, the canonical JS shim ({@link #SHIM_JS}), the per-name wrapper
+ * installer, the inbound-call parsing, and the outbound resolve.
+ *
+ * <p>Threading: synchronous handlers ({@link JavascriptFunction}) run on the
+ * worker pool; asynchronous handlers ({@link AsyncJavascriptFunction}) are
+ * invoked on the binding-callback thread and return a future.  The result is
+ * delivered back to the page through a fire-and-forget {@code eval} (never
+ * {@code evalAsync}, never {@code get()}), so no dispatcher code blocks the
+ * engine UI thread or the Swing EDT.  This is the deadlock-free property that
+ * motivates the feature over a synchronous value-returning callback.
+ *
+ * <p>Like the other dispatchers the wire format is a base64-encoded
+ * pipe-separated record and there is no JSON-parsing dependency.
+ */
+public final class FunctionDispatcher {
+
+    /**
+     * Reserved JS binding name through which the page posts inbound calls.
+     * Carries base64 of {@code <id>|<name>|<arg>}.  Protected from caller
+     * collision by the existing {@code RESERVED_BINDING_PREFIX} check on
+     * {@code WebViewComponent.addJavascriptCallback}.
+     */
+    public static final String INBOUND_CHANNEL = "__webview_fn_call__";
+
+    /** Reserved prefix; registered function names may not start with it. */
+    private static final String RESERVED_PREFIX = "__webview_";
+
+    /** Registered names must be plain JS identifiers (no quotes/backslashes),
+     *  so they can be substituted into the per-name wrapper without escaping. */
+    private static final Pattern NAME_PATTERN =
+        Pattern.compile("^[A-Za-z_$][A-Za-z0-9_$]*$");
+
+    /**
+     * Canonical base shim installed once per page (via {@code addOnBeforeLoad}
+     * by the consuming surface).  Defines, on {@code window}:
+     * <ul>
+     *   <li>{@code __webview_fn_invoke(name, arg)} &mdash; returns a Promise,
+     *       allocates a request id, stashes its {@code {resolve,reject}}, and
+     *       posts {@code <id>|<name>|<arg>} (base64) through
+     *       {@code window.__webview_fn_call__}.</li>
+     *   <li>{@code __webview_fn_resolve__(b64)} &mdash; the sink Java calls
+     *       back into; decodes {@code <id>|<ok>|<result>} and settles the
+     *       stashed Promise.</li>
+     * </ul>
+     *
+     * <p>Idempotency-guarded with {@code window.__webview_fn_installed__} so
+     * re-injection on repeated navigations is a no-op.  The inbound binding
+     * reference is cached BEFORE any user JS runs, so user code that
+     * reassigns {@code window.__webview_fn_call__} cannot reroute calls
+     * (mirrors {@link EvalDispatcher#SHIM_JS}).
+     */
+    public static final String SHIM_JS =
+        "(function(){"
+      + "if(window.__webview_fn_installed__)return;"
+      + "window.__webview_fn_installed__=true;"
+      + "var pending={}, seq=0;"
+      + "function enc(s){try{return btoa(unescape(encodeURIComponent(s)));}catch(e){return '';}}"
+      + "function dec(s){try{return decodeURIComponent(escape(atob(s)));}catch(e){return '';}}"
+      + "var post=window.__webview_fn_call__;"
+      + "window.__webview_fn_invoke=function(name,arg){"
+      + "  var id=++seq;"
+      + "  return new Promise(function(resolve,reject){"
+      + "    pending[id]={resolve:resolve,reject:reject};"
+      + "    var sink=post||window.__webview_fn_call__;"
+      + "    if(typeof sink!=='function'){reject(new Error('webview function channel unavailable'));return;}"
+      + "    sink(enc(id+'|'+name+'|'+(arg==null?'':String(arg))));"
+      + "  });"
+      + "};"
+      + "window.__webview_fn_resolve__=function(b64){"
+      + "  var rec=dec(b64);"
+      + "  var p1=rec.indexOf('|'); if(p1<0)return;"
+      + "  var p2=rec.indexOf('|',p1+1); if(p2<0)return;"
+      + "  var id=rec.substring(0,p1), ok=rec.substring(p1+1,p2), val=rec.substring(p2+1);"
+      + "  var e=pending[id]; if(!e)return; delete pending[id];"
+      + "  if(ok==='1') e.resolve(val); else e.reject(new Error(val));"
+      + "};"
+      + "})();";
+
+    /**
+     * Engine-specific delivery channel injected at construction time.  Unlike
+     * {@link EvalDispatcher.EvalSink} this carries two methods (so it is NOT a
+     * {@code @FunctionalInterface}); modeled on
+     * {@code WebViewMouseDispatcher.FlagSink}, which likewise carries both
+     * {@code eval} and {@code addOnBeforeLoad}.  Implementations own
+     * engine-alive checks and {@code IllegalStateException} swallowing.
+     */
+    public static interface FunctionSink {
+        /** Fire-and-forget eval of {@code js} on the live engine. */
+        void eval(String js);
+        /** Register {@code js} as a document-start script. */
+        void addOnBeforeLoad(String js);
+    }
+
+    private final FunctionSink sink;
+    private final String disposeLabel;
+    private final ConcurrentHashMap<String, AsyncJavascriptFunction> handlers;
+    private final ExecutorService worker;
+    private volatile boolean disposed;
+
+    public FunctionDispatcher(FunctionSink sink, String disposeLabel) {
+        if (sink == null) throw new NullPointerException("sink");
+        if (disposeLabel == null) throw new NullPointerException("disposeLabel");
+        this.sink = sink;
+        this.disposeLabel = disposeLabel;
+        this.handlers = new ConcurrentHashMap<String, AsyncJavascriptFunction>();
+        final String label = disposeLabel;
+        final AtomicInteger seq = new AtomicInteger(0);
+        this.worker = Executors.newCachedThreadPool(new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r,
+                    "webview-fn-" + label + "-" + seq.incrementAndGet());
+                t.setDaemon(true);
+                return t;
+            }
+        });
+    }
+
+    /**
+     * Register a synchronous handler under {@code name}.  The handler runs on
+     * the worker pool (never the engine UI thread); its return value resolves
+     * the page Promise and a thrown exception rejects it.  The function is
+     * installed for the current document and all future navigations.
+     *
+     * @throws NullPointerException if {@code name} or {@code fn} is null.
+     * @throws IllegalArgumentException if {@code name} starts with the
+     *         reserved prefix or is not a valid JS identifier.
+     */
+    public void registerSync(final String name, final JavascriptFunction fn) {
+        validateName(name);
+        if (fn == null) throw new NullPointerException("fn");
+        if (disposed) return;
+        AsyncJavascriptFunction adapted = new AsyncJavascriptFunction() {
+            @Override
+            public CompletableFuture<String> run(final String arg) {
+                return CompletableFuture.supplyAsync(new java.util.function.Supplier<String>() {
+                    @Override
+                    public String get() {
+                        try {
+                            return fn.run(arg);
+                        } catch (RuntimeException e) {
+                            throw e;
+                        } catch (Error e) {
+                            throw e;
+                        } catch (Exception e) {
+                            throw new CompletionException(e);
+                        }
+                    }
+                }, worker);
+            }
+        };
+        handlers.put(name, adapted);
+        installWrapper(name);
+    }
+
+    /**
+     * Register an asynchronous handler under {@code name}.  The handler is
+     * invoked on the binding-callback thread and must return promptly with a
+     * future; the future's completion resolves/rejects the page Promise.  The
+     * function is installed for the current document and all future
+     * navigations.
+     *
+     * @throws NullPointerException if {@code name} or {@code fn} is null.
+     * @throws IllegalArgumentException if {@code name} starts with the
+     *         reserved prefix or is not a valid JS identifier.
+     */
+    public void registerAsync(String name, AsyncJavascriptFunction fn) {
+        validateName(name);
+        if (fn == null) throw new NullPointerException("fn");
+        if (disposed) return;
+        handlers.put(name, fn);
+        installWrapper(name);
+    }
+
+    /**
+     * Consume the raw bind-envelope JSON the native engine passes to the
+     * inbound callback, parse the base64 {@code <id>|<name>|<arg>} record,
+     * route to the handler, and arrange the resolve.  Called from the native
+     * binding-callback thread; never throws.  Silently drops malformed
+     * payloads (matches {@code EvalDispatcher.dispatch}).
+     */
+    public void dispatch(String rawJson) {
+        if (rawJson == null) return;
+        String b64 = extractFirstArg(rawJson);
+        if (b64 == null) return;
+        String rec = decodeBase64Utf8(b64);
+        if (rec == null) return;
+        int p1 = rec.indexOf('|');
+        if (p1 <= 0) return;
+        final long id;
+        try {
+            id = Long.parseLong(rec.substring(0, p1));
+        } catch (NumberFormatException e) {
+            return;
+        }
+        int p2 = rec.indexOf('|', p1 + 1);
+        if (p2 < 0) return;
+        String name = rec.substring(p1 + 1, p2);
+        String arg = rec.substring(p2 + 1);
+        AsyncJavascriptFunction h = handlers.get(name);
+        if (h == null) {
+            resolve(id, false, "no such function: " + name);
+            return;
+        }
+        CompletableFuture<String> fut;
+        try {
+            fut = h.run(arg);
+        } catch (Throwable t) {
+            resolve(id, false, msgOf(t));
+            return;
+        }
+        if (fut == null) {
+            resolve(id, true, "");
+            return;
+        }
+        fut.whenComplete(new java.util.function.BiConsumer<String, Throwable>() {
+            @Override
+            public void accept(String value, Throwable err) {
+                if (err != null) {
+                    resolve(id, false, msgOf(unwrap(err)));
+                } else {
+                    resolve(id, true, value == null ? "" : value);
+                }
+            }
+        });
+    }
+
+    /**
+     * Stop accepting work and release the worker pool.  Idempotent and safe
+     * from any thread.  In-flight synchronous handlers are interrupted; their
+     * results are dropped (no resolver remains after native teardown).  The
+     * dispatcher does not unbind the inbound channel &mdash; the native
+     * destroy invalidates it wholesale.
+     */
+    public void disposeAll() {
+        if (disposed) return;
+        disposed = true;
+        handlers.clear();
+        worker.shutdownNow();
+    }
+
+    // ----------------------------------------------------------------------
+
+    private void installWrapper(String name) {
+        String js = wrapperFor(name);
+        // Future navigations, then the current document.
+        sink.addOnBeforeLoad(js);
+        sink.eval(js);
+    }
+
+    private static String wrapperFor(String name) {
+        // name has already passed NAME_PATTERN, so it is safe to interpolate
+        // directly into both the property key and the string-literal argument.
+        return "(function(){window[\"" + name + "\"]=function(a){"
+             + "return window.__webview_fn_invoke(\"" + name + "\",a);};})();";
+    }
+
+    private void resolve(long id, boolean ok, String payload) {
+        String rec = id + "|" + (ok ? "1" : "0") + "|"
+            + (payload == null ? "" : payload);
+        String b64 = encodeBase64Utf8(rec);
+        // Base64 alphabet (A-Za-z0-9+/=) is safe inside a single-quoted JS
+        // string, so no escaping is required.  eval is non-blocking.
+        sink.eval("window.__webview_fn_resolve__('" + b64 + "')");
+    }
+
+    private static void validateName(String name) {
+        if (name == null) throw new NullPointerException("name");
+        if (name.startsWith(RESERVED_PREFIX)) {
+            throw new IllegalArgumentException(
+                "name must not start with " + RESERVED_PREFIX + ": " + name);
+        }
+        if (!NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException(
+                "name must be a valid JS identifier: " + name);
+        }
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        if (t instanceof CompletionException && t.getCause() != null) {
+            return t.getCause();
+        }
+        return t;
+    }
+
+    private static String msgOf(Throwable t) {
+        if (t == null) return "error";
+        String m = t.getMessage();
+        return (m != null) ? m : t.getClass().getSimpleName();
+    }
+
+    /**
+     * Extract the first arg from a bind-shim JSON wrapper of the form
+     * {@code {"name":"...","seq":...,"args":["<value>"]}}.  Copied verbatim
+     * from {@code EvalDispatcher.extractFirstArg}.  Assumes the value is a
+     * single base64 string (no JSON-special characters).
+     */
+    private static String extractFirstArg(String json) {
+        int argsIdx = json.indexOf("\"args\":[");
+        if (argsIdx < 0) return null;
+        int quoteStart = json.indexOf('"', argsIdx + 8);
+        if (quoteStart < 0) return null;
+        int quoteEnd = json.indexOf('"', quoteStart + 1);
+        if (quoteEnd < 0) return null;
+        return json.substring(quoteStart + 1, quoteEnd);
+    }
+
+    private static String decodeBase64Utf8(String b64) {
+        try {
+            byte[] bytes = Base64.getDecoder().decode(b64);
+            return new String(bytes, "UTF-8");
+        } catch (IllegalArgumentException e) {
+            return null;
+        } catch (UnsupportedEncodingException e) {
+            return null;
+        }
+    }
+
+    private static String encodeBase64Utf8(String s) {
+        try {
+            return Base64.getEncoder().encodeToString(s.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            return "";
+        }
+    }
+}

--- a/src/ca/weblite/webview/JavascriptFunction.java
+++ b/src/ca/weblite/webview/JavascriptFunction.java
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction.
+ */
+package ca.weblite.webview;
+
+/**
+ * A Java-backed JavaScript function with a <em>synchronous</em> handler.
+ *
+ * <p>Register one with
+ * {@code addJavascriptFunction(String name, JavascriptFunction fn)} and it
+ * appears in the page as a global that returns a Promise:
+ *
+ * <pre>{@code
+ * webView.addJavascriptFunction("greet", arg -> "Hello, " + arg + "!");
+ * // in the page:  const msg = await window.greet("world");  // "Hello, world!"
+ * }</pre>
+ *
+ * <p><strong>Threading.</strong> The library invokes {@link #run(String)} on a
+ * background worker thread &mdash; never on the engine's UI thread &mdash; so a
+ * slow handler cannot freeze the UI or deadlock the engine against the Swing
+ * EDT. You may do blocking work here.
+ *
+ * <p><strong>Result.</strong> The returned {@code String} resolves the page-side
+ * Promise verbatim (string passthrough). For structured data, return JSON text
+ * and {@code JSON.parse} it in the page. A {@code null} return resolves to the
+ * empty string.
+ *
+ * <p><strong>Errors.</strong> Throwing any exception rejects the page-side
+ * Promise with an {@code Error} carrying this exception's message.
+ *
+ * <p>For inherently-asynchronous work (where the handler itself awaits a
+ * future), use {@link AsyncJavascriptFunction} instead.
+ */
+@FunctionalInterface
+public interface JavascriptFunction {
+
+    /**
+     * Compute the result for one page-side invocation.
+     *
+     * @param arg the single string argument the JavaScript caller passed
+     *            (never {@code null}; the empty string when the caller passed
+     *            {@code null}/{@code undefined}).
+     * @return the value the page-side Promise resolves to; {@code null} is
+     *         treated as the empty string.
+     * @throws Exception any failure; the page-side Promise rejects with an
+     *         {@code Error} carrying {@link Throwable#getMessage()}.
+     */
+    String run(String arg) throws Exception;
+}

--- a/src/ca/weblite/webview/OffscreenWebView.java
+++ b/src/ca/weblite/webview/OffscreenWebView.java
@@ -55,6 +55,14 @@ public class OffscreenWebView {
      */
     private final EvalDispatcher evalDispatcher;
 
+    /**
+     * Per-engine hub for {@link #addJavascriptFunction} — value-returning
+     * JS&rarr;Java functions.  Mirrors the offscreen {@code evalDispatcher}
+     * wiring; the {@code FunctionSink} issues {@code webview_offscreen_eval}
+     * / {@code webview_offscreen_init} when {@code peer != 0}.
+     */
+    private final FunctionDispatcher functionDispatcher;
+
     private OffscreenWebView(long peer) {
         this.peer = peer;
         this.evalDispatcher = new EvalDispatcher(new EvalDispatcher.EvalSink() {
@@ -66,6 +74,23 @@ public class OffscreenWebView {
                 }
             }
         }, true, "OffscreenWebView");
+        this.functionDispatcher = new FunctionDispatcher(
+            new FunctionDispatcher.FunctionSink() {
+                @Override
+                public void eval(String js) {
+                    long p = OffscreenWebView.this.peer;
+                    if (p != 0L) {
+                        WebViewNative.webview_offscreen_eval(p, js);
+                    }
+                }
+                @Override
+                public void addOnBeforeLoad(String js) {
+                    long p = OffscreenWebView.this.peer;
+                    if (p != 0L) {
+                        WebViewNative.webview_offscreen_init(p, js);
+                    }
+                }
+            }, "OffscreenWebView");
     }
 
     /**
@@ -94,6 +119,16 @@ public class OffscreenWebView {
         };
         ow.heap.add(evalCb);
         WebViewNative.webview_offscreen_bind(p, EvalDispatcher.CHANNEL_NAME, evalCb, p);
+        // Install the addJavascriptFunction bridge the same way.
+        WebViewNative.webview_offscreen_init(p, FunctionDispatcher.SHIM_JS);
+        WebViewNativeCallback fnCb = new WebViewNativeCallback() {
+            @Override
+            public void invoke(String arg, long wv) {
+                ow.functionDispatcher.dispatch(arg);
+            }
+        };
+        ow.heap.add(fnCb);
+        WebViewNative.webview_offscreen_bind(p, FunctionDispatcher.INBOUND_CHANNEL, fnCb, p);
         return ow;
     }
 
@@ -236,6 +271,26 @@ public class OffscreenWebView {
     }
 
     /**
+     * Register a synchronous Java-backed JavaScript function under
+     * {@code window.<name>}.  See {@link JavascriptFunction}.
+     */
+    public OffscreenWebView addJavascriptFunction(String name, JavascriptFunction fn) {
+        checkAlive();
+        functionDispatcher.registerSync(name, fn);
+        return this;
+    }
+
+    /**
+     * Register an asynchronous Java-backed JavaScript function under
+     * {@code window.<name>}.  See {@link AsyncJavascriptFunction}.
+     */
+    public OffscreenWebView addJavascriptFunction(String name, AsyncJavascriptFunction fn) {
+        checkAlive();
+        functionDispatcher.registerAsync(name, fn);
+        return this;
+    }
+
+    /**
      * Dispatch a Runnable onto the offscreen WebView's native UI thread.
      */
     public OffscreenWebView dispatch(final Runnable r) {
@@ -331,6 +386,7 @@ public class OffscreenWebView {
             // the drain ensures such a late callback finds an empty
             // pending map and silently drops.
             evalDispatcher.disposeAllPending();
+            functionDispatcher.disposeAll();
             peer = 0L;
             WebViewNative.webview_offscreen_destroy(p);
             heap.clear();

--- a/src/ca/weblite/webview/WebView.java
+++ b/src/ca/weblite/webview/WebView.java
@@ -105,6 +105,17 @@ public class WebView {
     private final EvalDispatcher evalDispatcher;
 
     /**
+     * Per-engine hub for {@link #addJavascriptFunction} — value-returning
+     * JS&rarr;Java functions.  Its {@code FunctionSink} routes
+     * {@code addOnBeforeLoad} through this instance's own buffering
+     * {@link #addOnBeforeLoad(String)} (so functions registered before
+     * {@link #show()} are replayed at document-start once the window is
+     * shown) and issues a live {@code webview_eval} only once a peer
+     * exists.
+     */
+    private final FunctionDispatcher functionDispatcher;
+
+    /**
      * Creates a new webview.
      */
     public WebView() {
@@ -117,6 +128,22 @@ public class WebView {
                 }
             }
         }, false, "WebView");
+        this.functionDispatcher = new FunctionDispatcher(
+            new FunctionDispatcher.FunctionSink() {
+                @Override
+                public void eval(String js) {
+                    long p = peer;
+                    if (p != 0L) {
+                        WebViewNative.webview_eval(p, js);
+                    }
+                }
+                @Override
+                public void addOnBeforeLoad(String js) {
+                    // Delegates to the buffering addOnBeforeLoad so per-name
+                    // wrappers survive both the pre-show and post-show cases.
+                    WebView.this.addOnBeforeLoad(js);
+                }
+            }, "WebView");
     }
     
     /**
@@ -216,6 +243,29 @@ public class WebView {
     }
     
     /**
+     * Register a synchronous Java-backed JavaScript function under
+     * {@code window.<name>}.  In the page, call it as
+     * {@code const r = await window.<name>(arg)}.  See
+     * {@link JavascriptFunction}.  May be called before {@link #show()};
+     * the page-side wrapper is installed at document-start once shown.
+     * @return this
+     */
+    public WebView addJavascriptFunction(String name, JavascriptFunction fn) {
+        functionDispatcher.registerSync(name, fn);
+        return this;
+    }
+
+    /**
+     * Register an asynchronous Java-backed JavaScript function under
+     * {@code window.<name>}.  See {@link AsyncJavascriptFunction}.
+     * @return this
+     */
+    public WebView addJavascriptFunction(String name, AsyncJavascriptFunction fn) {
+        functionDispatcher.registerAsync(name, fn);
+        return this;
+    }
+
+    /**
      * Execute javascript.
      * @param js Javscript to run
      * @return
@@ -287,6 +337,10 @@ public class WebView {
         // before any user init script.  Idempotency-guarded inside the
         // shim itself by window.__webview_eval_installed__.
         WebViewNative.webview_init(peer, EvalDispatcher.SHIM_JS);
+        // Install the addJavascriptFunction base shim BEFORE the buffered
+        // onBeforeLoad scripts so window.__webview_fn_invoke exists before
+        // any per-name wrapper (registered pre-show, replayed below) runs.
+        WebViewNative.webview_init(peer, FunctionDispatcher.SHIM_JS);
         for (String js : onBeforeLoad) {
             WebViewNative.webview_init(peer, js);
         }
@@ -301,6 +355,11 @@ public class WebView {
         };
         heap.add(evalCb);
         WebViewNative.webview_bind(peer, EvalDispatcher.CHANNEL_NAME, evalCb, peer);
+        WebViewNativeCallback fnCb = (String arg, long wv) -> {
+            functionDispatcher.dispatch(arg);
+        };
+        heap.add(fnCb);
+        WebViewNative.webview_bind(peer, FunctionDispatcher.INBOUND_CHANNEL, fnCb, peer);
         for (final String key : bindings.keySet()) {
             WebViewNativeCallback fn = (String arg2, long wv) -> {
                 JavascriptCallback cb = bindings.get(key);
@@ -319,6 +378,7 @@ public class WebView {
         // not hang.
         peer = 0L;
         evalDispatcher.disposeAllPending();
+        functionDispatcher.disposeAll();
     }
 
 }

--- a/src/ca/weblite/webview/swing/WebViewComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewComponent.java
@@ -215,6 +215,39 @@ public abstract class WebViewComponent extends JComponent {
                                                            WebView.JavascriptCallback cb);
 
     /**
+     * Register a synchronous Java-backed JavaScript function. In the page it
+     * appears as a global returning a Promise: {@code const r = await
+     * window.<name>(arg)}. The handler runs on a background thread (never the
+     * engine UI thread), so it can do blocking work without freezing the UI
+     * or deadlocking; its returned {@code String} resolves the Promise and a
+     * thrown exception rejects it. May be called before display; the
+     * page-side wrapper is installed once the component is displayable.
+     *
+     * <p>This is the deadlock-free, Java-only way to return a value to
+     * JavaScript — no JavaScript glue and no synchronous round trip. See
+     * {@link ca.weblite.webview.JavascriptFunction}.
+     *
+     * @throws IllegalArgumentException if {@code name} starts with
+     *         {@link #RESERVED_BINDING_PREFIX} or is not a valid JS
+     *         identifier.
+     */
+    public abstract WebViewComponent addJavascriptFunction(String name,
+                                                           ca.weblite.webview.JavascriptFunction fn);
+
+    /**
+     * Register an asynchronous Java-backed JavaScript function whose handler
+     * returns a {@code CompletableFuture<String>}. The page-side Promise
+     * resolves/rejects when the future completes. See
+     * {@link ca.weblite.webview.AsyncJavascriptFunction}.
+     *
+     * @throws IllegalArgumentException if {@code name} starts with
+     *         {@link #RESERVED_BINDING_PREFIX} or is not a valid JS
+     *         identifier.
+     */
+    public abstract WebViewComponent addJavascriptFunction(String name,
+                                                           ca.weblite.webview.AsyncJavascriptFunction fn);
+
+    /**
      * Dispatch a {@code Runnable} onto the native WebView's UI thread.  No-op
      * until the component is displayable -- transient work is not buffered.
      */

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -5,9 +5,11 @@
  */
 package ca.weblite.webview.swing;
 
+import ca.weblite.webview.AsyncJavascriptFunction;
 import ca.weblite.webview.ConsoleDispatcher;
 import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.EmbeddedWebView;
+import ca.weblite.webview.JavascriptFunction;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewClickCallback;
 import ca.weblite.webview.WebViewDialogCallback;
@@ -89,6 +91,10 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
     private final List<String> pendingInit = new ArrayList<String>();
     private final Map<String, WebView.JavascriptCallback> pendingBindings =
             new LinkedHashMap<String, WebView.JavascriptCallback>();
+    private final Map<String, JavascriptFunction> pendingSyncFunctions =
+            new LinkedHashMap<String, JavascriptFunction>();
+    private final Map<String, AsyncJavascriptFunction> pendingAsyncFunctions =
+            new LinkedHashMap<String, AsyncJavascriptFunction>();
     private KeyEventDispatcher editingShortcutDispatcher;
     private PropertyChangeListener focusOwnerListener;
     private AWTEventListener globalMouseListener;
@@ -174,6 +180,36 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         pendingBindings.put(name, cb);
         if (embedded != null) {
             embedded.addJavascriptCallback(name, cb);
+        }
+        return this;
+    }
+
+    @Override
+    public WebViewComponent addJavascriptFunction(String name, JavascriptFunction fn) {
+        if (name != null && name.startsWith(RESERVED_BINDING_PREFIX)) {
+            throw new IllegalArgumentException(
+                "name is reserved for internal use: names starting with \""
+                + RESERVED_BINDING_PREFIX + "\" are not allowed (got \""
+                + name + "\")");
+        }
+        pendingSyncFunctions.put(name, fn);
+        if (embedded != null) {
+            embedded.addJavascriptFunction(name, fn);
+        }
+        return this;
+    }
+
+    @Override
+    public WebViewComponent addJavascriptFunction(String name, AsyncJavascriptFunction fn) {
+        if (name != null && name.startsWith(RESERVED_BINDING_PREFIX)) {
+            throw new IllegalArgumentException(
+                "name is reserved for internal use: names starting with \""
+                + RESERVED_BINDING_PREFIX + "\" are not allowed (got \""
+                + name + "\")");
+        }
+        pendingAsyncFunctions.put(name, fn);
+        if (embedded != null) {
+            embedded.addJavascriptFunction(name, fn);
         }
         return this;
     }
@@ -469,6 +505,12 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         }
         for (Map.Entry<String, WebView.JavascriptCallback> e : pendingBindings.entrySet()) {
             embedded.addJavascriptCallback(e.getKey(), e.getValue());
+        }
+        for (Map.Entry<String, JavascriptFunction> e : pendingSyncFunctions.entrySet()) {
+            embedded.addJavascriptFunction(e.getKey(), e.getValue());
+        }
+        for (Map.Entry<String, AsyncJavascriptFunction> e : pendingAsyncFunctions.entrySet()) {
+            embedded.addJavascriptFunction(e.getKey(), e.getValue());
         }
         embedded.navigate(pendingUrl);
         sizeNative();

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -14,6 +14,7 @@ import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewClickCallback;
 import ca.weblite.webview.WebViewDialogCallback;
 import ca.weblite.webview.WebViewFocusCallback;
+import ca.weblite.webview.WebViewAttachListener;
 import ca.weblite.webview.WebViewMouseDispatcher;
 import java.awt.AWTEvent;
 import java.awt.event.AWTEventListener;
@@ -514,6 +515,22 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         }
         embedded.navigate(pendingUrl);
         sizeNative();
+        // On macOS the WKWebView attaches asynchronously: the sizeNative()
+        // above runs before the native view exists and is a no-op, and a
+        // frame that never receives a later AWT resize would leave the
+        // WebView at a zero/stale frame (blank).  Re-run sizeNative() once
+        // the attach resolves.  The listener fires on the EDT (immediately
+        // on the next tick on Windows/Linux, where attach is synchronous).
+        embedded.addOnAttachComplete(new WebViewAttachListener() {
+            @Override
+            public void onAttached(EmbeddedWebView webView) {
+                sizeNative();
+            }
+            @Override
+            public void onAttachFailed(EmbeddedWebView webView, Throwable cause) {
+                // Engine is unusable; existing teardown paths discard it.
+            }
+        });
         // Install the native focus callback so we can mirror WKWebView's
         // first-responder state into Swing's visual focus indicators.
         // The lambda is anchored in EmbeddedWebView.heap via

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -5,9 +5,11 @@
  */
 package ca.weblite.webview.swing;
 
+import ca.weblite.webview.AsyncJavascriptFunction;
 import ca.weblite.webview.ConsoleDispatcher;
 import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.GdkInput;
+import ca.weblite.webview.JavascriptFunction;
 import ca.weblite.webview.OffscreenWebView;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewDialogCallback;
@@ -93,6 +95,10 @@ public class WebViewLightweightComponent extends WebViewComponent {
     private final List<String> pendingInit = new ArrayList<String>();
     private final Map<String, WebView.JavascriptCallback> pendingBindings =
             new LinkedHashMap<String, WebView.JavascriptCallback>();
+    private final Map<String, JavascriptFunction> pendingSyncFunctions =
+            new LinkedHashMap<String, JavascriptFunction>();
+    private final Map<String, AsyncJavascriptFunction> pendingAsyncFunctions =
+            new LinkedHashMap<String, AsyncJavascriptFunction>();
     private KeyEventDispatcher editingShortcutDispatcher;
 
     public WebViewLightweightComponent() {
@@ -277,6 +283,12 @@ public class WebViewLightweightComponent extends WebViewComponent {
         }
         for (Map.Entry<String, WebView.JavascriptCallback> ent : pendingBindings.entrySet()) {
             engine.addJavascriptCallback(ent.getKey(), ent.getValue());
+        }
+        for (Map.Entry<String, JavascriptFunction> ent : pendingSyncFunctions.entrySet()) {
+            engine.addJavascriptFunction(ent.getKey(), ent.getValue());
+        }
+        for (Map.Entry<String, AsyncJavascriptFunction> ent : pendingAsyncFunctions.entrySet()) {
+            engine.addJavascriptFunction(ent.getKey(), ent.getValue());
         }
         allocateBuffer(w, h);
         engine.navigate(pendingUrl);
@@ -472,6 +484,36 @@ public class WebViewLightweightComponent extends WebViewComponent {
         pendingBindings.put(name, cb);
         if (engine != null) {
             engine.addJavascriptCallback(name, cb);
+        }
+        return this;
+    }
+
+    @Override
+    public WebViewComponent addJavascriptFunction(String name, JavascriptFunction fn) {
+        if (name != null && name.startsWith(RESERVED_BINDING_PREFIX)) {
+            throw new IllegalArgumentException(
+                "name is reserved for internal use: names starting with \""
+                + RESERVED_BINDING_PREFIX + "\" are not allowed (got \""
+                + name + "\")");
+        }
+        pendingSyncFunctions.put(name, fn);
+        if (engine != null) {
+            engine.addJavascriptFunction(name, fn);
+        }
+        return this;
+    }
+
+    @Override
+    public WebViewComponent addJavascriptFunction(String name, AsyncJavascriptFunction fn) {
+        if (name != null && name.startsWith(RESERVED_BINDING_PREFIX)) {
+            throw new IllegalArgumentException(
+                "name is reserved for internal use: names starting with \""
+                + RESERVED_BINDING_PREFIX + "\" are not allowed (got \""
+                + name + "\")");
+        }
+        pendingAsyncFunctions.put(name, fn);
+        if (engine != null) {
+            engine.addJavascriptFunction(name, fn);
         }
         return this;
     }

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -3921,6 +3921,45 @@ static void cocoa_navigate(Engine *e, std::string url) {
     cocoa_run_on_main_async([=] {
         if (!e || e->destroyed.load()) return;
         if (!e->webview) return;
+        // WKWebView's loadRequest: silently refuses data: URLs (a
+        // long-standing WKWebView restriction) -- the page renders blank
+        // with no error.  Route data:text/html through
+        // loadHTMLString:baseURL: instead, decoding the body from base64
+        // or percent-encoding as the prefix indicates.
+        static const std::string DATA_HTML = "data:text/html";
+        if (url.compare(0, DATA_HTML.size(), DATA_HTML) == 0) {
+            size_t comma = url.find(',');
+            if (comma != std::string::npos) {
+                std::string meta = url.substr(0, comma);
+                std::string body = url.substr(comma + 1);
+                id html = nullptr;
+                if (meta.find(";base64") != std::string::npos) {
+                    id b64 = ns_str(body.c_str());
+                    id data = msg<id, id, unsigned long>(
+                        msg<id>(objc_cls("NSData"), sel("alloc")),
+                        sel("initWithBase64EncodedString:options:"),
+                        b64, (unsigned long)0);
+                    if (data) {
+                        // NSUTF8StringEncoding == 4
+                        html = msg<id, id, unsigned long>(
+                            msg<id>(objc_cls("NSString"), sel("alloc")),
+                            sel("initWithData:encoding:"),
+                            data, (unsigned long)4);
+                    }
+                } else {
+                    id raw = ns_str(body.c_str());
+                    id decoded = msg<id, id>(
+                        raw, sel("stringByRemovingPercentEncoding"));
+                    html = decoded ? decoded : raw;
+                }
+                if (html) {
+                    msg<void, id, id>(e->webview,
+                                      sel("loadHTMLString:baseURL:"),
+                                      html, (id)nullptr);
+                    return;
+                }
+            }
+        }
         id nsurl = msg<id, id>(objc_cls("NSURL"), sel("URLWithString:"),
                                ns_str(url.c_str()));
         id req = msg<id, id>(objc_cls("NSURLRequest"),

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -3948,7 +3948,7 @@ static void cocoa_navigate(Engine *e, std::string url) {
                     }
                 } else {
                     id raw = ns_str(body.c_str());
-                    id decoded = msg<id, id>(
+                    id decoded = msg<id>(
                         raw, sel("stringByRemovingPercentEncoding"));
                     html = decoded ? decoded : raw;
                 }

--- a/test/ca/weblite/webview/DialogDispatcherTest.java
+++ b/test/ca/weblite/webview/DialogDispatcherTest.java
@@ -56,6 +56,10 @@ public class DialogDispatcherTest {
         }
         @Override public WebViewComponent addJavascriptCallback(
                 String name, WebView.JavascriptCallback cb) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, JavascriptFunction fn) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, AsyncJavascriptFunction fn) { return this; }
         @Override public WebViewComponent dispatch(Runnable r) { return this; }
         @Override public void dispose() { }
     }

--- a/test/ca/weblite/webview/FunctionDispatcherTest.java
+++ b/test/ca/weblite/webview/FunctionDispatcherTest.java
@@ -1,0 +1,219 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Per-Canvas-14 Definition of Done: exercises name registration (sync +
+ * async), reserved-name / invalid-name rejection, inbound-envelope parsing,
+ * that a synchronous handler runs OFF the calling thread, async-handler
+ * resolve, handler-throw &rarr; reject, malformed-payload silent drop, and
+ * dispose.  A mock {@link FunctionDispatcher.FunctionSink} stands in for the
+ * native engine so the tests run without a live WebView peer.
+ */
+public class FunctionDispatcherTest {
+
+    private static final String RESOLVE_PREFIX = "window.__webview_fn_resolve__('";
+
+    /** Mock sink: records before-load scripts and queues every eval. */
+    private static final class RecordingSink implements FunctionDispatcher.FunctionSink {
+        final List<String> beforeLoad = new ArrayList<String>();
+        final LinkedBlockingQueue<String> evals = new LinkedBlockingQueue<String>();
+
+        @Override
+        public synchronized void eval(String js) {
+            evals.add(js);
+        }
+
+        @Override
+        public synchronized void addOnBeforeLoad(String js) {
+            beforeLoad.add(js);
+        }
+
+        /** Wait for the next resolve() eval and return its decoded
+         *  {@code <id>|<ok>|<payload>} record, or fail on timeout. */
+        String awaitResolve() throws InterruptedException {
+            long deadline = System.currentTimeMillis() + 3000;
+            while (System.currentTimeMillis() < deadline) {
+                String js = evals.poll(
+                    Math.max(1, deadline - System.currentTimeMillis()),
+                    TimeUnit.MILLISECONDS);
+                if (js == null) break;
+                if (js.startsWith(RESOLVE_PREFIX)) {
+                    String b64 = js.substring(RESOLVE_PREFIX.length(),
+                        js.length() - "')".length());
+                    return new String(Base64.getDecoder().decode(b64),
+                        StandardCharsets.UTF_8);
+                }
+            }
+            fail("no resolve() eval observed within timeout");
+            return null;
+        }
+    }
+
+    /** Build the native-bind envelope the inbound binding callback receives:
+     *  base64 of {@code <id>|<name>|<arg>} wrapped as
+     *  {@code {"name":"__webview_fn_call__","seq":0,"args":["<b64>"]}}. */
+    private static String envelope(long id, String name, String arg) {
+        String pipe = id + "|" + name + "|" + arg;
+        String b64 = Base64.getEncoder().encodeToString(
+            pipe.getBytes(StandardCharsets.UTF_8));
+        return "{\"name\":\"__webview_fn_call__\",\"seq\":0,\"args\":[\"" + b64 + "\"]}";
+    }
+
+    @Test
+    public void registerSync_installsWrapperForCurrentAndFuture() {
+        RecordingSink sink = new RecordingSink();
+        FunctionDispatcher d = new FunctionDispatcher(sink, "Test");
+        d.registerSync("greet", new JavascriptFunction() {
+            @Override public String run(String arg) { return "hi " + arg; }
+        });
+        // addOnBeforeLoad (future navigations) + a one-shot eval (current doc).
+        assertEquals(1, sink.beforeLoad.size());
+        assertTrue(sink.beforeLoad.get(0).contains("window[\"greet\"]"));
+        assertTrue(sink.evals.contains(sink.beforeLoad.get(0)));
+    }
+
+    @Test
+    public void syncHandler_resolvesWithReturnValue_offCallingThread() throws Exception {
+        RecordingSink sink = new RecordingSink();
+        FunctionDispatcher d = new FunctionDispatcher(sink, "Test");
+        final AtomicReference<String> handlerThread = new AtomicReference<String>();
+        d.registerSync("rev", new JavascriptFunction() {
+            @Override public String run(String arg) {
+                handlerThread.set(Thread.currentThread().getName());
+                return new StringBuilder(arg).reverse().toString();
+            }
+        });
+        String dispatchThread = Thread.currentThread().getName();
+        d.dispatch(envelope(7, "rev", "abc"));
+        assertEquals("7|1|cba", sink.awaitResolve());
+        assertNotEquals("sync handler must run off the calling thread",
+            dispatchThread, handlerThread.get());
+        assertTrue(handlerThread.get().startsWith("webview-fn-"));
+    }
+
+    @Test
+    public void syncHandler_argWithPipes_isPreservedVerbatim() throws Exception {
+        RecordingSink sink = new RecordingSink();
+        FunctionDispatcher d = new FunctionDispatcher(sink, "Test");
+        d.registerSync("echo", new JavascriptFunction() {
+            @Override public String run(String arg) { return arg; }
+        });
+        d.dispatch(envelope(1, "echo", "a|b|c"));
+        assertEquals("1|1|a|b|c", sink.awaitResolve());
+    }
+
+    @Test
+    public void syncHandler_throw_rejectsWithMessage() throws Exception {
+        RecordingSink sink = new RecordingSink();
+        FunctionDispatcher d = new FunctionDispatcher(sink, "Test");
+        d.registerSync("boom", new JavascriptFunction() {
+            @Override public String run(String arg) throws Exception {
+                throw new IllegalStateException("kaboom");
+            }
+        });
+        d.dispatch(envelope(3, "boom", "x"));
+        assertEquals("3|0|kaboom", sink.awaitResolve());
+    }
+
+    @Test
+    public void asyncHandler_resolvesWhenFutureCompletes() throws Exception {
+        RecordingSink sink = new RecordingSink();
+        FunctionDispatcher d = new FunctionDispatcher(sink, "Test");
+        final CompletableFuture<String> gate = new CompletableFuture<String>();
+        d.registerAsync("later", new AsyncJavascriptFunction() {
+            @Override public CompletableFuture<String> run(String arg) {
+                return gate;
+            }
+        });
+        d.dispatch(envelope(9, "later", "ignored"));
+        gate.complete("done");
+        assertEquals("9|1|done", sink.awaitResolve());
+    }
+
+    @Test
+    public void asyncHandler_exceptionalFuture_rejects() throws Exception {
+        RecordingSink sink = new RecordingSink();
+        FunctionDispatcher d = new FunctionDispatcher(sink, "Test");
+        d.registerAsync("fail", new AsyncJavascriptFunction() {
+            @Override public CompletableFuture<String> run(String arg) {
+                CompletableFuture<String> f = new CompletableFuture<String>();
+                f.completeExceptionally(new RuntimeException("nope"));
+                return f;
+            }
+        });
+        d.dispatch(envelope(2, "fail", "x"));
+        assertEquals("2|0|nope", sink.awaitResolve());
+    }
+
+    @Test
+    public void unknownFunction_rejects() throws Exception {
+        RecordingSink sink = new RecordingSink();
+        FunctionDispatcher d = new FunctionDispatcher(sink, "Test");
+        d.dispatch(envelope(5, "missing", "x"));
+        assertEquals("5|0|no such function: missing", sink.awaitResolve());
+    }
+
+    @Test
+    public void reservedAndInvalidNames_rejected() {
+        FunctionDispatcher d = new FunctionDispatcher(new RecordingSink(), "Test");
+        JavascriptFunction noop = new JavascriptFunction() {
+            @Override public String run(String arg) { return ""; }
+        };
+        try {
+            d.registerSync("__webview_evil", noop);
+            fail("expected IllegalArgumentException for reserved prefix");
+        } catch (IllegalArgumentException expected) { /* ok */ }
+        try {
+            d.registerSync("has space", noop);
+            fail("expected IllegalArgumentException for invalid identifier");
+        } catch (IllegalArgumentException expected) { /* ok */ }
+        try {
+            d.registerSync(null, noop);
+            fail("expected NullPointerException for null name");
+        } catch (NullPointerException expected) { /* ok */ }
+    }
+
+    @Test
+    public void malformedPayloads_silentlyDropped() {
+        RecordingSink sink = new RecordingSink();
+        FunctionDispatcher d = new FunctionDispatcher(sink, "Test");
+        d.dispatch(null);
+        d.dispatch("not json");
+        d.dispatch("{\"args\":[\"%%%not-base64%%%\"]}");
+        // No resolve eval should have been emitted.
+        assertTrue("malformed input must not emit a resolve", sink.evals.isEmpty());
+    }
+
+    @Test
+    public void dispose_isIdempotent_andStopsRegistration() {
+        RecordingSink sink = new RecordingSink();
+        FunctionDispatcher d = new FunctionDispatcher(sink, "Test");
+        d.disposeAll();
+        d.disposeAll(); // idempotent, no throw
+        d.registerSync("late", new JavascriptFunction() {
+            @Override public String run(String arg) { return "x"; }
+        });
+        // Registration after dispose is a no-op: no wrapper installed.
+        assertTrue(sink.beforeLoad.isEmpty());
+    }
+}


### PR DESCRIPTION
Implements value-returning JavaScript functions that can be called from the page and handled by Java code, with no JavaScript glue required.

## Summary

This change introduces a new API for exposing Java methods as JavaScript functions that return Promises. The page calls `const result = await window.<name>(arg)` and a Java handler produces the result. This is the inverse of the existing `evalAsync` feature — instead of Java calling JavaScript and awaiting a result, JavaScript calls Java and awaits a result.

## Key Changes

- **New core classes:**
  - `FunctionDispatcher` — per-engine hub managing the `name → handler` registry, a daemon worker pool for synchronous handlers, the canonical JS shim, inbound-call parsing, and outbound result delivery
  - `JavascriptFunction` — functional interface for synchronous handlers (`String run(String arg) throws Exception`)
  - `AsyncJavascriptFunction` — functional interface for asynchronous handlers (returns `CompletableFuture<String>`)

- **New public API methods:**
  - `addJavascriptFunction(String name, JavascriptFunction fn)` — register a synchronous handler (runs on background thread, never blocks the engine UI thread)
  - `addJavascriptFunction(String name, AsyncJavascriptFunction fn)` — register an asynchronous handler

- **Integration across all surfaces:**
  - `WebView` (standalone in-process)
  - `EmbeddedWebView` (heavyweight Swing component)
  - `OffscreenWebView` (lightweight Swing component)
  - `WebViewComponent` (abstract base with default implementations)

- **Wire format:** Base64-encoded pipe-separated records (`<id>|<name>|<arg>` inbound, `<id>|<ok>|<result>` outbound), consistent with existing `EvalDispatcher` pattern. No JSON-parsing dependency added.

- **Threading:** Synchronous handlers run on a daemon worker pool off the engine UI thread, eliminating the deadlock hazard that would arise from a synchronous value-returning callback blocking the UI thread against the Swing EDT.

- **Error handling:** Handler exceptions cause the page Promise to reject with an Error whose message is the Java exception message.

- **Name validation:** Registered names must be valid JavaScript identifiers and cannot start with the reserved `__webview_` prefix.

- **Idempotency:** The JS shim is guarded by `window.__webview_fn_installed__` and re-injected on every page navigation via `addOnBeforeLoad`.

- **Demo and tests:**
  - `WebViewAsyncCallbackDemo` — demonstrates both sync and async handlers with a live HTTP server
  - `FunctionDispatcherTest` — comprehensive unit tests with a mock sink (no native WebView required)
  - `WebViewDataUrlSmokeTest` — smoke test for macOS data: URL navigation fix

- **Native changes:** Fixed macOS `cocoa_navigate` to route `data:text/html` URLs through `loadHTMLString:baseURL:` instead of `loadRequest:`, which silently refuses data: URLs.

## Implementation Details

- The dispatcher owns a `ConcurrentHashMap<String, AsyncJavascriptFunction>` registry; synchronous handlers are adapted to async at registration time for uniform dispatch
- Inbound binding callback returns immediately; result delivery is non-blocking via `eval` (never `evalAsync`, never `.get()`)
- Per-name wrappers are installed at document-start on every navigation and also immediately via one-shot `eval` if registered after page load
- The inbound binding reference is cached before user JS runs to defend against user code reassigning the binding
- Reserved channel names (`__webview_fn_call__`, `__webview_fn_resolve__`) live under `RESERVED_BINDING_PREFIX` and are protected from caller collision by existing guards

https://claude.ai/code/session_01Jsv2cRyv98YNWzBF6VhT69