### PR TITLE
chore: update dependency version references to 1.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the dependency to your `pom.xml`:
 <dependency>
     <groupId>ca.weblite</groupId>
     <artifactId>webview</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
 </dependency>
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
 <section id="top" class="hero">
   <div class="container hero-inner">
     <div class="hero-text">
-      <span class="eyebrow">ca.weblite:webview &middot; v1.0.7 &middot; MIT</span>
+      <span class="eyebrow">ca.weblite:webview &middot; v1.0.10 &middot; MIT</span>
       <h1>A native WebView, embedded in your <em>Java&nbsp;Swing</em> app.</h1>
       <p class="lede">
         Cross-platform &mdash; native WebKit / WebView2 rendering on macOS,
@@ -80,7 +80,7 @@ frame.setVisible(true);</code></pre>
 <pre id="pom"><code class="language-xml">&lt;dependency&gt;
     &lt;groupId&gt;ca.weblite&lt;/groupId&gt;
     &lt;artifactId&gt;webview&lt;/artifactId&gt;
-    &lt;version&gt;1.0.7&lt;/version&gt;
+    &lt;version&gt;1.0.10&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
   </div>
 
@@ -91,7 +91,7 @@ frame.setVisible(true);</code></pre>
         <span class="code-card-file">build.gradle</span>
         <button class="copy-btn" data-copy="gradle">Copy</button>
       </div>
-<pre id="gradle"><code class="language-java">implementation 'ca.weblite:webview:1.0.7'</code></pre>
+<pre id="gradle"><code class="language-java">implementation 'ca.weblite:webview:1.0.10'</code></pre>
     </div>
   </details>
 


### PR DESCRIPTION
Updates the library version from 1.0.9 to 1.0.10 in:
- `README.md` (Maven dependency snippet)
- `docs/index.html` (eyebrow badge, Maven XML, and Gradle snippets)