### PR TITLE
Make native embedding diagnostics quiet by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,32 @@ For debugging, set `-Dca.weblite.webview.debugShortcut=true` (Java
 side) and `WEBVIEW_DEBUG_SHORTCUT=1` (native side) to log the
 dispatcher decisions and Win32 `SetFocus` calls.
 
+The native embedding layer (`src_c/webview_embed.cpp`) is **quiet by
+default** — a normal embed/launch prints no `[webview-embed]` lines to
+stderr.  Set `DEBUG_WEBVIEW_EMBED=1` on the way in — for example
+`DEBUG_WEBVIEW_EMBED=1 java -jar your-app.jar` — to restore the full
+verbose trace: JAWT resolution, the `JAWT_GetAWT` version-mask that
+succeeded, GTK reparenting, the WebKit load lifecycle, click/focus
+grabs, the repaint timer, navigation, the per-frame `draw#`/frame-clock
+instrumentation, and (on macOS) host-`NSView` discovery and
+`WKWebView` subview attachment.  Genuine error/failure conditions
+(missing `JAWT_GetAWT`, `dlopen`/`dlsym` failures, a rejected JAWT
+version mask, a `JAWT_LOCK_ERROR`, a non-X11 `GdkWindow`, a WebKit
+`load-failed`, or the macOS layer-only-fallback warning) always print,
+regardless of the flag.  The Windows port
+(`windows/webview_embed.cc`) already logs only on failure, so it has
+no default chatter to silence.
+
+> This flag is read by the native library, so it only takes effect
+> once you are running against a native build that includes it —
+> the natives are produced by `build-{linux,mac,windows}.sh` / the CI
+> release matrix rather than checked into the repo, so downstream
+> consumers pick it up after the next native release.
+>
+> The macOS `ApplePersistenceIgnoreState: Existing state will not be
+> touched …` line is emitted by AppKit itself, not by this library,
+> so it is unaffected by `DEBUG_WEBVIEW_EMBED`.
+
 ## Talking to JavaScript
 
 Four methods on `WebViewComponent` (and on the standalone `WebView`)

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -2528,6 +2528,38 @@ Files:
   and the analysis in
   `spdd/analysis/GGQPA-XXX-202605201900-[Analysis]-edt-appkit-sync-deadlock-elimination.md`
   document the full reasoning.
+- **Native embedding diagnostics are quiet by default.** Every
+  informational or success `[webview-embed]` trace emitted by the
+  native embed code in `src_c/webview_embed.cpp` MUST be gated behind
+  a single verbose switch so that a normal embed/launch prints NO
+  `[webview-embed]` lines and no per-frame `draw#` traces to stderr.
+  This covers the JAWT-resolution traces (`Resolved JAWT_GetAWT via
+  RTLD_DEFAULT`/`via dlsym`, the "not visible in RTLD_DEFAULT; trying
+  dlopen" fallback note, `dlopen'd libjawt from …`), the
+  `JAWT_GetAWT succeeded with mask …` success line, the GTK
+  `Reparenting …` and `repaint timer started` traces, the WebKit
+  `load-<phase>` lifecycle trace, the click/focus-grab trace, the
+  `webkit_web_view_load_uri: …` navigation trace, and the macOS
+  host-NSView discovery (`Found NSView …`) and
+  `WKWebView added as subview of …` attach traces. The switch is the
+  `DEBUG_WEBVIEW_EMBED` environment variable, read once and cached in
+  a `embed_verbose()` helper and routed through an `EMBED_LOG(...)`
+  macro that no-ops unless verbose. It reuses the SAME environment
+  variable that already gates the per-frame `draw#`/frame-clock
+  instrumentation, so one flag controls all embedding diagnostics.
+  Genuine error/failure conditions MUST continue to print
+  unconditionally via plain `fprintf(stderr, …)` — specifically: no
+  `JAWT_GetAWT` symbol available, `dlopen`/`dlsym` of libjawt failed,
+  every JAWT version mask rejected, `GetDrawingSurface`/
+  `GetDrawingSurfaceInfo` returned NULL, `JAWT_LOCK_ERROR`,
+  `gtk_widget_get_window` returned NULL after realize, non-X11
+  `GdkWindow`, WebKit `load-failed`, and the macOS "could not locate
+  any host NSView" layer-only-fallback WARNING. The `windows/
+  webview_embed.cc` port already follows this shape (its `WV_LOG`
+  calls are all failure paths or already gated behind
+  `WEBVIEW_DEBUG_SHORTCUT`), so no unconditional info traces exist
+  there to silence. Document the `DEBUG_WEBVIEW_EMBED` flag in the
+  README debugging section alongside `debugShortcut`.
 
 ## S · Safeguards
 - `EmbeddedWebView.attach` validates `parent != null` AND

--- a/spdd/prompt/7-20260516-0719-[Feat]-Swing-Lightweight-Webview-Embedding.md
+++ b/spdd/prompt/7-20260516-0719-[Feat]-Swing-Lightweight-Webview-Embedding.md
@@ -1144,6 +1144,19 @@ Files:
   same contract as the heavyweight
   `webview_embed_execute_editing_command` norm in
   [[swing-heavyweight-webview-embedding]].
+- **Offscreen embedding diagnostics are quiet by default.** The
+  informational `[webview-embed]` traces emitted from the offscreen
+  engine path in `src_c/webview_embed.cpp` — `offscreen engine
+  ready (WxH)` and `offscreen load_uri: …` — MUST be routed through
+  the same gated `EMBED_LOG(...)` logger the heavyweight path uses, so
+  a normal lightweight launch prints NO `[webview-embed]` lines to
+  stderr. The switch is the shared `DEBUG_WEBVIEW_EMBED` environment
+  variable (cached in `embed_verbose()`); the offscreen path shares
+  the JAWT-resolution helpers with the heavyweight engine, so those
+  traces obey the same flag. This is the same quiet-by-default logging
+  norm defined for the heavyweight engine in
+  [[swing-heavyweight-webview-embedding]]; genuine error/failure
+  messages (e.g. WebKit `load-failed`) still print unconditionally.
 
 ## S · Safeguards
 - `OffscreenWebView.create` returns `null` for unsupported

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -55,6 +55,25 @@
 namespace embed {
 
 // ---------------------------------------------------------------------------
+// Diagnostic logging
+// ---------------------------------------------------------------------------
+
+// Embedding diagnostics are quiet by default.  Informational/success
+// "[webview-embed] ..." traces are routed through EMBED_LOG and only reach
+// stderr when the DEBUG_WEBVIEW_EMBED environment variable is set; a normal
+// embed/launch therefore prints nothing.  Genuine error/failure conditions
+// stay on a plain fprintf(stderr, ...) path so real problems are always
+// visible.  This is the same switch that gates the per-frame draw#/frame-clock
+// instrumentation below, so one flag controls all embedding diagnostics.
+static bool embed_verbose() {
+    static const bool verbose = (getenv("DEBUG_WEBVIEW_EMBED") != nullptr);
+    return verbose;
+}
+
+#define EMBED_LOG(...) \
+    do { if (embed_verbose()) fprintf(stderr, __VA_ARGS__); } while (0)
+
+// ---------------------------------------------------------------------------
 // JAWT helpers
 // ---------------------------------------------------------------------------
 
@@ -77,13 +96,13 @@ static jawt_get_awt_fn resolve_jawt_get_awt() {
     // without us having to know the JDK install layout.
     void *sym = dlsym(RTLD_DEFAULT, "JAWT_GetAWT");
     if (sym != nullptr) {
-        fprintf(stderr,
+        EMBED_LOG(
             "[webview-embed] Resolved JAWT_GetAWT via RTLD_DEFAULT at %p\n",
             sym);
         cached = reinterpret_cast<jawt_get_awt_fn>(sym);
         return cached;
     }
-    fprintf(stderr,
+    EMBED_LOG(
         "[webview-embed] JAWT_GetAWT not visible in RTLD_DEFAULT; "
         "trying explicit dlopen of libjawt.\n");
 
@@ -110,7 +129,7 @@ static jawt_get_awt_fn resolve_jawt_get_awt() {
     for (const auto &path : candidates) {
         handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
         if (handle != nullptr) {
-            fprintf(stderr,
+            EMBED_LOG(
                 "[webview-embed] dlopen'd libjawt from \"%s\"\n",
                 path.c_str());
             break;
@@ -128,7 +147,7 @@ static jawt_get_awt_fn resolve_jawt_get_awt() {
             "[webview-embed] dlsym JAWT_GetAWT failed: %s\n", dlerror());
         return nullptr;
     }
-    fprintf(stderr,
+    EMBED_LOG(
         "[webview-embed] Resolved JAWT_GetAWT via dlsym at %p\n", sym);
     cached = reinterpret_cast<jawt_get_awt_fn>(sym);
     return cached;
@@ -171,7 +190,7 @@ struct JawtLock {
         for (jint m : masks) {
             awt.version = m;
             if (fn(env, &awt)) {
-                fprintf(stderr,
+                EMBED_LOG(
                     "[webview-embed] JAWT_GetAWT succeeded with mask 0x%x\n",
                     (unsigned)m);
                 got = true;
@@ -900,7 +919,7 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug) {
 
         Window child = GDK_WINDOW_XID(gdkw);
         Display *gdkd = GDK_WINDOW_XDISPLAY(gdkw);
-        fprintf(stderr,
+        EMBED_LOG(
             "[webview-embed] Reparenting GTK X11 window 0x%lx under AWT "
             "Canvas X11 window 0x%lx (display %s).\n",
             (unsigned long)child, (unsigned long)e->parent_xid,
@@ -971,7 +990,7 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug) {
                 int idx = (int)ev;
                 const char *n = (idx >= 0 && idx < 4) ? names[idx] : "?";
                 const char *uri = webkit_web_view_get_uri(wv);
-                fprintf(stderr,
+                EMBED_LOG(
                     "[webview-embed] load-%s: %s\n",
                     n, uri ? uri : "(null)");
             };
@@ -1083,7 +1102,7 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug) {
                     // is the focus widget within the popup, so any
                     // keys that arrive get dispatched to it.
                     gtk_widget_grab_focus(eng->web);
-                    fprintf(stderr,
+                    EMBED_LOG(
                         "[webview-embed] click @ (%.0f,%.0f) -> "
                         "focus grabbed (web_xid=0x%lx)\n",
                         x, y,
@@ -1131,7 +1150,7 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug) {
                 return G_SOURCE_CONTINUE;
             };
         e->redraw_timer_id = g_timeout_add(16, redraw_tick, e);
-        fprintf(stderr,
+        EMBED_LOG(
             "[webview-embed] repaint timer started (id=%u, period=16ms).\n",
             (unsigned)e->redraw_timer_id);
 
@@ -1144,7 +1163,7 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug) {
         //     (no => begin_updating isn't taking effect on this window)
         //   - widget state right after show_all
         //     (mapped/realized/drawable/viewable + allocation)
-        if (getenv("DEBUG_WEBVIEW_EMBED")) {
+        if (embed_verbose()) {
             auto on_draw =
                 +[](GtkWidget *w, cairo_t *, gpointer name) -> gboolean {
                     static guint counter = 0;
@@ -1306,7 +1325,7 @@ static void gtk_set_bounds(Engine *e, int /*x*/, int /*y*/,
 static void gtk_navigate(Engine *e, std::string url) {
     GtkPump::instance().run_async([=] {
         if (!e->web) return;
-        fprintf(stderr,
+        EMBED_LOG(
             "[webview-embed] webkit_web_view_load_uri: %s\n", url.c_str());
         webkit_web_view_load_uri(WEBKIT_WEB_VIEW(e->web), url.c_str());
     });
@@ -1634,7 +1653,7 @@ static OffEngine *gtk_off_create_engine(JNIEnv *env,
         delete e;
         return nullptr;
     }
-    fprintf(stderr,
+    EMBED_LOG(
         "[webview-embed] offscreen engine ready (%dx%d)\n",
         e->width, e->height);
     return e;
@@ -1735,7 +1754,7 @@ static void gtk_off_resize(OffEngine *e, int w, int h) {
 static void gtk_off_navigate(OffEngine *e, std::string url) {
     GtkPump::instance().run_async([=] {
         if (!e->web) return;
-        fprintf(stderr,
+        EMBED_LOG(
             "[webview-embed] offscreen load_uri: %s\n", url.c_str());
         webkit_web_view_load_uri(WEBKIT_WEB_VIEW(e->web), url.c_str());
     });
@@ -3597,7 +3616,7 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
                     }
                 }
             }
-            fprintf(stderr,
+            EMBED_LOG(
                 "[webview-embed] Found NSView %s; %s\n", cls_name,
                 host_is_awt ? "using directly" :
                 (host ? "deferring to NSWindow.contentView" : "no window"));
@@ -3611,7 +3630,7 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
             // it; make sure it is so AppKit composites WKWebView properly.
             msg<void, BOOL>(host, sel("setWantsLayer:"), YES);
             msg<void, id>(host, sel("addSubview:"), e->webview);
-            fprintf(stderr,
+            EMBED_LOG(
                 "[webview-embed] WKWebView added as subview of %s at %p\n",
                 host_kind, host);
             // Hide the WKWebView until the first setBounds positions it


### PR DESCRIPTION
## Summary

Introduces a `DEBUG_WEBVIEW_EMBED` environment variable to gate informational logging in the native embedding layer. By default, the embedding code now prints nothing to stderr; genuine error/failure conditions continue to print unconditionally. This reduces noise during normal operation while preserving visibility into real problems.

## Changes

- **Add diagnostic logging infrastructure** (`src_c/webview_embed.cpp`):
  - Introduce `embed_verbose()` helper that reads and caches the `DEBUG_WEBVIEW_EMBED` environment variable
  - Define `EMBED_LOG(...)` macro that routes informational traces through the verbose flag
  - Reuse the same environment variable that already gates per-frame `draw#`/frame-clock instrumentation

- **Gate all informational traces** in `src_c/webview_embed.cpp`:
  - JAWT resolution traces (symbol lookup, dlopen/dlsym attempts, version-mask success)
  - GTK reparenting and repaint timer initialization
  - WebKit load-phase lifecycle events
  - Click/focus-grab diagnostics
  - Navigation URI traces
  - macOS host-NSView discovery and WKWebView subview attachment
  - Offscreen engine readiness and navigation

- **Preserve unconditional error logging**:
  - Missing `JAWT_GetAWT` symbol, dlopen/dlsym failures, rejected JAWT version masks
  - `JAWT_LOCK_ERROR`, null drawing surface, non-X11 `GdkWindow`
  - WebKit `load-failed` events
  - macOS layer-only-fallback warnings

- **Update documentation**:
  - README: Add `DEBUG_WEBVIEW_EMBED` flag documentation in the debugging section alongside `debugShortcut`
  - SPDD Canvases: Document the quiet-by-default logging norm for both heavyweight and lightweight embedding paths

## Implementation Details

The `embed_verbose()` function uses a static variable to cache the environment variable lookup, avoiding repeated `getenv()` calls. The `EMBED_LOG` macro is a no-op when verbose is false, allowing the compiler to optimize away the logging code entirely in the common case. This approach mirrors the existing `WEBVIEW_DEBUG_SHORTCUT` pattern on the Windows port, which already logs only on failure.

https://claude.ai/code/session_015QueNCVQKA6TM9TRefSPPn